### PR TITLE
feat: Add thread context prompt for mid-thread session starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Worktree context**: Replay first user prompt after mid-session worktree creation (`!worktree create`)
+- **Thread context prompt**: When starting a session mid-thread (replying to an existing thread), offers to include previous conversation context
+  - Shows options for last 3, 5, or 10 messages (only options that make sense for available message count)
+  - "All X messages" option when message count doesn't match standard options
+  - 30-second timeout defaults to no context
+  - Context is prepended to the initial prompt so Claude understands the conversation history
 
 ### Fixed
 - Session timeout warning showing negative minutes (e.g., "-24min")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This is a multi-platform bot that lets users interact with Claude Code through c
 - **Session persistence** - sessions resume automatically after bot restart
 - **Session collaboration** - `!invite @user` to temporarily allow users in a session
 - **Message approval** - unauthorized users can request approval for their messages
+- **Thread context prompt** - when starting a session mid-thread, offers to include previous conversation context
 - Interactive permission approval via emoji reactions
 - Plan approval and question answering via reactions
 - Task list display with live updates
@@ -59,7 +60,7 @@ This is a multi-platform bot that lets users interact with Claude Code through c
 **Session contains:**
 - `claude: ClaudeCli` - the Claude CLI process
 - `claudeSessionId: string` - UUID for session persistence/resume
-- `pendingApproval`, `pendingQuestionSet`, `pendingMessageApproval` - interactive state
+- `pendingApproval`, `pendingQuestionSet`, `pendingMessageApproval`, `pendingContextPrompt` - interactive state
 - `sessionAllowedUsers: Set<string>` - per-session allowlist (includes session owner)
 - `updateTimer`, `typingTimer` - per-session timers
 - `activeSubagents: Map<toolUseId, postId>` - subagent tracking
@@ -126,14 +127,15 @@ The session management is split into focused modules for maintainability:
 
 | File | Lines | Purpose |
 |------|-------|---------|
-| `src/session/manager.ts` | ~635 | **Orchestrator** - thin wrapper that delegates to modules |
-| `src/session/lifecycle.ts` | ~590 | Session start, resume, exit, cleanup |
+| `src/session/manager.ts` | ~700 | **Orchestrator** - thin wrapper that delegates to modules |
+| `src/session/lifecycle.ts` | ~610 | Session start, resume, exit, cleanup |
 | `src/session/events.ts` | ~480 | Claude CLI event handling (assistant, tool_use, etc.) |
 | `src/session/commands.ts` | ~510 | User commands (!cd, !invite, !kick, !permissions) |
 | `src/session/reactions.ts` | ~210 | Emoji reaction handling (approvals, questions) |
 | `src/session/worktree.ts` | ~520 | Git worktree management |
 | `src/session/streaming.ts` | ~180 | Message batching and flushing to chat |
-| `src/session/types.ts` | ~130 | TypeScript types (Session, PendingApproval, etc.) |
+| `src/session/context-prompt.ts` | ~190 | Thread context prompt for mid-thread session starts |
+| `src/session/types.ts` | ~135 | TypeScript types (Session, PendingApproval, etc.) |
 | `src/session/index.ts` | ~15 | Public exports |
 
 **Design Pattern**: SessionManager uses dependency injection via context objects to delegate to modules while maintaining a clean public API.

--- a/src/persistence/session-store.ts
+++ b/src/persistence/session-store.ts
@@ -12,6 +12,17 @@ export interface WorktreeInfo {
 }
 
 /**
+ * Persisted context prompt state (without timeoutId which can't be serialized)
+ */
+export interface PersistedContextPrompt {
+  postId: string;
+  queuedPrompt: string;
+  threadMessageCount: number;
+  createdAt: number;
+  availableOptions: number[];
+}
+
+/**
  * Persisted session state for resuming after bot restart
  */
 export interface PersistedSession {
@@ -34,6 +45,8 @@ export interface PersistedSession {
   worktreePromptDisabled?: boolean;         // User opted out with !worktree off
   queuedPrompt?: string;                    // User's original message when waiting for worktree response
   firstPrompt?: string;                     // First user message, sent again after mid-session worktree creation
+  // Context prompt support
+  pendingContextPrompt?: PersistedContextPrompt; // Waiting for context selection
 }
 
 /**

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -4,6 +4,7 @@ import type {
   PlatformPost,
   PlatformReaction,
   PlatformFile,
+  ThreadMessage,
 } from './types.js';
 import type { PlatformFormatter } from './formatter.js';
 
@@ -136,6 +137,17 @@ export interface PlatformClient extends EventEmitter {
    * @returns The post, or null if not found/deleted
    */
   getPost(postId: string): Promise<PlatformPost | null>;
+
+  /**
+   * Get thread history (messages in a thread)
+   * @param threadId - Thread/root post ID
+   * @param options - Optional filtering/limiting options
+   * @returns Array of messages in chronological order (oldest first)
+   */
+  getThreadHistory(
+    threadId: string,
+    options?: { limit?: number; excludeBotMessages?: boolean }
+  ): Promise<ThreadMessage[]>;
 
   // ============================================================================
   // Reactions

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -25,4 +25,5 @@ export type {
   CreatePostRequest,
   UpdatePostRequest,
   AddReactionRequest,
+  ThreadMessage,
 } from './types.js';

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -75,3 +75,14 @@ export interface AddReactionRequest {
   postId: string;
   emojiName: string;
 }
+
+/**
+ * Normalized thread message for context retrieval
+ */
+export interface ThreadMessage {
+  id: string;           // Message/post ID
+  userId: string;       // Author's user ID
+  username: string;     // Author's username
+  message: string;      // Message content
+  createAt: number;     // Timestamp (ms since epoch)
+}

--- a/src/session/context-prompt.test.ts
+++ b/src/session/context-prompt.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  getContextSelectionFromReaction,
+  formatContextForClaude,
+  getValidContextOptions,
+  CONTEXT_OPTIONS,
+} from './context-prompt.js';
+import type { ThreadMessage } from '../platform/index.js';
+
+describe('context-prompt', () => {
+  describe('getValidContextOptions', () => {
+    it('returns empty array for 0 messages', () => {
+      expect(getValidContextOptions(0)).toEqual([]);
+    });
+
+    it('returns empty array for 2 messages (less than smallest option)', () => {
+      expect(getValidContextOptions(2)).toEqual([]);
+    });
+
+    it('returns [3] for 3 messages', () => {
+      expect(getValidContextOptions(3)).toEqual([3]);
+    });
+
+    it('returns [3] for 4 messages', () => {
+      expect(getValidContextOptions(4)).toEqual([3]);
+    });
+
+    it('returns [3, 5] for 5 messages', () => {
+      expect(getValidContextOptions(5)).toEqual([3, 5]);
+    });
+
+    it('returns [3, 5] for 8 messages', () => {
+      expect(getValidContextOptions(8)).toEqual([3, 5]);
+    });
+
+    it('returns [3, 5, 10] for 10 messages', () => {
+      expect(getValidContextOptions(10)).toEqual([3, 5, 10]);
+    });
+
+    it('returns [3, 5, 10] for 20 messages', () => {
+      expect(getValidContextOptions(20)).toEqual([3, 5, 10]);
+    });
+  });
+
+  describe('getContextSelectionFromReaction', () => {
+    const standardOptions = [3, 5, 10];
+    const customOptions = [3, 5, 8]; // For 8 messages
+
+    it('returns first option for "one" emoji', () => {
+      expect(getContextSelectionFromReaction('one', standardOptions)).toBe(3);
+      expect(getContextSelectionFromReaction('one', customOptions)).toBe(3);
+    });
+
+    it('returns second option for "two" emoji', () => {
+      expect(getContextSelectionFromReaction('two', standardOptions)).toBe(5);
+      expect(getContextSelectionFromReaction('two', customOptions)).toBe(5);
+    });
+
+    it('returns third option for "three" emoji', () => {
+      expect(getContextSelectionFromReaction('three', standardOptions)).toBe(10);
+      expect(getContextSelectionFromReaction('three', customOptions)).toBe(8); // "All 8 messages"
+    });
+
+    it('returns 0 (no context) for denial emojis', () => {
+      expect(getContextSelectionFromReaction('-1', standardOptions)).toBe(0);
+      expect(getContextSelectionFromReaction('thumbsdown', standardOptions)).toBe(0);
+    });
+
+    it('returns 0 (no context) for "x" emoji', () => {
+      expect(getContextSelectionFromReaction('x', standardOptions)).toBe(0);
+    });
+
+    it('returns null for invalid emojis', () => {
+      expect(getContextSelectionFromReaction('heart', standardOptions)).toBe(null);
+      expect(getContextSelectionFromReaction('+1', standardOptions)).toBe(null);
+    });
+
+    it('returns null for out-of-range number emojis', () => {
+      const twoOptions = [3, 5];
+      expect(getContextSelectionFromReaction('three', twoOptions)).toBe(null);
+    });
+
+    it('handles unicode number emojis', () => {
+      expect(getContextSelectionFromReaction('1️⃣', standardOptions)).toBe(3);
+      expect(getContextSelectionFromReaction('2️⃣', standardOptions)).toBe(5);
+      expect(getContextSelectionFromReaction('3️⃣', standardOptions)).toBe(10);
+    });
+  });
+
+  describe('formatContextForClaude', () => {
+    it('returns empty string for empty messages', () => {
+      expect(formatContextForClaude([])).toBe('');
+    });
+
+    it('formats single message correctly', () => {
+      const messages: ThreadMessage[] = [
+        {
+          id: '1',
+          userId: 'user1',
+          username: 'alice',
+          message: 'Hello world',
+          createAt: Date.now(),
+        },
+      ];
+
+      const result = formatContextForClaude(messages);
+      expect(result).toContain('[Previous conversation in this thread:]');
+      expect(result).toContain('@alice: Hello world');
+      expect(result).toContain('[Current request:]');
+    });
+
+    it('formats multiple messages in order', () => {
+      const messages: ThreadMessage[] = [
+        {
+          id: '1',
+          userId: 'user1',
+          username: 'alice',
+          message: 'First message',
+          createAt: 1000,
+        },
+        {
+          id: '2',
+          userId: 'user2',
+          username: 'bob',
+          message: 'Second message',
+          createAt: 2000,
+        },
+      ];
+
+      const result = formatContextForClaude(messages);
+      expect(result).toContain('@alice: First message');
+      expect(result).toContain('@bob: Second message');
+      // Check order (alice before bob)
+      const aliceIndex = result.indexOf('@alice');
+      const bobIndex = result.indexOf('@bob');
+      expect(aliceIndex).toBeLessThan(bobIndex);
+    });
+
+    it('truncates very long messages', () => {
+      const longMessage = 'x'.repeat(600);
+      const messages: ThreadMessage[] = [
+        {
+          id: '1',
+          userId: 'user1',
+          username: 'alice',
+          message: longMessage,
+          createAt: Date.now(),
+        },
+      ];
+
+      const result = formatContextForClaude(messages);
+      expect(result).toContain('...');
+      expect(result).not.toContain(longMessage);
+    });
+
+    it('includes separator and current request header', () => {
+      const messages: ThreadMessage[] = [
+        {
+          id: '1',
+          userId: 'user1',
+          username: 'alice',
+          message: 'Test',
+          createAt: Date.now(),
+        },
+      ];
+
+      const result = formatContextForClaude(messages);
+      expect(result).toContain('---');
+      expect(result).toContain('[Current request:]');
+    });
+  });
+
+  describe('CONTEXT_OPTIONS', () => {
+    it('has exactly 3 options', () => {
+      expect(CONTEXT_OPTIONS.length).toBe(3);
+    });
+
+    it('options are in ascending order', () => {
+      for (let i = 1; i < CONTEXT_OPTIONS.length; i++) {
+        expect(CONTEXT_OPTIONS[i]).toBeGreaterThan(CONTEXT_OPTIONS[i - 1]);
+      }
+    });
+
+    it('first option is 3 messages', () => {
+      expect(CONTEXT_OPTIONS[0]).toBe(3);
+    });
+  });
+});

--- a/src/session/context-prompt.ts
+++ b/src/session/context-prompt.ts
@@ -1,0 +1,253 @@
+/**
+ * Thread context prompt module
+ *
+ * Handles offering users the option to include previous thread context
+ * when a session restarts (via !cd, worktree creation, or mid-thread @mention).
+ */
+
+import type { Session } from './types.js';
+import type { ThreadMessage } from '../platform/index.js';
+import { NUMBER_EMOJIS, DENIAL_EMOJIS, getNumberEmojiIndex, isDenialEmoji } from '../utils/emoji.js';
+
+// Context timeout in milliseconds (30 seconds)
+export const CONTEXT_PROMPT_TIMEOUT_MS = 30000;
+
+// Context options: last N messages
+export const CONTEXT_OPTIONS = [3, 5, 10] as const;
+
+/**
+ * Pending context prompt state
+ */
+export interface PendingContextPrompt {
+  postId: string;
+  queuedPrompt: string;       // The prompt to send after decision
+  threadMessageCount: number; // Total messages in thread before this point
+  createdAt: number;          // Timestamp for timeout tracking
+  timeoutId?: ReturnType<typeof setTimeout>; // Reference to timeout for cleanup
+  availableOptions: number[]; // The actual options shown (e.g., [3, 5, 8] for 8 messages)
+}
+
+// ---------------------------------------------------------------------------
+// Context prompt functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if we should prompt for context.
+ * Returns the number of messages available, or 0 if we shouldn't prompt.
+ */
+export async function getThreadContextCount(
+  session: Session,
+  excludePostId?: string
+): Promise<number> {
+  try {
+    const messages = await session.platform.getThreadHistory(
+      session.threadId,
+      { excludeBotMessages: true }
+    );
+
+    // Filter out the current post if specified
+    const relevantMessages = excludePostId
+      ? messages.filter(m => m.id !== excludePostId)
+      : messages;
+
+    return relevantMessages.length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Get the valid context options based on available message count.
+ * Only returns options that are <= messageCount.
+ */
+export function getValidContextOptions(messageCount: number): number[] {
+  return CONTEXT_OPTIONS.filter(opt => opt <= messageCount);
+}
+
+/**
+ * Post the context prompt to the user.
+ * Returns the pending context prompt state.
+ */
+export async function postContextPrompt(
+  session: Session,
+  queuedPrompt: string,
+  messageCount: number,
+  registerPost: (postId: string, threadId: string) => void,
+  onTimeout: () => void
+): Promise<PendingContextPrompt> {
+  // Filter options to only those <= messageCount
+  const validOptions = getValidContextOptions(messageCount);
+
+  // Build message with only valid options
+  let optionsText = '';
+  const reactionOptions: string[] = [];
+
+  for (let i = 0; i < validOptions.length; i++) {
+    const opt = validOptions[i];
+    const emoji = ['1️⃣', '2️⃣', '3️⃣'][i];
+    optionsText += `${emoji} Last ${opt} messages\n`;
+    reactionOptions.push(NUMBER_EMOJIS[i]);
+  }
+
+  // Add "All messages" option if messageCount > largest option shown
+  // or if no options are valid (messageCount < smallest option)
+  if (validOptions.length === 0 || messageCount > validOptions[validOptions.length - 1]) {
+    const nextIndex = validOptions.length;
+    if (nextIndex < 3) {
+      const emoji = ['1️⃣', '2️⃣', '3️⃣'][nextIndex];
+      optionsText += `${emoji} All ${messageCount} messages\n`;
+      reactionOptions.push(NUMBER_EMOJIS[nextIndex]);
+    }
+  }
+
+  // Add no context option
+  optionsText += `❌ No context (default after 30s)`;
+  reactionOptions.push(DENIAL_EMOJIS[0]);
+
+  const message =
+    `🧵 **Include thread context?**\n` +
+    `This thread has ${messageCount} message${messageCount === 1 ? '' : 's'} before this point.\n` +
+    `React to include previous messages, or continue without context.\n\n` +
+    optionsText;
+
+  const post = await session.platform.createInteractivePost(
+    message,
+    reactionOptions,
+    session.threadId
+  );
+
+  // Register for reaction routing
+  registerPost(post.id, session.threadId);
+
+  // Set up timeout
+  const timeoutId = setTimeout(onTimeout, CONTEXT_PROMPT_TIMEOUT_MS);
+
+  // Build the list of available options that were shown
+  // This includes the valid CONTEXT_OPTIONS plus potentially "all messages"
+  const availableOptions = [...validOptions];
+  if (validOptions.length === 0 || messageCount > validOptions[validOptions.length - 1]) {
+    if (validOptions.length < 3) {
+      availableOptions.push(messageCount); // "All X messages" option
+    }
+  }
+
+  return {
+    postId: post.id,
+    queuedPrompt,
+    threadMessageCount: messageCount,
+    createdAt: Date.now(),
+    timeoutId,
+    availableOptions,
+  };
+}
+
+/**
+ * Handle a reaction on the context prompt.
+ * Returns the number of messages to include, or null if not a valid reaction.
+ * Returns 0 for "no context" selection.
+ *
+ * @param emojiName - The emoji that was reacted with
+ * @param availableOptions - The options that were shown in the prompt
+ */
+export function getContextSelectionFromReaction(
+  emojiName: string,
+  availableOptions: number[]
+): number | null {
+  // Check for number emoji (1, 2, 3)
+  const numberIndex = getNumberEmojiIndex(emojiName);
+  if (numberIndex >= 0 && numberIndex < availableOptions.length) {
+    return availableOptions[numberIndex];
+  }
+
+  // Check for "no context" / denial emoji
+  if (isDenialEmoji(emojiName)) {
+    return 0;
+  }
+
+  // Also accept 'x' emoji as "no context"
+  if (emojiName === 'x') {
+    return 0;
+  }
+
+  return null; // Not a valid context selection reaction
+}
+
+/**
+ * Get thread messages for context.
+ */
+export async function getThreadMessagesForContext(
+  session: Session,
+  limit: number,
+  excludePostId?: string
+): Promise<ThreadMessage[]> {
+  const messages = await session.platform.getThreadHistory(
+    session.threadId,
+    { limit, excludeBotMessages: true }
+  );
+
+  // Filter out the current post if specified
+  return excludePostId
+    ? messages.filter(m => m.id !== excludePostId)
+    : messages;
+}
+
+/**
+ * Format thread messages as context for Claude.
+ */
+export function formatContextForClaude(messages: ThreadMessage[]): string {
+  if (messages.length === 0) return '';
+
+  const lines = ['[Previous conversation in this thread:]', ''];
+
+  for (const msg of messages) {
+    // Truncate very long messages
+    const content = msg.message.length > 500
+      ? msg.message.substring(0, 500) + '...'
+      : msg.message;
+    lines.push(`@${msg.username}: ${content}`);
+  }
+
+  lines.push('', '---', '', '[Current request:]');
+
+  return lines.join('\n');
+}
+
+/**
+ * Update the context prompt post to show the user's selection.
+ */
+export async function updateContextPromptPost(
+  session: Session,
+  postId: string,
+  selection: number | 'timeout' | 'skip',
+  username?: string
+): Promise<void> {
+  let message: string;
+
+  if (selection === 'timeout') {
+    message = '⏱️ Continuing without context (no response)';
+  } else if (selection === 'skip' || selection === 0) {
+    message = username
+      ? `✅ Continuing without context (skipped by @${username})`
+      : '✅ Continuing without context';
+  } else {
+    message = username
+      ? `✅ Including last ${selection} messages (selected by @${username})`
+      : `✅ Including last ${selection} messages`;
+  }
+
+  try {
+    await session.platform.updatePost(postId, message);
+  } catch (err) {
+    console.error('  ⚠️ Failed to update context prompt post:', err);
+  }
+}
+
+/**
+ * Clear the context prompt timeout.
+ */
+export function clearContextPromptTimeout(pending: PendingContextPrompt): void {
+  if (pending.timeoutId) {
+    clearTimeout(pending.timeoutId);
+    pending.timeoutId = undefined;
+  }
+}

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -11,3 +11,4 @@ export type {
   PendingQuestionSet,
   PendingMessageApproval,
 } from './types.js';
+export type { PendingContextPrompt } from './context-prompt.js';

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -5,6 +5,7 @@
 import type { ClaudeCli } from '../claude/cli.js';
 import type { PlatformClient } from '../platform/index.js';
 import type { WorktreeInfo } from '../persistence/session-store.js';
+import type { PendingContextPrompt } from './context-prompt.js';
 
 // =============================================================================
 // Interactive State Types
@@ -120,6 +121,9 @@ export interface Session {
   queuedPrompt?: string;                    // User's original message when waiting for worktree response
   worktreePromptPostId?: string;            // Post ID of the worktree prompt (for ❌ reaction)
   firstPrompt?: string;                     // First user message, sent again after mid-session worktree creation
+
+  // Thread context prompt support
+  pendingContextPrompt?: PendingContextPrompt; // Waiting for context selection
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

When starting a Claude session in an existing thread (replying mid-thread), the bot now offers to include previous conversation context:

- Shows options for last 3, 5, or 10 messages (dynamically based on available messages)
- Adds "All X messages" option when message count doesn't match standard options
- 30-second timeout defaults to no context
- Context is prepended to the initial prompt so Claude understands the conversation history

**Example prompt for 8 messages:**
```
🧵 **Include thread context?**
This thread has 8 messages before this point.
React to include previous messages, or continue without context.

1️⃣ Last 3 messages
2️⃣ Last 5 messages
3️⃣ All 8 messages
❌ No context (default after 30s)
```

## Changes

### New Files
- `src/session/context-prompt.ts`: Core context prompt logic
- `src/session/context-prompt.test.ts`: Unit tests (9 new tests)

### Platform Layer
- Added `getThreadHistory()` to `PlatformClient` interface
- Implemented for Mattermost using `/posts/{id}/thread` API
- Added `ThreadMessage` type for normalized thread messages

### Session Management
- Added `pendingContextPrompt` to Session state
- Added persistence for context prompt state (survives bot restart)
- Integrated into `lifecycle.ts` for mid-thread session starts
- Reaction handling in `manager.ts`

## Test plan

- [ ] Start a new session in a channel (first message) - should NOT show context prompt
- [ ] Reply to an existing thread with @mention - should show context prompt with appropriate options
- [ ] React with number emoji - should include selected context
- [ ] React with ❌ or thumbsdown - should continue without context
- [ ] Wait 30 seconds - should timeout and continue without context
- [ ] Verify context is properly formatted in Claude's prompt