### PR TITLE
fix: use per-request usage for accurate context window percentage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,4 +409,4 @@ Claude CLI emits JSON events. Key event types:
 - [ ] Support file uploads via Mattermost attachments
 - [ ] Keep task list at the bottommost message (always update to latest position)
 - [ ] Session restart improvements: verify all important state is preserved (cwd ✓, permissions ✓, worktree ✓)
-- [ ] Accurate context usage: Use Claude Code's status line script as a data source for real-time `context_window.current_usage` instead of cumulative billing tokens from stream-json
+- [x] Accurate context usage: Use per-request `usage` field from result events instead of cumulative billing tokens - **Done**


### PR DESCRIPTION
## Summary

- Use per-request `usage` field from result events for accurate context window calculation
- Previously used cumulative `modelUsage` which inflated the percentage over time
- Falls back to old calculation if `usage` field is not available

## Test plan

- [x] Updated tests to verify new context calculation with `usage` field
- [x] Added test for fallback behavior when `usage` is missing
- [x] All 445 tests pass