### PR TITLE
fix: Keep task list below subagent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Hard threshold at 14K chars ensures messages stay within platform limits
   - Adds `*... (continued below)*` marker when breaking messages
 
+### Fixed
+- **Task list stays below subagent messages** - Task list now bumps to bottom when subagents start
+  - Previously, subagent status messages would appear below the task list
+  - Now the task list correctly repositions itself below subagent posts
+
 ## [0.19.1] - 2026-01-01
 
 ### Fixed

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -139,6 +139,7 @@ export class SessionManager {
       startTyping: (s) => this.startTyping(s),
       stopTyping: (s) => this.stopTyping(s),
       appendContent: (s, t) => this.appendContent(s, t),
+      bumpTasksToBottom: (s) => this.bumpTasksToBottom(s),
     };
   }
 


### PR DESCRIPTION
## Summary
- Task list now bumps to the bottom when a subagent starts
- Ensures subagent status messages appear above the task list rather than below
- Adds `bumpTasksToBottom` to EventContext and calls it after creating subagent posts

## Test plan
- [ ] Start a session with tasks and trigger a subagent (e.g., use Task tool)
- [ ] Verify the task list appears below the subagent status message
- [ ] Verify task list still bumps correctly on follow-up messages