### PR TITLE
fix: Task list collapse toggle not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Slimmer session header table** - Moved session slots, permissions, and Chrome status to the status bar, keeping only contextual info (topic, directory, participants, etc.) in the table
 
+### Fixed
+- **Task list collapse toggle not working** - Fixed a bug where clicking the 🔽 emoji to collapse/expand the task list had no effect. The task post ID was not being registered in the reaction routing index, causing all toggle reactions to be silently ignored. Now the task post is properly registered in all scenarios: initial creation, session resume, and after being bumped to the bottom of the thread.
+
 ## [0.21.1] - 2026-01-01
 
 ### Fixed

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -446,6 +446,8 @@ async function handleTodoWrite(
         session.threadId
       );
       session.tasksPostId = post.id;
+      // Register the task post so reaction clicks are routed to this session
+      ctx.registerPost(post.id, session.threadId);
     }
     // Update sticky message with new task progress
     ctx.updateStickyMessage().catch(() => {});

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -434,6 +434,10 @@ export async function resumeSession(
   if (state.sessionStartPostId) {
     ctx.registerPost(state.sessionStartPostId, state.threadId);
   }
+  // Register task post for reaction routing (task collapse toggle)
+  if (state.tasksPostId) {
+    ctx.registerPost(state.tasksPostId, state.threadId);
+  }
 
   // Notify keep-alive that a session started
   keepAlive.sessionStarted();

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -538,7 +538,7 @@ export class SessionManager {
   }
 
   private async bumpTasksToBottom(session: Session): Promise<void> {
-    return streaming.bumpTasksToBottom(session);
+    return streaming.bumpTasksToBottom(session, (pid, tid) => this.registerPost(pid, tid));
   }
 
   // ---------------------------------------------------------------------------

--- a/src/session/streaming.ts
+++ b/src/session/streaming.ts
@@ -380,6 +380,8 @@ async function bumpTasksToBottomWithContent(
   if (oldTasksContent) {
     const newTasksPost = await session.platform.createPost(oldTasksContent, session.threadId);
     session.tasksPostId = newTasksPost.id;
+    // Register the new task post so reaction clicks are routed to this session
+    registerPost(newTasksPost.id, session.threadId);
   } else {
     // No task content to re-post, clear the task post ID
     session.tasksPostId = null;
@@ -395,8 +397,12 @@ async function bumpTasksToBottomWithContent(
  * below user messages. Deletes the old task post and creates a new one.
  *
  * @param session - The session
+ * @param registerPost - Callback to register the new post for reaction routing
  */
-export async function bumpTasksToBottom(session: Session): Promise<void> {
+export async function bumpTasksToBottom(
+  session: Session,
+  registerPost?: (postId: string, threadId: string) => void
+): Promise<void> {
   if (!session.tasksPostId || !session.lastTasksContent) {
     return; // No task list to bump
   }
@@ -413,6 +419,10 @@ export async function bumpTasksToBottom(session: Session): Promise<void> {
     // Create a new task post at the bottom
     const newPost = await session.platform.createPost(session.lastTasksContent, session.threadId);
     session.tasksPostId = newPost.id;
+    // Register the task post so reaction clicks are routed to this session
+    if (registerPost) {
+      registerPost(newPost.id, session.threadId);
+    }
   } catch (err) {
     console.error('  ⚠️ Failed to bump tasks to bottom:', err);
   }


### PR DESCRIPTION
## Summary
- Fixed a bug where clicking the 🔽 emoji to collapse/expand the task list had no effect
- The task post ID was not being registered in the reaction routing index (postIndex), causing all toggle reactions to be silently ignored

## Root Cause
When `handleReaction()` receives a reaction, it calls `getSessionByPost(postId)` which looks up the post ID in `postIndex` to find the associated session. However, the task post was never registered in this index, so `getSessionByPost()` would return `undefined` and the reaction would be silently dropped.

## Changes
Added `registerPost()` calls in four places:
1. **events.ts** - When creating the initial task post via `createInteractivePost()`
2. **streaming.ts** - When bumping tasks to bottom (simple bump with delete/recreate)
3. **streaming.ts** - When bumping tasks to bottom with new content (repurpose + create new)
4. **lifecycle.ts** - When resuming a session that has an existing task post

## Test plan
- [ ] Start a new session that uses TodoWrite
- [ ] Click the 🔽 emoji on the task list
- [ ] Verify the task list collapses to show only the progress bar
- [ ] Click the 🔽 emoji again to expand
- [ ] Verify the full task list is shown again