### PR TITLE
fix: Show context prompt after worktree creation and !cd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.9] - 2025-12-31
+
+### Fixed
+- **Context prompt after restart**: Context prompt now appears after session restarts (worktree creation, `!cd`)
+  - Previously, after worktree creation or directory change, the context prompt was skipped
+  - Now users can include thread history when Claude restarts in a new directory
+  - Added `needsContextPromptOnNextMessage` flag for deferred context prompt (after `!cd`)
+
 ## [0.16.8] - 2025-12-31
 
 ### Fixed

--- a/src/persistence/session-store.ts
+++ b/src/persistence/session-store.ts
@@ -47,6 +47,7 @@ export interface PersistedSession {
   firstPrompt?: string;                     // First user message, sent again after mid-session worktree creation
   // Context prompt support
   pendingContextPrompt?: PersistedContextPrompt; // Waiting for context selection
+  needsContextPromptOnNextMessage?: boolean;     // Offer context prompt on next follow-up message (after !cd)
 }
 
 /**

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -36,6 +36,7 @@ export interface CommandContext {
   persistSession: (session: Session) => void;
   killSession: (threadId: string) => void;
   registerPost: (postId: string, threadId: string) => void;
+  offerContextPrompt: (session: Session, queuedPrompt: string) => Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------
@@ -196,6 +197,10 @@ export async function changeDirectory(
   // Update activity
   session.lastActivityAt = new Date();
   session.timeoutWarningPosted = false;
+
+  // Mark session to offer context prompt on next message
+  // This allows the user to include thread history after directory change
+  session.needsContextPromptOnNextMessage = true;
 
   // Persist the updated session state
   ctx.persistSession(session);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -161,6 +161,7 @@ export class SessionManager {
       persistSession: (s) => this.persistSession(s),
       killSession: (tid) => this.killSession(tid),
       registerPost: (pid, tid) => this.registerPost(pid, tid),
+      offerContextPrompt: (s, q) => this.offerContextPrompt(s, q),
     };
   }
 
@@ -217,7 +218,7 @@ export class SessionManager {
         session,
         username,
         (s) => this.persistSession(s),
-        (s) => this.startTyping(s)
+        (s, q) => this.offerContextPrompt(s, q)
       );
       return;
     }
@@ -499,6 +500,7 @@ export class SessionManager {
       queuedPrompt: session.queuedPrompt,
       firstPrompt: session.firstPrompt,
       pendingContextPrompt: persistedContextPrompt,
+      needsContextPromptOnNextMessage: session.needsContextPromptOnNextMessage,
     };
     this.sessionStore.save(session.sessionId, state);
   }
@@ -673,7 +675,7 @@ export class SessionManager {
       session,
       username,
       (s) => this.persistSession(s),
-      (s) => this.startTyping(s)
+      (s, q) => this.offerContextPrompt(s, q)
     );
   }
 
@@ -690,6 +692,7 @@ export class SessionManager {
       persistSession: (s) => this.persistSession(s),
       startTyping: (s) => this.startTyping(s),
       stopTyping: (s) => this.stopTyping(s),
+      offerContextPrompt: (s, q) => this.offerContextPrompt(s, q),
     });
   }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -124,6 +124,7 @@ export interface Session {
 
   // Thread context prompt support
   pendingContextPrompt?: PendingContextPrompt; // Waiting for context selection
+  needsContextPromptOnNextMessage?: boolean;   // Offer context prompt on next follow-up message (after !cd)
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Fixed bug where context prompt wasn't shown after session restarts (worktree creation, `!cd`)
- Users can now include thread history when Claude restarts in a new directory
- Added deferred context prompt mechanism for `!cd` command

## Test plan
- [ ] Start session mid-thread, create worktree → context prompt should appear
- [ ] Start session mid-thread, skip worktree (❌) → context prompt should appear
- [ ] In existing session, use `!cd /path` then send message → context prompt should appear
- [ ] Verify normal follow-up messages (without restart) don't trigger context prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)