### PR TITLE
fix: prevent cancelled sessions from being resumed

### DIFF
--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -747,7 +747,7 @@ export async function killSession(
 
   // Explicitly unpersist if requested
   if (unpersist) {
-    ctx.ops.unpersistSession(session.threadId);
+    ctx.ops.unpersistSession(session.sessionId);
   }
 
   log.info(`✖ Session killed (${shortId}…) — ${ctx.state.sessions.size} active`);


### PR DESCRIPTION
## Summary

- Fixed bug where cancelled sessions (via `!stop` or ❌ reaction) were incorrectly resumed after bot restart
- The `killSession()` function was using `session.threadId` instead of `session.sessionId` when calling `unpersistSession()`
- Since the session store uses composite keys (`platformId:threadId`), passing just `threadId` meant the session was never actually removed from persistence

## Test plan

- [x] Build passes
- [x] All 308 tests pass
- [ ] Manual test: Cancel a session with `!stop`, restart bot, verify session is NOT resumed