### PR TITLE
fix: Pass system prompt to Claude CLI when restarting after worktree creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Session title/description not generated after worktree creation** - When a session started with a worktree prompt, the system prompt instructing Claude to generate session metadata was not passed to the restarted Claude CLI in the new worktree directory
+
 ## [0.21.0] - 2026-01-01
 
 ### Added

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -73,7 +73,7 @@ function findPersistedByThreadId(
  * System prompt that instructs Claude to generate session titles and descriptions.
  * This is appended to Claude's system prompt via --append-system-prompt.
  */
-const CHAT_PLATFORM_PROMPT = `
+export const CHAT_PLATFORM_PROMPT = `
 You are running inside a chat platform (like Mattermost or Slack). Users interact with you through chat messages in a thread.
 
 SESSION METADATA: At the START of your first response, include metadata about this session:

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -27,6 +27,7 @@ import * as events from './events.js';
 import * as reactions from './reactions.js';
 import * as commands from './commands.js';
 import * as lifecycle from './lifecycle.js';
+import { CHAT_PLATFORM_PROMPT } from './lifecycle.js';
 import * as worktreeModule from './worktree.js';
 import * as contextPrompt from './context-prompt.js';
 import * as stickyMessage from './sticky-message.js';
@@ -832,6 +833,7 @@ export class SessionManager {
       startTyping: (s) => this.startTyping(s),
       stopTyping: (s) => this.stopTyping(s),
       offerContextPrompt: (s, q) => this.offerContextPrompt(s, q),
+      appendSystemPrompt: CHAT_PLATFORM_PROMPT,
     });
   }
 

--- a/src/session/worktree.ts
+++ b/src/session/worktree.ts
@@ -192,6 +192,7 @@ export async function createAndSwitchToWorktree(
     startTyping: (session: Session) => void;
     stopTyping: (session: Session) => void;
     offerContextPrompt: (session: Session, queuedPrompt: string) => Promise<boolean>;
+    appendSystemPrompt?: string;
   }
 ): Promise<void> {
   // Only session owner or admins can manage worktrees
@@ -280,6 +281,10 @@ export async function createAndSwitchToWorktree(
       session.claudeSessionId = newSessionId;
 
       // Create new CLI with new working directory
+      // Include system prompt if session doesn't have a title yet
+      // This ensures Claude will generate a title on its next response
+      const needsTitlePrompt = !session.sessionTitle;
+
       const cliOptions: ClaudeCliOptions = {
         workingDir: worktreePath,
         threadId: session.threadId,
@@ -288,6 +293,7 @@ export async function createAndSwitchToWorktree(
         resume: false,  // Fresh start - can't resume across directories
         chrome: options.chromeEnabled,
         platformConfig: session.platform.getMcpConfig(),
+        appendSystemPrompt: needsTitlePrompt ? options.appendSystemPrompt : undefined,
       };
       session.claude = new ClaudeCli(cliOptions);
 


### PR DESCRIPTION
## Summary

- Fixes session title/description not being generated when a session starts with a worktree prompt
- The system prompt instructing Claude to generate metadata was not passed to the restarted Claude CLI in the new worktree directory

## Changes

- Export `CHAT_PLATFORM_PROMPT` from `lifecycle.ts`
- Add `appendSystemPrompt` option to `createAndSwitchToWorktree()`
- Pass the system prompt when restarting Claude in the worktree (only if session doesn't have a title yet)

## Test plan

- [ ] Start a session with worktree mode enabled
- [ ] Provide a branch name when prompted
- [ ] Verify that after the worktree is created, Claude generates a session title/description