### PR TITLE
feat: Add session status bar with battery, uptime, and system status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Session status bar** - Compact status line between logo and table showing at-a-glance info:
+  - Session slots (`1/5`)
+  - Permission mode (`🔐 Interactive` or `⚡ Auto`)
+  - Chrome status (`🌐 Chrome`) - only when enabled
+  - Keep-alive status (`💓 Keep-alive`) - only when active
+  - Battery level (`🔋 85%` or `🔌 AC`) - macOS and Linux
+  - Session uptime (`⏱️ 5m`, `1h23m`, etc.)
+
+### Changed
+- **Slimmer session header table** - Moved session slots, permissions, and Chrome status to the status bar, keeping only contextual info (topic, directory, participants, etc.) in the table
+
 ## [0.21.1] - 2026-01-01
 
 ### Fixed

--- a/src/utils/battery.test.ts
+++ b/src/utils/battery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { getBatteryStatus, formatBatteryStatus } from './battery.js';
+
+describe('getBatteryStatus', () => {
+  it('should return battery status or null', async () => {
+    const status = await getBatteryStatus();
+    // On systems with battery, we get an object; on desktops, we get null
+    if (status !== null) {
+      expect(status).toHaveProperty('percentage');
+      expect(status).toHaveProperty('charging');
+      expect(typeof status.percentage).toBe('number');
+      expect(typeof status.charging).toBe('boolean');
+      expect(status.percentage).toBeGreaterThanOrEqual(0);
+      expect(status.percentage).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe('formatBatteryStatus', () => {
+  it('should return formatted string or null', async () => {
+    const formatted = await formatBatteryStatus();
+    // On systems with battery, we get a string; on desktops, we get null
+    if (formatted !== null) {
+      expect(typeof formatted).toBe('string');
+      // Should contain either battery or AC icon
+      expect(formatted).toMatch(/^[🔋🔌]/u);
+    }
+  });
+});

--- a/src/utils/battery.ts
+++ b/src/utils/battery.ts
@@ -1,0 +1,114 @@
+/**
+ * Battery Status Module
+ *
+ * Detects laptop battery status for display in the session status bar.
+ * Uses platform-specific methods:
+ * - macOS: pmset -g batt
+ * - Linux: /sys/class/power_supply/
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { readFile } from 'fs/promises';
+
+const execAsync = promisify(exec);
+
+export interface BatteryStatus {
+  percentage: number;
+  charging: boolean;
+}
+
+/**
+ * Get current battery status.
+ * Returns null if no battery is present or on unsupported platforms.
+ */
+export async function getBatteryStatus(): Promise<BatteryStatus | null> {
+  switch (process.platform) {
+    case 'darwin':
+      return getMacOSBattery();
+    case 'linux':
+      return getLinuxBattery();
+    default:
+      return null;
+  }
+}
+
+/**
+ * macOS: Parse output from pmset -g batt
+ * Example output:
+ *   Now drawing from 'Battery Power'
+ *   -InternalBattery-0 (id=...)	85%; discharging; 3:45 remaining
+ * Or:
+ *   Now drawing from 'AC Power'
+ *   -InternalBattery-0 (id=...)	100%; charged; 0:00 remaining
+ */
+async function getMacOSBattery(): Promise<BatteryStatus | null> {
+  try {
+    const { stdout } = await execAsync('pmset -g batt');
+
+    // Check if on AC power
+    const charging = stdout.includes("'AC Power'") ||
+                     stdout.includes('charging') ||
+                     stdout.includes('charged');
+
+    // Extract percentage (e.g., "85%")
+    const percentMatch = stdout.match(/(\d+)%/);
+    if (!percentMatch) {
+      return null; // No battery or couldn't parse
+    }
+
+    return {
+      percentage: parseInt(percentMatch[1], 10),
+      charging,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Linux: Read from /sys/class/power_supply/
+ * Common battery names: BAT0, BAT1, battery
+ */
+async function getLinuxBattery(): Promise<BatteryStatus | null> {
+  const batteryNames = ['BAT0', 'BAT1', 'battery'];
+
+  for (const name of batteryNames) {
+    try {
+      const basePath = `/sys/class/power_supply/${name}`;
+
+      // Read capacity (percentage)
+      const capacityStr = await readFile(`${basePath}/capacity`, 'utf-8');
+      const percentage = parseInt(capacityStr.trim(), 10);
+
+      // Read status (Charging, Discharging, Full, Not charging)
+      const status = await readFile(`${basePath}/status`, 'utf-8');
+      const charging = status.trim().toLowerCase() !== 'discharging';
+
+      return { percentage, charging };
+    } catch {
+      // Try next battery name
+      continue;
+    }
+  }
+
+  return null; // No battery found
+}
+
+/**
+ * Format battery status for display in status bar.
+ * Returns: "🔋 85%" or "🔌 AC" or null if no battery
+ */
+export async function formatBatteryStatus(): Promise<string | null> {
+  const status = await getBatteryStatus();
+  if (!status) {
+    return null;
+  }
+
+  if (status.charging && status.percentage === 100) {
+    return '🔌 AC';
+  }
+
+  const icon = status.charging ? '🔌' : '🔋';
+  return `${icon} ${status.percentage}%`;
+}

--- a/src/utils/uptime.test.ts
+++ b/src/utils/uptime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'bun:test';
+import { formatUptime } from './uptime.js';
+
+describe('formatUptime', () => {
+  it('should format less than a minute', () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - 30 * 1000); // 30 seconds ago
+    expect(formatUptime(startedAt)).toBe('<1m');
+  });
+
+  it('should format minutes only', () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - 5 * 60 * 1000); // 5 minutes ago
+    expect(formatUptime(startedAt)).toBe('5m');
+  });
+
+  it('should format hours and minutes', () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - (1 * 60 + 23) * 60 * 1000); // 1h23m ago
+    expect(formatUptime(startedAt)).toBe('1h23m');
+  });
+
+  it('should format hours only when no minutes', () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - 2 * 60 * 60 * 1000); // 2 hours ago
+    expect(formatUptime(startedAt)).toBe('2h');
+  });
+
+  it('should format days and hours', () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - (1 * 24 + 5) * 60 * 60 * 1000); // 1d5h ago
+    expect(formatUptime(startedAt)).toBe('1d5h');
+  });
+
+  it('should format days only when no hours', () => {
+    const now = new Date();
+    const startedAt = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+    expect(formatUptime(startedAt)).toBe('2d');
+  });
+});

--- a/src/utils/uptime.ts
+++ b/src/utils/uptime.ts
@@ -1,0 +1,42 @@
+/**
+ * Uptime Formatting Module
+ *
+ * Formats session duration for display in the status bar.
+ */
+
+/**
+ * Format a duration from a start time to now.
+ * Returns compact format: "5m", "1h23m", "2h", "1d5h"
+ */
+export function formatUptime(startedAt: Date): string {
+  const now = Date.now();
+  const elapsed = now - startedAt.getTime();
+
+  // Convert to minutes
+  const totalMinutes = Math.floor(elapsed / (1000 * 60));
+
+  if (totalMinutes < 1) {
+    return '<1m';
+  }
+
+  const minutes = totalMinutes % 60;
+  const totalHours = Math.floor(totalMinutes / 60);
+  const hours = totalHours % 24;
+  const days = Math.floor(totalHours / 24);
+
+  if (days > 0) {
+    if (hours > 0) {
+      return `${days}d${hours}h`;
+    }
+    return `${days}d`;
+  }
+
+  if (hours > 0) {
+    if (minutes > 0) {
+      return `${hours}h${minutes}m`;
+    }
+    return `${hours}h`;
+  }
+
+  return `${minutes}m`;
+}


### PR DESCRIPTION
## Summary

- Add a compact status bar to the session header showing at-a-glance system info
- Slim down the table by moving session slots, permissions, and Chrome status to the status bar

## Status Bar Items

| Item | Format | When Shown |
|------|--------|------------|
| Session slots | `1/5` | Always |
| Permissions | `🔐 Interactive` or `⚡ Auto` | Always |
| Chrome | `🌐 Chrome` | Only when enabled |
| Keep-alive | `💓 Keep-alive` | Only when active |
| Battery | `🔋 85%` or `🔌 AC` | macOS/Linux with battery |
| Uptime | `⏱️ 5m` | Always |

## Example

**Before:**
```
| 🔢 **Session** | #1 of 5 max |
| 🔐 **Permissions** | Interactive |
| 🌐 **Chrome** | Enabled |
```

**After:**
```
`1/5` · `🔐 Interactive` · `🌐 Chrome` · `💓 Keep-alive` · `🔋 85%` · `⏱️ 5m`
```

## Test plan

- [x] Build succeeds
- [x] All 268 tests pass
- [ ] Manual test: Start a session and verify status bar appears
- [ ] Manual test: Verify battery shows correctly (or is hidden on desktop)
- [ ] Manual test: Verify uptime updates as session progresses