### PR TITLE
fix: Preserve 🔽 emoji when task list is bumped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Task list 🔽 emoji not preserved when bumped** - Fixed issues where the collapse/expand toggle emoji would disappear or get stuck on the wrong post:
+  - When a task list is bumped to the bottom, the new post now gets the 🔽 emoji via `createInteractivePost`
+  - When a task post is repurposed for other content, the emoji is removed from the old post before reuse
+  - Added `removeReaction` method to platform client interface for proper emoji cleanup
+
 ## [0.23.0] - 2026-01-02
 
 ### Added

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -186,6 +186,13 @@ export interface PlatformClient extends EventEmitter {
    */
   addReaction(postId: string, emojiName: string): Promise<void>;
 
+  /**
+   * Remove a reaction from a post
+   * @param postId - Post ID
+   * @param emojiName - Emoji name (e.g., '+1', 'white_check_mark')
+   */
+  removeReaction(postId: string, emojiName: string): Promise<void>;
+
   // ============================================================================
   // Bot Mentions
   // ============================================================================

--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -203,6 +203,11 @@ export class MattermostClient extends EventEmitter implements PlatformClient {
     });
   }
 
+  // Remove a reaction from a post
+  async removeReaction(postId: string, emojiName: string): Promise<void> {
+    await this.api('DELETE', `/users/${this.botUserId}/posts/${postId}/reactions/${emojiName}`);
+  }
+
   /**
    * Create a post with reaction options for user interaction
    *

--- a/src/session/streaming.test.ts
+++ b/src/session/streaming.test.ts
@@ -64,6 +64,9 @@ function createMockPlatform() {
         createAt: Date.now(),
       };
     }),
+    removeReaction: mock(async (_postId: string, _emojiName: string): Promise<void> => {
+      // Mock - do nothing
+    }),
     sendTyping: mock(() => {}),
     posts,
   };
@@ -161,8 +164,12 @@ describe('flush', () => {
 
     // Should have updated the old tasks post with new content
     expect(platform.updatePost).toHaveBeenCalledWith('tasks_post', 'New Claude response');
-    // Should have created a new tasks post
-    expect(platform.createPost).toHaveBeenCalledWith('📋 **Tasks** (0/1)\n○ Do something', 'thread1');
+    // Should have created a new tasks post with toggle emoji
+    expect(platform.createInteractivePost).toHaveBeenCalledWith(
+      '📋 **Tasks** (0/1)\n○ Do something',
+      ['arrow_down_small'],
+      'thread1'
+    );
     // currentPostId should be the old tasks post (repurposed)
     expect(session.currentPostId).toBe('tasks_post');
     // tasksPostId should be the new post
@@ -235,9 +242,10 @@ describe('bumpTasksToBottom', () => {
 
     // Should delete the old post
     expect(platform.deletePost).toHaveBeenCalledWith('old_tasks_post');
-    // Should create new post with same content
-    expect(platform.createPost).toHaveBeenCalledWith(
+    // Should create new post with same content and toggle emoji
+    expect(platform.createInteractivePost).toHaveBeenCalledWith(
       '📋 **Tasks** (1/2)\n✅ Done\n○ Pending',
+      ['arrow_down_small'],
       'thread1'
     );
     // tasksPostId should be updated to new post
@@ -318,8 +326,8 @@ describe('flush with continuation (message splitting)', () => {
     // Should repurpose tasks post for continuation
     expect(platform.updatePost).toHaveBeenCalledWith('tasks_post', expect.stringContaining('*(continued)*'));
 
-    // Should create new tasks post
-    expect(platform.createPost).toHaveBeenCalledWith('📋 Tasks', 'thread1');
+    // Should create new tasks post with toggle emoji
+    expect(platform.createInteractivePost).toHaveBeenCalledWith('📋 Tasks', ['arrow_down_small'], 'thread1');
   });
 
   test('does not bump completed task list when creating continuation post', async () => {
@@ -391,8 +399,12 @@ describe('flush with completed tasks', () => {
     // Should repurpose tasks post for new content
     expect(platform.updatePost).toHaveBeenCalledWith('tasks_post', 'New response content');
 
-    // Should create new tasks post at bottom
-    expect(platform.createPost).toHaveBeenCalledWith('📋 **Tasks** (0/1)\n○ Pending task', 'thread1');
+    // Should create new tasks post at bottom with toggle emoji
+    expect(platform.createInteractivePost).toHaveBeenCalledWith(
+      '📋 **Tasks** (0/1)\n○ Pending task',
+      ['arrow_down_small'],
+      'thread1'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixed issues where the collapse/expand toggle emoji would disappear or get stuck on the wrong post when task lists are bumped to the bottom of the thread
- Added `removeReaction` method to properly clean up emojis from repurposed posts
- Use `createInteractivePost` instead of `createPost` when recreating task list posts

## Test plan
- [x] All 277 tests pass
- [x] Lint passes
- [ ] Manual test: Start a session with tasks, verify 🔽 emoji appears
- [ ] Manual test: Send follow-up message that bumps tasks, verify emoji moves with task list
- [ ] Manual test: Verify emoji doesn't get stuck on repurposed posts