### PR TITLE
fix: Improve thinking trace display formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Task list collapse emoji now pre-added** - The 🔽 toggle emoji is now automatically added as a reaction when the task list is created, making it easy to click and collapse/expand the list (previously users had to manually add the emoji)
+- **Improved thinking trace display** - Better formatting for extended thinking blocks
+  - Use blockquote format (`> 💭 *...*`) for cleaner visual separation
+  - Increased preview length from 100 to 200 characters
+  - Cut at word boundaries instead of mid-word for cleaner truncation
 
 ## [0.19.0] - 2026-01-01
 

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -131,10 +131,18 @@ function formatEvent(
           const formatted = sharedFormatToolUse(block.name, block.input || {}, session.platform.getFormatter(), { detailed: true });
           if (formatted) parts.push(formatted);
         } else if (block.type === 'thinking' && block.thinking) {
-          // Extended thinking - show abbreviated version
+          // Extended thinking - show abbreviated version in blockquote
           const thinking = block.thinking as string;
-          const preview = thinking.length > 100 ? thinking.substring(0, 100) + '...' : thinking;
-          parts.push(`💭 *Thinking: ${preview}*`);
+          const maxLength = 200;
+          let preview = thinking;
+          if (thinking.length > maxLength) {
+            // Cut at word boundary
+            const truncated = thinking.substring(0, maxLength);
+            const lastSpace = truncated.lastIndexOf(' ');
+            preview = (lastSpace > maxLength * 0.7 ? truncated.substring(0, lastSpace) : truncated) + '...';
+          }
+          // Use blockquote for better formatting
+          parts.push(`> 💭 *${preview}*`);
         } else if (block.type === 'server_tool_use' && block.name) {
           // Server-managed tools like web search
           parts.push(


### PR DESCRIPTION
## Summary
- Use blockquote format (`> 💭 *...*`) for cleaner visual separation
- Increase preview length from 100 to 200 characters  
- Cut at word boundaries instead of mid-word for cleaner truncation

## Test plan
- [ ] Deploy and trigger extended thinking in a session
- [ ] Verify thinking traces display in blockquote format
- [ ] Verify long thinking content is truncated at word boundaries