### PR TITLE
fix: Move status bar above header and remove hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Sticky message status bar layout** - Moved status bar above the "Active Claude Threads" header for better visual hierarchy
+- **Shorter status bar** - Removed hostname from status bar to reduce clutter
+
 ## [0.26.0] - 2026-01-02
 
 ### Added

--- a/src/session/sticky-message.test.ts
+++ b/src/session/sticky-message.test.ts
@@ -104,8 +104,6 @@ describe('buildStickyMessage', () => {
     expect(result).toContain('`0/5 sessions`');
     // Should contain uptime
     expect(result).toMatch(/`⏱️ <?\d+[mhd]`/);
-    // Should contain hostname
-    expect(result).toMatch(/`💻 .+`/);
   });
 
   it('shows Chrome status when enabled', async () => {

--- a/src/session/sticky-message.ts
+++ b/src/session/sticky-message.ts
@@ -6,7 +6,6 @@
  * The message is updated whenever sessions start or end.
  */
 
-import { hostname } from 'os';
 import type { Session } from './types.js';
 import type { PlatformClient } from '../platform/index.js';
 import type { SessionStore } from '../persistence/session-store.js';
@@ -175,10 +174,6 @@ async function buildStatusBar(
   const shortDir = config.workingDir.replace(process.env.HOME || '', '~');
   items.push(`\`📂 ${shortDir}\``);
 
-  // Hostname
-  const host = hostname();
-  items.push(`\`💻 ${host}\``);
-
   return items.join(' · ');
 }
 
@@ -227,9 +222,9 @@ export async function buildStickyMessage(
   if (platformSessions.length === 0) {
     return [
       '---',
-      '**Active Claude Threads**',
-      '',
       statusBar,
+      '',
+      '**Active Claude Threads**',
       '',
       '_No active sessions_',
       '',
@@ -243,9 +238,9 @@ export async function buildStickyMessage(
   const count = platformSessions.length;
   const lines: string[] = [
     '---',
-    `**Active Claude Threads** (${count})`,
-    '',
     statusBar,
+    '',
+    `**Active Claude Threads** (${count})`,
     '',
   ];
 


### PR DESCRIPTION
## Summary
- Moved status bar above the "Active Claude Threads" header for better visual hierarchy
- Removed hostname from status bar to reduce clutter

This fix was previously made on `fix/status-bar` but never merged to main.

## Test plan
- [x] Sticky message tests pass
- [ ] Verify sticky message layout in Mattermost

🤖 Generated with [Claude Code](https://claude.com/claude-code)