### PR TITLE
fix: Auto-include single-message thread context without prompting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Auto-include single-message thread context** - When starting a session in a thread that has only one prior message (the thread starter), it now auto-includes that message as context without prompting. Previously, this would trigger an unnecessary "Include 1 message as context?" prompt with reaction options. Now, single-message context is silently included, while multi-message threads still prompt for confirmation.
+- **Worktree branch response excluded from context count** - When a user responds to a worktree branch prompt (e.g., typing "fix/my-branch"), that response is now excluded from the thread context count and messages. Previously, this response was incorrectly counted as conversation context, leading to misleading "Include 2 messages?" prompts when only the original thread starter was meaningful context.
 
 ## [0.24.0] - 2026-01-02
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,7 +308,7 @@ async function main() {
       if (session.hasPendingWorktreePrompt(threadRoot)) {
         // Only session owner can respond
         if (session.isUserAllowedInSession(threadRoot, username)) {
-          const handled = await session.handleWorktreeBranchResponse(threadRoot, content, username);
+          const handled = await session.handleWorktreeBranchResponse(threadRoot, content, username, post.id);
           if (handled) return;
         }
       }

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -71,7 +71,7 @@ export interface CommandContext {
   persistSession: (session: Session) => void;
   killSession: (threadId: string) => Promise<void>;
   registerPost: (postId: string, threadId: string) => void;
-  offerContextPrompt: (session: Session, queuedPrompt: string) => Promise<boolean>;
+  offerContextPrompt: (session: Session, queuedPrompt: string, excludePostId?: string) => Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -182,7 +182,7 @@ export class SessionManager {
       persistSession: (s) => this.persistSession(s),
       killSession: (tid) => this.killSession(tid),
       registerPost: (pid, tid) => this.registerPost(pid, tid),
-      offerContextPrompt: (s, q) => this.offerContextPrompt(s, q),
+      offerContextPrompt: (s, q, e) => this.offerContextPrompt(s, q, e),
     };
   }
 
@@ -848,13 +848,14 @@ export class SessionManager {
   }
 
   // Worktree commands
-  async handleWorktreeBranchResponse(threadId: string, branchName: string, username: string): Promise<boolean> {
+  async handleWorktreeBranchResponse(threadId: string, branchName: string, username: string, responsePostId: string): Promise<boolean> {
     const session = this.findSessionByThreadId(threadId);
     if (!session) return false;
     return worktreeModule.handleWorktreeBranchResponse(
       session,
       branchName,
       username,
+      responsePostId,
       (tid, branch, user) => this.createAndSwitchToWorktree(tid, branch, user)
     );
   }
@@ -883,7 +884,7 @@ export class SessionManager {
       persistSession: (s) => this.persistSession(s),
       startTyping: (s) => this.startTyping(s),
       stopTyping: (s) => this.stopTyping(s),
-      offerContextPrompt: (s, q) => this.offerContextPrompt(s, q),
+      offerContextPrompt: (s, q, e) => this.offerContextPrompt(s, q, e),
       appendSystemPrompt: CHAT_PLATFORM_PROMPT,
       registerPost: (postId, tid) => this.registerPost(postId, tid),
     });

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -170,6 +170,7 @@ export interface Session {
   worktreePromptDisabled?: boolean;         // User opted out with !worktree off
   queuedPrompt?: string;                    // User's original message when waiting for worktree response
   worktreePromptPostId?: string;            // Post ID of the worktree prompt (for ❌ reaction)
+  worktreeResponsePostId?: string;          // Post ID of user's worktree branch response (to exclude from context)
   firstPrompt?: string;                     // First user message, sent again after mid-session worktree creation
   pendingExistingWorktreePrompt?: PendingExistingWorktreePrompt; // Waiting for user to confirm joining existing worktree
 


### PR DESCRIPTION
## Summary
- When starting a session in a thread with only one prior message (the thread starter), automatically include it as context without showing a reaction prompt
- This improves UX by avoiding an unnecessary prompt when there's really only one obvious choice
- Multi-message threads still show the context inclusion prompt as before

## Test plan
- [ ] Start a session in a thread that has only 1 prior message → should auto-include without prompt
- [ ] Start a session in a thread with 2+ messages → should show the reaction prompt as before
- [ ] Verify the debug log shows "auto-included 1 message as context (thread starter)" when applicable