### PR TITLE
fix: update sticky message when worktree prompts are shown

### DIFF
--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -308,6 +308,7 @@ export async function startSession(
     session.pendingWorktreePrompt = true;
     await ctx.postWorktreePrompt(session, shouldPrompt);
     ctx.persistSession(session);
+    await ctx.updateStickyMessage();
     return;
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -887,6 +887,7 @@ export class SessionManager {
       offerContextPrompt: (s, q, e) => this.offerContextPrompt(s, q, e),
       appendSystemPrompt: CHAT_PLATFORM_PROMPT,
       registerPost: (postId, tid) => this.registerPost(postId, tid),
+      updateStickyMessage: () => this.updateStickyMessage(),
     });
   }
 

--- a/src/session/worktree.ts
+++ b/src/session/worktree.ts
@@ -198,6 +198,7 @@ export async function createAndSwitchToWorktree(
     offerContextPrompt: (session: Session, queuedPrompt: string, excludePostId?: string) => Promise<boolean>;
     appendSystemPrompt?: string;
     registerPost: (postId: string, threadId: string) => void;
+    updateStickyMessage: () => Promise<void>;
   }
 ): Promise<void> {
   // Only session owner or admins can manage worktrees
@@ -245,8 +246,9 @@ export async function createAndSwitchToWorktree(
     // Register the post for reaction routing
     options.registerPost(post.id, session.threadId);
 
-    // Persist the session state
+    // Persist the session state and update sticky message
     options.persistSession(session);
+    await options.updateStickyMessage();
     return;
   }
 


### PR DESCRIPTION
## Summary
- Fixed bug where pending worktree prompts weren't shown in the active threads list
- Added `updateStickyMessage()` calls after setting `pendingWorktreePrompt` and `pendingExistingWorktreePrompt`

## Test plan
- [x] Build passes
- [x] All 308 tests pass
- [ ] Manual test: Start a session when another is already using the same repo, verify the thread list shows `⏳ 🌿 Branch name` indicator