### PR TITLE
feat: display pending prompts in active threads list

### DIFF
--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -10,5 +10,10 @@ export type {
   PendingApproval,
   PendingQuestionSet,
   PendingMessageApproval,
+  PendingExistingWorktreePrompt,
 } from './types.js';
 export type { PendingContextPrompt } from './context-prompt.js';
+
+// Pending prompts utilities (reusable for displaying pending states)
+export type { PendingPrompt } from './sticky-message.js';
+export { getPendingPrompts, formatPendingPrompts } from './sticky-message.js';


### PR DESCRIPTION
## Summary
- Add visual indicators for pending user prompts in the sticky channel message showing active sessions
- Users can now see at a glance which sessions are waiting for input (e.g., plan approval, questions, worktree prompts)
- Reusable `getPendingPrompts()` and `formatPendingPrompts()` functions exported for use elsewhere

## Test plan
- [x] All 308 tests pass (21 new tests added)
- [x] Build succeeds
- [ ] Manual test in Mattermost: start session, trigger plan mode, verify prompt appears in thread list
- [ ] Verify multiple prompt types display correctly with `·` separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)