### PR TITLE
feat: Add model and context usage to session status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Enhanced session status bar with model and context info** - The session header now displays real-time usage information similar to Claude Code's status line:
+  - Model name (`🤖 Opus 4.5`, `🤖 Sonnet 4`, etc.)
+  - Context usage with visual progress bar (`🟢▓▓░░░░░░░░ 23%`)
+  - Session cost (`💰 $0.07`)
+  - Color-coded context indicator:
+    - 🟢 Green: < 50% (plenty of context)
+    - 🟡 Yellow: 50-75% (moderate usage)
+    - 🟠 Orange: 75-90% (getting full)
+    - 🔴 Red: 90%+ (almost full)
+- **Periodic status bar updates** - Status bar now refreshes every 30 seconds automatically to keep uptime and usage stats current
+- **Usage stats tracking** - Session now tracks token usage, cost, and model information extracted from Claude CLI result events
+
 ### Fixed
 - **Task list 🔽 emoji not preserved when bumped** - Fixed issues where the collapse/expand toggle emoji would disappear or get stuck on the wrong post:
   - When a task list is bumped to the bottom, the new post now gets the 🔽 emoji via `createInteractivePost`

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -242,6 +242,7 @@ export async function startSession(
     activeToolStarts: new Map(),
     firstPrompt: options.prompt,  // Set early so sticky message can use it
     messageCount: 0,  // Will be incremented when first message is sent
+    statusBarTimer: null,  // Will be started after first result event
   };
 
   // Register session
@@ -427,6 +428,7 @@ export async function resumeSession(
     sessionTitle: state.sessionTitle,
     sessionDescription: state.sessionDescription,
     messageCount: state.messageCount ?? 0,
+    statusBarTimer: null,  // Will be started after first result event
   };
 
   // Register session
@@ -611,6 +613,10 @@ export async function handleExit(
       clearTimeout(session.updateTimer);
       session.updateTimer = null;
     }
+    if (session.statusBarTimer) {
+      clearInterval(session.statusBarTimer);
+      session.statusBarTimer = null;
+    }
     ctx.sessions.delete(session.sessionId);
     // Notify keep-alive that a session ended
     keepAlive.sessionEnded();
@@ -624,6 +630,10 @@ export async function handleExit(
     if (session.updateTimer) {
       clearTimeout(session.updateTimer);
       session.updateTimer = null;
+    }
+    if (session.statusBarTimer) {
+      clearInterval(session.statusBarTimer);
+      session.statusBarTimer = null;
     }
     ctx.persistSession(session);
     ctx.sessions.delete(session.sessionId);
@@ -658,6 +668,10 @@ export async function handleExit(
       clearTimeout(session.updateTimer);
       session.updateTimer = null;
     }
+    if (session.statusBarTimer) {
+      clearInterval(session.statusBarTimer);
+      session.statusBarTimer = null;
+    }
     ctx.sessions.delete(session.sessionId);
     // Notify keep-alive that a session ended
     keepAlive.sessionEnded();
@@ -681,6 +695,10 @@ export async function handleExit(
   if (session.updateTimer) {
     clearTimeout(session.updateTimer);
     session.updateTimer = null;
+  }
+  if (session.statusBarTimer) {
+    clearInterval(session.statusBarTimer);
+    session.statusBarTimer = null;
   }
   await ctx.flush(session);
 

--- a/src/session/sticky-message.test.ts
+++ b/src/session/sticky-message.test.ts
@@ -78,6 +78,7 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
     inProgressTaskStart: null,
     activeToolStarts: new Map(),
     firstPrompt: 'Help me with this task',
+    statusBarTimer: null,
     ...overrides,
   } as Session;
 }

--- a/src/session/streaming.test.ts
+++ b/src/session/streaming.test.ts
@@ -111,6 +111,7 @@ function createTestSession(platform: PlatformClient): Session {
     inProgressTaskStart: null,
     activeToolStarts: new Map(),
     messageCount: 0,
+    statusBarTimer: null,
   };
 }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -8,6 +8,42 @@ import type { WorktreeInfo } from '../persistence/session-store.js';
 import type { PendingContextPrompt } from './context-prompt.js';
 
 // =============================================================================
+// Model and Usage Types
+// =============================================================================
+
+/**
+ * Token usage for a single model
+ */
+export interface ModelTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  contextWindow: number;  // Maximum context window size
+  costUSD: number;
+}
+
+/**
+ * Aggregated usage stats from Claude CLI result events
+ */
+export interface SessionUsageStats {
+  /** Primary model being used (e.g., "claude-opus-4-5-20251101") */
+  primaryModel: string;
+  /** Display name for the model (e.g., "Opus 4.5") */
+  modelDisplayName: string;
+  /** Maximum context window size */
+  contextWindowSize: number;
+  /** Total tokens used (input + output across all models) */
+  totalTokensUsed: number;
+  /** Total cost in USD */
+  totalCostUSD: number;
+  /** Per-model usage breakdown */
+  modelUsage: Record<string, ModelTokenUsage>;
+  /** Last update timestamp */
+  lastUpdated: Date;
+}
+
+// =============================================================================
 // Interactive State Types
 // =============================================================================
 
@@ -150,6 +186,12 @@ export interface Session {
 
   // Message counter for periodic reminders
   messageCount: number;  // Number of user messages sent to Claude in this session
+
+  // Usage stats from Claude CLI (updated on each result event)
+  usageStats?: SessionUsageStats;
+
+  // Status bar update timer (for periodic refreshes)
+  statusBarTimer: ReturnType<typeof setInterval> | null;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Display model name (e.g., "🤖 Opus 4.5") extracted from result events
- Show context usage with visual progress bar and color indicator (🟢▓▓░░░░░░░░ 23%)
- Display session cost in USD (💰 $0.07)
- Add periodic 30-second status bar updates for uptime/stats
- Track usage stats (tokens, cost, model) from Claude CLI result events

The status bar now shows real-time usage information similar to Claude Code's own status line, helping users monitor their session's resource consumption at a glance.

### Color-coded context indicator:
- 🟢 Green: < 50% (plenty of context)
- 🟡 Yellow: 50-75% (moderate usage)
- 🟠 Orange: 75-90% (getting full)
- 🔴 Red: 90%+ (almost full)

## Test plan

- [x] Added 6 new tests for usage stats extraction
- [x] Tests verify model name parsing for various model formats
- [x] Tests verify primary model selection by highest cost
- [x] Tests verify status bar timer initialization
- [x] All 283 tests pass
- [ ] Manual testing in Mattermost to verify status bar display