### PR TITLE
fix: Validate session titles and descriptions to reject placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Session title/description validation** - Reject placeholder values like "..." that Claude sometimes generates instead of real titles/descriptions
+
 ## [0.20.0] - 2026-01-01
 
 ### Added

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -151,7 +151,13 @@ function formatEvent(
           const titleMatch = text.match(/\[SESSION_TITLE:\s*([^\]]+)\]/);
           if (titleMatch) {
             const newTitle = titleMatch[1].trim();
-            if (newTitle !== session.sessionTitle) {
+            // Validate title: reject placeholders like "...", empty, or too short
+            const isValidTitle = newTitle.length >= 3 &&
+              !/^\.+$/.test(newTitle) &&
+              !/^…+$/.test(newTitle) &&
+              newTitle !== '<short title>' &&
+              !newTitle.startsWith('...');
+            if (isValidTitle && newTitle !== session.sessionTitle) {
               session.sessionTitle = newTitle;
               // Persist the updated title
               ctx.persistSession(session);
@@ -166,7 +172,13 @@ function formatEvent(
           const descMatch = text.match(/\[SESSION_DESCRIPTION:\s*([^\]]+)\]/);
           if (descMatch) {
             const newDesc = descMatch[1].trim();
-            if (newDesc !== session.sessionDescription) {
+            // Validate description: reject placeholders like "...", empty, or too short
+            const isValidDesc = newDesc.length >= 5 &&
+              !/^\.+$/.test(newDesc) &&
+              !/^…+$/.test(newDesc) &&
+              newDesc !== '<brief description>' &&
+              !newDesc.startsWith('...');
+            if (isValidDesc && newDesc !== session.sessionDescription) {
               session.sessionDescription = newDesc;
               // Persist the updated description
               ctx.persistSession(session);


### PR DESCRIPTION
## Summary
- Adds validation for session titles and descriptions extracted from Claude's responses
- Rejects placeholder values like `...`, `…`, `<short title>`, `<brief description>`
- Invalid values are ignored, falling back to the first prompt as the topic

## Test plan
- [x] Build passes
- [x] All 248 tests pass
- [ ] Manual test: Start a session and verify valid titles are accepted
- [ ] Manual test: Verify "..." placeholders are rejected (session falls back to first prompt)