### PR TITLE
refactor: Unify CLI output styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Unified CLI output styling** - Consistent 2-space indented output with emoji prefixes
+  - Created centralized `src/utils/output.ts` module with shared color helpers
+  - Keep-alive messages now use `☕ Sleep prevention active (caffeinate)` format instead of `[keep-alive]` prefix
+  - All files now import colors from the shared module instead of defining locally
+
 ## [0.18.0] - 2026-01-01
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,7 @@ import { getReleaseNotes, formatReleaseNotes } from './changelog.js';
 import { printLogo } from './logo.js';
 import { VERSION } from './version.js';
 import { keepAlive } from './utils/keep-alive.js';
-
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
-const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+import { dim, bold, cyan } from './utils/output.js';
 
 // Define CLI options
 program

--- a/src/logo.ts
+++ b/src/logo.ts
@@ -4,16 +4,7 @@
  * Stylized CT in Claude Code's block character style.
  */
 
-// ANSI color codes for terminal
-const colors = {
-  reset: '\x1b[0m',
-  bold: '\x1b[1m',
-  dim: '\x1b[2m',
-  // Claude blue
-  blue: '\x1b[38;5;27m',
-  // Claude orange/coral
-  orange: '\x1b[38;5;209m',
-};
+import { colors } from './utils/output.js';
 
 /**
  * ASCII logo for CLI display (with ANSI colors)

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -8,10 +8,7 @@ import {
   type MattermostPlatformConfig,
   type SlackPlatformConfig,
 } from './config/migration.js';
-
-const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
-const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
-const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+import { bold, dim, green } from './utils/output.js';
 
 const onCancel = () => {
   console.log('');

--- a/src/utils/output.test.ts
+++ b/src/utils/output.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, spyOn, beforeEach, afterEach } from 'bun:test';
+import { colors, dim, bold, cyan, green, red, yellow, log, debug, error, warn, logPlain, logEmpty } from './output.js';
+
+describe('colors', () => {
+  it('exports ANSI color codes', () => {
+    expect(colors.reset).toBe('\x1b[0m');
+    expect(colors.bold).toBe('\x1b[1m');
+    expect(colors.dim).toBe('\x1b[2m');
+    expect(colors.cyan).toBe('\x1b[36m');
+    expect(colors.green).toBe('\x1b[32m');
+    expect(colors.red).toBe('\x1b[31m');
+    expect(colors.yellow).toBe('\x1b[33m');
+    expect(colors.blue).toBe('\x1b[38;5;27m');
+    expect(colors.orange).toBe('\x1b[38;5;209m');
+  });
+});
+
+describe('styling helpers', () => {
+  it('dim wraps text with dim codes', () => {
+    expect(dim('test')).toBe('\x1b[2mtest\x1b[0m');
+  });
+
+  it('bold wraps text with bold codes', () => {
+    expect(bold('test')).toBe('\x1b[1mtest\x1b[0m');
+  });
+
+  it('cyan wraps text with cyan codes', () => {
+    expect(cyan('test')).toBe('\x1b[36mtest\x1b[0m');
+  });
+
+  it('green wraps text with green codes', () => {
+    expect(green('test')).toBe('\x1b[32mtest\x1b[0m');
+  });
+
+  it('red wraps text with red codes', () => {
+    expect(red('test')).toBe('\x1b[31mtest\x1b[0m');
+  });
+
+  it('yellow wraps text with yellow codes', () => {
+    expect(yellow('test')).toBe('\x1b[33mtest\x1b[0m');
+  });
+});
+
+describe('logging functions', () => {
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+  let consoleErrorSpy: ReturnType<typeof spyOn>;
+  const originalEnv = process.env.DEBUG;
+
+  beforeEach(() => {
+    consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    delete process.env.DEBUG;
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    if (originalEnv !== undefined) {
+      process.env.DEBUG = originalEnv;
+    } else {
+      delete process.env.DEBUG;
+    }
+  });
+
+  describe('log', () => {
+    it('logs with emoji and 2-space indent', () => {
+      log('☕', 'test message');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  ☕ test message');
+    });
+  });
+
+  describe('debug', () => {
+    it('does not log when DEBUG is not set', () => {
+      debug('☕', 'test message');
+      expect(consoleLogSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs with dim styling when DEBUG=1', () => {
+      process.env.DEBUG = '1';
+      debug('☕', 'test message');
+      expect(consoleLogSpy).toHaveBeenCalledWith(`  ☕ ${dim('test message')}`);
+    });
+  });
+
+  describe('error', () => {
+    it('logs to stderr with emoji and 2-space indent', () => {
+      error('❌', 'error message');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('  ❌ error message');
+    });
+  });
+
+  describe('warn', () => {
+    it('logs with emoji and 2-space indent', () => {
+      warn('⚠️', 'warning message');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  ⚠️ warning message');
+    });
+  });
+
+  describe('logPlain', () => {
+    it('logs with 2-space indent but no emoji', () => {
+      logPlain('plain message');
+      expect(consoleLogSpy).toHaveBeenCalledWith('  plain message');
+    });
+  });
+
+  describe('logEmpty', () => {
+    it('logs an empty line', () => {
+      logEmpty();
+      expect(consoleLogSpy).toHaveBeenCalledWith('');
+    });
+  });
+});

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,0 +1,77 @@
+/**
+ * Unified CLI Output Module
+ *
+ * Provides consistent styling and formatting for all CLI output.
+ * All messages use 2-space indentation with emoji prefixes.
+ */
+
+// ANSI color codes
+export const colors = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  // Claude brand colors
+  blue: '\x1b[38;5;27m',
+  orange: '\x1b[38;5;209m',
+};
+
+// Helper functions for styling text
+export const dim = (s: string): string => `${colors.dim}${s}${colors.reset}`;
+export const bold = (s: string): string => `${colors.bold}${s}${colors.reset}`;
+export const cyan = (s: string): string => `${colors.cyan}${s}${colors.reset}`;
+export const green = (s: string): string => `${colors.green}${s}${colors.reset}`;
+export const red = (s: string): string => `${colors.red}${s}${colors.reset}`;
+export const yellow = (s: string): string => `${colors.yellow}${s}${colors.reset}`;
+
+/**
+ * Log an info message with emoji prefix (always shown)
+ * Format: "  {emoji} {message}"
+ */
+export function log(emoji: string, message: string): void {
+  console.log(`  ${emoji} ${message}`);
+}
+
+/**
+ * Log a debug message with emoji prefix (only when DEBUG=1)
+ * Format: "  {emoji} {message}"
+ */
+export function debug(emoji: string, message: string): void {
+  if (process.env.DEBUG === '1') {
+    console.log(`  ${emoji} ${dim(message)}`);
+  }
+}
+
+/**
+ * Log an error message with emoji prefix (always shown, to stderr)
+ * Format: "  {emoji} {message}"
+ */
+export function error(emoji: string, message: string): void {
+  console.error(`  ${emoji} ${message}`);
+}
+
+/**
+ * Log a warning message with emoji prefix (always shown)
+ * Format: "  {emoji} {message}"
+ */
+export function warn(emoji: string, message: string): void {
+  console.log(`  ${emoji} ${message}`);
+}
+
+/**
+ * Log a plain message with standard indentation (no emoji)
+ * Format: "  {message}"
+ */
+export function logPlain(message: string): void {
+  console.log(`  ${message}`);
+}
+
+/**
+ * Log an empty line
+ */
+export function logEmpty(): void {
+  console.log('');
+}


### PR DESCRIPTION
## Summary

- Create centralized `src/utils/output.ts` module with shared colors and logging functions
- Update keep-alive messages to use emoji-prefix style instead of `[keep-alive]` bracket prefix
- Consolidate duplicate color helper definitions from multiple files
- Add 14 tests for the output module

**Before:**
```
  ☕ Keep-alive enabled
[keep-alive] System sleep prevention started (caffeinate)
```

**After:**
```
  ☕ Keep-alive enabled
  ☕ Sleep prevention active (caffeinate)
```

## Test plan

- [x] All 211 tests pass
- [x] Build succeeds
- [x] Lint passes