### PR TITLE
fix: Wait for shutdown message before exiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -453,10 +453,14 @@ async function main() {
 
     session.killAllSessions();
     mattermost.disconnect();
-    process.exit(0);
+    // Don't call process.exit() here - let the signal handler do it after we resolve
   };
-  process.on('SIGINT', () => { shutdown(); });
-  process.on('SIGTERM', () => { shutdown(); });
+  process.on('SIGINT', () => {
+    shutdown().finally(() => process.exit(0));
+  });
+  process.on('SIGTERM', () => {
+    shutdown().finally(() => process.exit(0));
+  });
 }
 
 main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- Fix shutdown message not being posted to active sessions when bot is stopped with Ctrl+C
- The async `shutdown()` function wasn't being awaited by the signal handlers, so `process.exit(0)` could run before the message was posted

## Changes

- Move `process.exit(0)` from inside the async `shutdown()` function to `.finally()` in the signal handlers
- This ensures the shutdown message is posted before the process exits

## Test plan

- [ ] Start the bot with an active session
- [ ] Press Ctrl+C to stop the bot
- [ ] Verify "⏸️ **Bot shutting down** - session will resume on restart" appears in the thread
- [ ] Restart the bot and verify session resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)