### PR TITLE
feat: Add smart message breaking to reduce Show More in Mattermost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-01-01
+
+### Added
+- **Smart message breaking** - Breaks long responses into multiple messages at logical points
+  - Reduces "Show More" toggles in Mattermost by breaking messages before they get too long
+  - Breaks at logical points: after tool completions, before headings, after code blocks, at paragraph breaks
+  - Soft threshold at 2000 chars / 15 lines triggers search for breakpoints
+  - Hard threshold at 14K chars ensures messages stay within platform limits
+  - Adds `*... (continued below)*` marker when breaking messages
+
 ## [0.19.1] - 2026-01-01
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Implements logical message breaking to prevent long responses from being hidden behind "Show More" toggles in Mattermost
- Messages are now split at semantic boundaries (tool results, headings, code blocks, paragraphs) rather than only at the hard 14K character limit
- Adds soft threshold (2000 chars / 15 lines) that triggers a search for logical breakpoints

## Changes

**`src/session/streaming.ts`**:
- Added `SOFT_BREAK_THRESHOLD` (2000), `MIN_BREAK_THRESHOLD` (500), `MAX_LINES_BEFORE_BREAK` (15) constants
- Added `findLogicalBreakpoint()` - finds best break position by priority: tool markers > headings > code blocks > paragraphs > line breaks
- Added `shouldFlushEarly()` - checks if content exceeds soft thresholds
- Added `endsAtBreakpoint()` - detects if content ends at a logical point
- Updated `flush()` to use smart breaking when exceeding soft threshold

**`src/session/events.ts`**:
- Added flush-after-tool_result when content exceeds threshold, creating natural message breaks after tool completions

**`src/session/streaming.test.ts`**:
- Added 25 new tests for breakpoint detection and smart breaking logic

## Test plan

- [x] All 236 tests pass (25 new + 211 existing)
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual test in Mattermost with multi-tool tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)