### PR TITLE
fix: Session timeout warning showing negative minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Session timeout warning showing negative minutes (e.g., "-24min")
+- Warning now fires 5 minutes before timeout instead of after 5 minutes idle
+- Stale sessions are now cleaned from persistence on startup
+
 ## [0.16.3] - 2025-12-31
 
 ### Fixed

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -588,9 +588,12 @@ export function cleanupIdleSessions(
       continue;
     }
 
-    // Check for warning threshold
-    if (idleMs > warningMs && !session.timeoutWarningPosted) {
-      const remainingMins = Math.round((timeoutMs - idleMs) / 60000);
+    // Check for warning threshold (warn when X minutes before timeout)
+    // warningMs = how long before timeout to warn (e.g., 5 min = 300000)
+    // So warn when: idleMs > (timeoutMs - warningMs)
+    const warningThresholdMs = timeoutMs - warningMs;
+    if (idleMs > warningThresholdMs && !session.timeoutWarningPosted) {
+      const remainingMins = Math.max(0, Math.round((timeoutMs - idleMs) / 60000));
       session.platform.createPost(
         `⏰ **Session idle** - will timeout in ~${remainingMins} minutes without activity`,
         session.threadId

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -369,6 +369,13 @@ export class SessionManager {
   // ---------------------------------------------------------------------------
 
   async initialize(): Promise<void> {
+    // Clean up stale sessions that timed out while bot was down
+    // Use 2x timeout to be generous (bot might have been down for a while)
+    const staleIds = this.sessionStore.cleanStale(SESSION_TIMEOUT_MS * 2);
+    if (staleIds.length > 0) {
+      console.log(`  🧹 Cleaned ${staleIds.length} stale session(s) from persistence`);
+    }
+
     const persisted = this.sessionStore.load();
     if (persisted.size === 0) return;
 


### PR DESCRIPTION
## Summary

- Fixed session timeout warning showing negative minutes (e.g., "-24min")
- Warning now fires 5 minutes before timeout instead of incorrectly firing after 5 minutes idle
- Stale sessions are now cleaned from persistence on startup

## Test plan

- [ ] Start a session and let it idle for 25+ minutes
- [ ] Verify warning shows "~5 minutes" remaining (not negative)
- [ ] Restart bot with stale persisted sessions older than 1 hour
- [ ] Verify stale sessions are cleaned and not resumed