### PR TITLE
fix: context bar crash when tokens exceed context window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,3 +403,4 @@ Claude CLI emits JSON events. Key event types:
 - [ ] Support file uploads via Mattermost attachments
 - [ ] Keep task list at the bottommost message (always update to latest position)
 - [ ] Session restart improvements: verify all important state is preserved (cwd ✓, permissions ✓, worktree ✓)
+- [ ] Accurate context usage: Use Claude Code's status line script as a data source for real-time `context_window.current_usage` instead of cumulative billing tokens from stream-json

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -34,7 +34,8 @@ import { keepAlive } from '../utils/keep-alive.js';
  */
 function formatContextBar(percent: number): string {
   const totalBlocks = 10;
-  const filledBlocks = Math.round((percent / 100) * totalBlocks);
+  // Clamp filledBlocks to [0, totalBlocks] to handle >100% usage
+  const filledBlocks = Math.min(totalBlocks, Math.max(0, Math.round((percent / 100) * totalBlocks)));
   const emptyBlocks = totalBlocks - filledBlocks;
 
   // Use different indicators based on usage level
@@ -499,8 +500,8 @@ export async function updateSessionHeader(
   if (session.usageStats) {
     const stats = session.usageStats;
     statusItems.push(`\`🤖 ${stats.modelDisplayName}\``);
-    // Calculate context usage percentage
-    const contextPercent = Math.round((stats.totalTokensUsed / stats.contextWindowSize) * 100);
+    // Calculate context usage percentage (using primary model's context tokens)
+    const contextPercent = Math.round((stats.contextTokens / stats.contextWindowSize) * 100);
     const contextBar = formatContextBar(contextPercent);
     statusItems.push(`\`${contextBar} ${contextPercent}%\``);
     // Show cost

--- a/src/session/events.test.ts
+++ b/src/session/events.test.ts
@@ -326,6 +326,8 @@ describe('handleEvent with result event (usage stats)', () => {
     expect(session.usageStats?.modelDisplayName).toBe('Opus 4.5');
     expect(session.usageStats?.contextWindowSize).toBe(200000);
     expect(session.usageStats?.totalCostUSD).toBe(0.072784);
+    // Context tokens (primary model only): 2471 + 12671 = 15142
+    expect(session.usageStats?.contextTokens).toBe(15142);
     // Total tokens: 2471+193+12671+7378 + 2341+163+0+0 = 25217
     expect(session.usageStats?.totalTokensUsed).toBe(25217);
   });

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -663,6 +663,7 @@ function updateUsageStats(
   let primaryModel = '';
   let highestCost = 0;
   let contextWindowSize = 200000; // Default
+  let contextTokens = 0; // Primary model's context usage estimate
 
   const modelUsage: Record<string, ModelTokenUsage> = {};
   let totalTokensUsed = 0;
@@ -677,7 +678,7 @@ function updateUsageStats(
       costUSD: usage.costUSD,
     };
 
-    // Sum all tokens
+    // Sum all tokens (for billing display)
     totalTokensUsed += usage.inputTokens + usage.outputTokens +
       usage.cacheReadInputTokens + usage.cacheCreationInputTokens;
 
@@ -686,6 +687,8 @@ function updateUsageStats(
       highestCost = usage.costUSD;
       primaryModel = modelId;
       contextWindowSize = usage.contextWindow;
+      // Context estimate: input + cache read (what's actually in context window)
+      contextTokens = usage.inputTokens + usage.cacheReadInputTokens;
     }
   }
 
@@ -694,6 +697,7 @@ function updateUsageStats(
     primaryModel,
     modelDisplayName: getModelDisplayName(primaryModel),
     contextWindowSize,
+    contextTokens,
     totalTokensUsed,
     totalCostUSD: result.total_cost_usd || 0,
     modelUsage,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -33,7 +33,9 @@ export interface SessionUsageStats {
   modelDisplayName: string;
   /** Maximum context window size */
   contextWindowSize: number;
-  /** Total tokens used (input + output across all models) */
+  /** Estimated context tokens (primary model input + cache read only) */
+  contextTokens: number;
+  /** Total tokens used (input + output across all models, for billing display) */
   totalTokensUsed: number;
   /** Total cost in USD */
   totalCostUSD: number;


### PR DESCRIPTION
## Summary

- Fix RangeError crash when `String.prototype.repeat` receives negative value
- Improve context usage calculation to use primary model's tokens only

## Problem

When token usage exceeded 100% of context window (e.g., 494,945 tokens vs 200,000 context), the context bar calculation produced a negative value for `emptyBlocks`, causing `String.repeat(-15)` to throw a RangeError.

Additionally, the previous calculation summed all tokens across all models (billing total), which doesn't represent actual context window usage.

## Solution

1. **Clamp filled blocks** to `[0, totalBlocks]` to prevent negative empty blocks
2. **Use primary model's context tokens** (`inputTokens + cacheReadInputTokens`) instead of cumulative billing total
3. **Add `contextTokens` field** to `SessionUsageStats` for accurate context estimation

## Test plan

- [x] All 287 tests pass
- [x] Build succeeds
- [ ] Manual test with high token usage session