### PR TITLE
fix: Persist sessions before killing on graceful shutdown

### DIFF
--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -772,10 +772,15 @@ export async function killSession(
 
 /**
  * Kill all active sessions.
+ * If isShuttingDown is true, persists sessions before killing so they can resume on restart.
  */
 export function killAllSessions(ctx: LifecycleContext): void {
   for (const session of ctx.sessions.values()) {
     ctx.stopTyping(session);
+    // Persist session state before killing if we're shutting down gracefully
+    if (ctx.isShuttingDown) {
+      ctx.persistSession(session);
+    }
     session.claude.kill();
   }
   ctx.sessions.clear();

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -997,9 +997,10 @@ export class SessionManager {
       }
     }
 
-    // Kill all sessions but preserve persistence
+    // Persist and kill all sessions for later resume
     for (const session of this.sessions.values()) {
       this.stopTyping(session);
+      this.persistSession(session);
       session.claude.kill();
     }
     this.sessions.clear();


### PR DESCRIPTION
## Summary

- **Fixed session persistence on Ctrl-C shutdown** - Sessions were not being saved before the bot shut down, causing them to not resume on restart

## What was the bug?

When the bot was shut down with Ctrl-C:
1. `setShuttingDown()` was called (good)
2. `killAllSessions()` was called
3. But `killAllSessions()` killed processes and cleared the session map **without first saving session state to disk**
4. Sessions were lost and couldn't resume on restart

## The fix

Now both `killAllSessions()` and `shutdown()` persist each session before killing it when `isShuttingDown` is true, ensuring sessions can be properly resumed after a bot restart.

## Test plan

- [ ] Start a session with the bot
- [ ] Ctrl-C the bot
- [ ] Verify "Bot shutting down - session will resume on restart" message appears
- [ ] Restart the bot
- [ ] Verify session resumes and posts "Session resumed" message to thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)