### PR TITLE
feat: add session history retention with soft deletion

### DIFF
--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -156,7 +156,7 @@ describe('Lifecycle Module', () => {
 
       await lifecycle.killSession(session, true, ctx);
 
-      expect(ctx.ops.unpersistSession).toHaveBeenCalledWith('thread-123');
+      expect(ctx.ops.unpersistSession).toHaveBeenCalledWith('test-platform:thread-123');
     });
 
     it('preserves persistence when not unpersisting', async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -525,7 +525,8 @@ export class SessionManager {
   }
 
   private unpersistSession(sessionId: string): void {
-    this.sessionStore.remove(sessionId);
+    // Soft-delete instead of hard delete - keeps session in history for display
+    this.sessionStore.softDelete(sessionId);
   }
 
   // ---------------------------------------------------------------------------
@@ -573,7 +574,13 @@ export class SessionManager {
     // Use 2x timeout to be generous (bot might have been down for a while)
     const staleIds = this.sessionStore.cleanStale(SESSION_TIMEOUT_MS * 2);
     if (staleIds.length > 0) {
-      log.info(`🧹 Cleaned ${staleIds.length} stale session(s) from persistence`);
+      log.info(`🧹 Soft-deleted ${staleIds.length} stale session(s) (kept for history)`);
+    }
+
+    // Permanently remove old history entries (older than 3 days by default)
+    const removedCount = this.sessionStore.cleanHistory();
+    if (removedCount > 0) {
+      log.info(`🗑️ Permanently removed ${removedCount} old session(s) from history`);
     }
 
     const persisted = this.sessionStore.load();


### PR DESCRIPTION
## Summary

- Sessions are now soft-deleted instead of permanently removed when they complete
- Session history is kept for display in the sticky message (up to 5 recent sessions)
- Old history is permanently cleaned up after 3 days

## Changes

- Add `cleanedAt` field to `PersistedSession` for tracking soft deletion
- Add `softDelete()` method to mark sessions as cleaned without removing
- Modify `cleanStale()` to soft-delete instead of hard delete
- Add `cleanHistory()` to permanently remove old history (>3 days)
- Add `getHistory()` to retrieve soft-deleted sessions for display
- Update sticky message to show "Recent" section with completed sessions
- Update `load()` to exclude soft-deleted sessions from active list
- Change `unpersistSession()` to use soft-delete

## Test plan

- [x] All 485 tests pass
- [x] Build succeeds
- [ ] Manual testing: verify sticky message shows recent completed sessions
- [ ] Manual testing: verify sessions are soft-deleted on exit
- [ ] Manual testing: verify history cleanup removes old entries after 3 days