### PR TITLE
fix: Correct WorktreeMode type and enable manual CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/src/session/sticky-message.test.ts
+++ b/src/session/sticky-message.test.ts
@@ -139,10 +139,10 @@ describe('buildStickyMessage', () => {
 
   it('shows worktree mode when not default prompt', async () => {
     const sessions = new Map<string, Session>();
-    const alwaysConfig = { ...testConfig, worktreeMode: 'always' as const };
-    const result = await buildStickyMessage(sessions, 'test-platform', alwaysConfig);
+    const requireConfig = { ...testConfig, worktreeMode: 'require' as const };
+    const result = await buildStickyMessage(sessions, 'test-platform', requireConfig);
 
-    expect(result).toContain('`🌿 Worktree: always`');
+    expect(result).toContain('`🌿 Worktree: require`');
   });
 
   it('hides worktree mode when set to prompt (default)', async () => {

--- a/src/session/sticky-message.ts
+++ b/src/session/sticky-message.ts
@@ -10,6 +10,7 @@ import { hostname } from 'os';
 import type { Session } from './types.js';
 import type { PlatformClient } from '../platform/index.js';
 import type { SessionStore } from '../persistence/session-store.js';
+import type { WorktreeMode } from '../config.js';
 import { formatBatteryStatus } from '../utils/battery.js';
 import { formatUptime } from '../utils/uptime.js';
 import { VERSION } from '../version.js';
@@ -24,7 +25,7 @@ export interface StickyMessageConfig {
   maxSessions: number;
   chromeEnabled: boolean;
   skipPermissions: boolean;
-  worktreeMode: 'prompt' | 'always' | 'never';
+  worktreeMode: WorktreeMode;
   workingDir: string;
   debug: boolean;
 }
@@ -125,10 +126,10 @@ async function buildStatusBar(
   items.push(`\`${permMode}\``);
 
   // Worktree mode (only show if not default 'prompt')
-  if (config.worktreeMode === 'always') {
-    items.push('`🌿 Worktree: always`');
-  } else if (config.worktreeMode === 'never') {
-    items.push('`🌿 Worktree: never`');
+  if (config.worktreeMode === 'require') {
+    items.push('`🌿 Worktree: require`');
+  } else if (config.worktreeMode === 'off') {
+    items.push('`🌿 Worktree: off`');
   }
 
   // Chrome status


### PR DESCRIPTION
## Summary

- **Fix typecheck error**: The `sticky-message.ts` was using `'always'`/`'never'` for worktree mode, but `WorktreeMode` type is defined as `'off' | 'prompt' | 'require'`
- **Add workflow_dispatch**: Allows manually triggering CI workflow from GitHub Actions UI

This fixes the failing CI on main branch.

## Changes

1. Import `WorktreeMode` type from config instead of using inline type
2. Update conditionals to use correct values (`'require'`/`'off'` instead of `'always'`/`'never'`)
3. Update test to use correct worktree mode value
4. Add `workflow_dispatch` trigger to ci.yml