### PR TITLE
feat: Resume timed-out sessions via emoji reaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cross-platform: macOS (`caffeinate`), Linux (`systemd-inhibit`), Windows (`SetThreadExecutionState`)
   - Enabled by default, disable with `--no-keep-alive` CLI flag or `keepAlive: false` in config
   - Shows `☕ Keep-alive enabled` in startup output
+- **Resume timed-out sessions via emoji reaction** - React with 🔄 to the timeout message or session header to resume a timed-out session
+  - Timeout message now shows resume hint: "💡 React with 🔄 to resume, or send a new message to continue."
+  - Resume also works by sending a new message in the thread (existing behavior)
+  - Session header now displays truncated session ID for reference
+  - Supports multiple resume emojis: 🔄 (arrows_counterclockwise), ▶️ (arrow_forward), 🔁 (repeat)
 
 ## [0.17.1] - 2025-12-31
 

--- a/src/persistence/session-store.test.ts
+++ b/src/persistence/session-store.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SessionStore, PersistedSession } from './session-store.js';
+
+describe('SessionStore', () => {
+  let store: SessionStore;
+
+  // Helper to create a test session
+  function createTestSession(overrides: Partial<PersistedSession> = {}): PersistedSession {
+    return {
+      platformId: 'test-platform',
+      threadId: 'thread-123',
+      claudeSessionId: 'uuid-456',
+      startedBy: 'testuser',
+      startedAt: new Date().toISOString(),
+      lastActivityAt: new Date().toISOString(),
+      sessionNumber: 1,
+      workingDir: '/tmp/test',
+      planApproved: false,
+      sessionAllowedUsers: ['testuser'],
+      forceInteractivePermissions: false,
+      sessionStartPostId: 'post-789',
+      tasksPostId: null,
+      lastTasksContent: null,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    store = new SessionStore();
+    store.clear(); // Start with clean state
+  });
+
+  afterEach(() => {
+    store.clear();
+  });
+
+  describe('save and load', () => {
+    it('saves and loads a session', () => {
+      const session = createTestSession();
+      const sessionId = `${session.platformId}:${session.threadId}`;
+
+      store.save(sessionId, session);
+      const loaded = store.load();
+
+      expect(loaded.size).toBe(1);
+      expect(loaded.get(sessionId)).toEqual(session);
+    });
+
+    it('saves multiple sessions', () => {
+      const session1 = createTestSession({ threadId: 'thread-1' });
+      const session2 = createTestSession({ threadId: 'thread-2' });
+
+      store.save('test-platform:thread-1', session1);
+      store.save('test-platform:thread-2', session2);
+
+      const loaded = store.load();
+      expect(loaded.size).toBe(2);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a session', () => {
+      const session = createTestSession();
+      const sessionId = `${session.platformId}:${session.threadId}`;
+
+      store.save(sessionId, session);
+      expect(store.load().size).toBe(1);
+
+      store.remove(sessionId);
+      expect(store.load().size).toBe(0);
+    });
+  });
+
+  describe('findByThread', () => {
+    it('finds a session by platform and thread ID', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      const found = store.findByThread('mattermost-main', 'thread-abc');
+      expect(found).toEqual(session);
+    });
+
+    it('returns undefined for non-existent session', () => {
+      const found = store.findByThread('nonexistent', 'thread-xyz');
+      expect(found).toBeUndefined();
+    });
+
+    it('does not find session from different platform', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      const found = store.findByThread('slack-main', 'thread-abc');
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('findByPostId', () => {
+    it('finds a session by timeoutPostId', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+        timeoutPostId: 'timeout-post-123',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      const found = store.findByPostId('mattermost-main', 'timeout-post-123');
+      expect(found).toEqual(session);
+    });
+
+    it('finds a session by sessionStartPostId', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+        sessionStartPostId: 'start-post-456',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      const found = store.findByPostId('mattermost-main', 'start-post-456');
+      expect(found).toEqual(session);
+    });
+
+    it('returns undefined for non-existent post ID', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+        timeoutPostId: 'timeout-post-123',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      const found = store.findByPostId('mattermost-main', 'other-post-789');
+      expect(found).toBeUndefined();
+    });
+
+    it('does not find session from different platform', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+        timeoutPostId: 'timeout-post-123',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      const found = store.findByPostId('slack-main', 'timeout-post-123');
+      expect(found).toBeUndefined();
+    });
+
+    it('finds session when both timeoutPostId and sessionStartPostId are set', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-abc',
+        sessionStartPostId: 'start-post-456',
+        timeoutPostId: 'timeout-post-123',
+      });
+      store.save('mattermost-main:thread-abc', session);
+
+      // Should find by either
+      expect(store.findByPostId('mattermost-main', 'timeout-post-123')).toEqual(session);
+      expect(store.findByPostId('mattermost-main', 'start-post-456')).toEqual(session);
+    });
+  });
+
+  describe('cleanStale', () => {
+    it('removes sessions older than maxAgeMs', () => {
+      const oldSession = createTestSession({
+        threadId: 'old-thread',
+        lastActivityAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+      });
+      const newSession = createTestSession({
+        threadId: 'new-thread',
+        lastActivityAt: new Date().toISOString(),
+      });
+
+      store.save('test-platform:old-thread', oldSession);
+      store.save('test-platform:new-thread', newSession);
+
+      const staleIds = store.cleanStale(60 * 60 * 1000); // 1 hour
+
+      expect(staleIds).toContain('test-platform:old-thread');
+      expect(staleIds).not.toContain('test-platform:new-thread');
+      expect(store.load().size).toBe(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all sessions', () => {
+      store.save('test-platform:thread-1', createTestSession({ threadId: 'thread-1' }));
+      store.save('test-platform:thread-2', createTestSession({ threadId: 'thread-2' }));
+
+      expect(store.load().size).toBe(2);
+
+      store.clear();
+
+      expect(store.load().size).toBe(0);
+    });
+  });
+});

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -475,6 +475,7 @@ export async function updateSessionHeader(
   }
 
   rows.push(`| 🔢 **Session** | #${session.sessionNumber} of ${ctx.maxSessions} max |`);
+  rows.push(`| 🆔 **Session ID** | \`${session.claudeSessionId.substring(0, 8)}\` |`);
   rows.push(`| ${permMode.split(' ')[0]} **Permissions** | ${permMode.split(' ')[1]} |`);
   if (ctx.chromeEnabled) {
     rows.push(`| 🌐 **Chrome** | Enabled |`);

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -127,6 +127,9 @@ export interface Session {
   // Thread context prompt support
   pendingContextPrompt?: PendingContextPrompt; // Waiting for context selection
   needsContextPromptOnNextMessage?: boolean;   // Offer context prompt on next follow-up message (after !cd)
+
+  // Resume support
+  timeoutPostId?: string;  // Post ID of timeout message (for resume via reaction)
 }
 
 // =============================================================================

--- a/src/utils/emoji.test.ts
+++ b/src/utils/emoji.test.ts
@@ -5,6 +5,7 @@ import {
   isAllowAllEmoji,
   isCancelEmoji,
   isEscapeEmoji,
+  isResumeEmoji,
   getNumberEmojiIndex,
   APPROVAL_EMOJIS,
   DENIAL_EMOJIS,
@@ -12,6 +13,7 @@ import {
   NUMBER_EMOJIS,
   CANCEL_EMOJIS,
   ESCAPE_EMOJIS,
+  RESUME_EMOJIS,
 } from './emoji.js';
 
 describe('emoji helpers', () => {
@@ -123,6 +125,32 @@ describe('emoji helpers', () => {
     it('matches all ESCAPE_EMOJIS', () => {
       for (const emoji of ESCAPE_EMOJIS) {
         expect(isEscapeEmoji(emoji)).toBe(true);
+      }
+    });
+  });
+
+  describe('isResumeEmoji', () => {
+    it('returns true for arrows_counterclockwise', () => {
+      expect(isResumeEmoji('arrows_counterclockwise')).toBe(true);
+    });
+
+    it('returns true for arrow_forward', () => {
+      expect(isResumeEmoji('arrow_forward')).toBe(true);
+    });
+
+    it('returns true for repeat', () => {
+      expect(isResumeEmoji('repeat')).toBe(true);
+    });
+
+    it('returns false for other emojis', () => {
+      expect(isResumeEmoji('heart')).toBe(false);
+      expect(isResumeEmoji('x')).toBe(false);
+      expect(isResumeEmoji('+1')).toBe(false);
+    });
+
+    it('matches all RESUME_EMOJIS', () => {
+      for (const emoji of RESUME_EMOJIS) {
+        expect(isResumeEmoji(emoji)).toBe(true);
       }
     });
   });

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -23,6 +23,9 @@ export const CANCEL_EMOJIS = ['x', 'octagonal_sign', 'stop_sign'] as const;
 /** Emojis for escaping/pausing a session */
 export const ESCAPE_EMOJIS = ['double_vertical_bar', 'pause_button'] as const;
 
+/** Emojis for resuming a timed-out session */
+export const RESUME_EMOJIS = ['arrows_counterclockwise', 'arrow_forward', 'repeat'] as const;
+
 /**
  * Check if the emoji indicates approval (thumbs up)
  */
@@ -56,6 +59,13 @@ export function isCancelEmoji(emoji: string): boolean {
  */
 export function isEscapeEmoji(emoji: string): boolean {
   return (ESCAPE_EMOJIS as readonly string[]).includes(emoji);
+}
+
+/**
+ * Check if the emoji indicates session resume
+ */
+export function isResumeEmoji(emoji: string): boolean {
+  return (RESUME_EMOJIS as readonly string[]).includes(emoji);
 }
 
 /** Unicode number emoji variants that also map to indices */


### PR DESCRIPTION
## Summary

- Add ability to resume timed-out sessions by reacting with 🔄 to the timeout message or session header
- Timeout message now shows resume hint: "💡 React with 🔄 to resume, or send a new message to continue."
- Session header now displays truncated session ID for reference
- Supports multiple resume emojis: 🔄 (arrows_counterclockwise), ▶️ (arrow_forward), 🔁 (repeat)

## Changes

| File | Changes |
|------|---------|
| `src/persistence/session-store.ts` | Added `timeoutPostId` field, `findByThread()` and `findByPostId()` methods |
| `src/session/types.ts` | Added `timeoutPostId` to Session type |
| `src/utils/emoji.ts` | Added `RESUME_EMOJIS` constant and `isResumeEmoji()` function |
| `src/session/lifecycle.ts` | Made `cleanupIdleSessions()` async, updated timeout message with resume hint |
| `src/session/commands.ts` | Added session ID row to header |
| `src/session/manager.ts` | Added `tryResumeFromReaction()` method, handles resume emoji in `handleReaction()` |

## Test plan

- [x] All 182 tests pass (18 new tests added)
- [x] ESLint passes
- [x] Build succeeds
- [ ] Manual test: Start a session, let it timeout, react with 🔄 to resume
- [ ] Manual test: Start a session, let it timeout, send a new message to resume