### PR TITLE
fix: Improve session title/description extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Understands multiple users can participate in a session
   - This helps Claude provide better UX by understanding its environment and guiding users about available controls
 
+### Fixed
+- **Session title/description markers visible in chat** - Fixed issue where `[SESSION_TITLE: ...]` and `[SESSION_DESCRIPTION: ...]` markers would appear in chat messages when validation failed. Markers are now always stripped from displayed text regardless of validation outcome.
+- **Session title/description length validation** - Added maximum length limits (title: 50 chars, description: 100 chars) to prevent overly long metadata from cluttering the session header and sticky message.
+
 ## [0.24.1] - 2026-01-02
 
 ### Fixed

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -152,8 +152,9 @@ function formatEvent(
           const titleMatch = text.match(/\[SESSION_TITLE:\s*([^\]]+)\]/);
           if (titleMatch) {
             const newTitle = titleMatch[1].trim();
-            // Validate title: reject placeholders like "...", empty, or too short
+            // Validate title: reject placeholders, too short, or too long (50 chars ~7 words)
             const isValidTitle = newTitle.length >= 3 &&
+              newTitle.length <= 50 &&
               !/^\.+$/.test(newTitle) &&
               !/^…+$/.test(newTitle) &&
               newTitle !== '<short title>' &&
@@ -166,16 +167,17 @@ function formatEvent(
               ctx.updateStickyMessage().catch(() => {});
               ctx.updateSessionHeader(session).catch(() => {});
             }
-            // Remove the title marker from the displayed text
-            text = text.replace(/\[SESSION_TITLE:\s*[^\]]+\]\s*/g, '').trim();
           }
+          // Always remove the title marker from displayed text (even if validation failed)
+          text = text.replace(/\[SESSION_TITLE:\s*[^\]]+\]\s*/g, '').trim();
 
           // Extract session description if present: [SESSION_DESCRIPTION: ...]
           const descMatch = text.match(/\[SESSION_DESCRIPTION:\s*([^\]]+)\]/);
           if (descMatch) {
             const newDesc = descMatch[1].trim();
-            // Validate description: reject placeholders like "...", empty, or too short
+            // Validate description: reject placeholders, too short, or too long (100 chars)
             const isValidDesc = newDesc.length >= 5 &&
+              newDesc.length <= 100 &&
               !/^\.+$/.test(newDesc) &&
               !/^…+$/.test(newDesc) &&
               newDesc !== '<brief description>' &&
@@ -188,9 +190,9 @@ function formatEvent(
               ctx.updateStickyMessage().catch(() => {});
               ctx.updateSessionHeader(session).catch(() => {});
             }
-            // Remove the description marker from the displayed text
-            text = text.replace(/\[SESSION_DESCRIPTION:\s*[^\]]+\]\s*/g, '').trim();
           }
+          // Always remove the description marker from displayed text (even if validation failed)
+          text = text.replace(/\[SESSION_DESCRIPTION:\s*[^\]]+\]\s*/g, '').trim();
 
           if (text) parts.push(text);
         } else if (block.type === 'tool_use' && block.name) {


### PR DESCRIPTION
## Summary

- Always strip `[SESSION_TITLE: ...]` and `[SESSION_DESCRIPTION: ...]` markers from displayed text, even when validation fails
- Add maximum length validation (title: 50 chars, description: 100 chars) to prevent overly long metadata

## Problem

1. When session title/description validation failed (e.g., too long), the raw markers like `[SESSION_DESCRIPTION: Adding context to Claude Code's system prompt...]` would appear in the chat output
2. There was no maximum length limit, allowing Claude to generate overly long titles/descriptions that cluttered the UI

## Solution

- Moved marker removal outside the validation `if` block so markers are always stripped
- Added `newTitle.length <= 50` and `newDesc.length <= 100` to validation checks

## Test plan

- [x] Build passes
- [x] All 283 tests pass
- [ ] Manual test: Start a session and verify markers don't appear in chat
- [ ] Manual test: Verify long titles/descriptions are rejected but markers still stripped