### PR TITLE
fix: Flush pending content before posting subagent status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Subagent layout issue** - Fixed a bug where starting a subagent could create an empty or near-empty message above the task list, causing a broken layout. The fix ensures pending content is flushed before posting subagent status messages.
+
 ## [0.21.0] - 2026-01-01
 
 ### Added

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -466,6 +466,11 @@ async function handleTaskStart(
   const description = (input.description as string) || 'Working...';
   const subagentType = (input.subagent_type as string) || 'general';
 
+  // Flush any pending content first to avoid empty continuation messages
+  await ctx.flush(session);
+  session.currentPostId = null;
+  session.pendingContent = '';
+
   // Post subagent status
   const message = `🤖 **Subagent** *(${subagentType})*\n` + `> ${description}\n` + `⏳ Running...`;
 


### PR DESCRIPTION
## Summary
- Fixed a layout bug where starting a subagent could create an empty or near-empty message above the task list
- The fix flushes pending content before posting subagent status messages, following the pattern used by other handlers

## Test plan
- [x] Build passes
- [x] All 248 tests pass
- [ ] Manual test: Start a session and trigger a subagent - verify no empty messages appear above the task list