### PR TITLE
fix: use Claude Code status line for accurate context usage percentage

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "bun --watch src/index.ts",
-    "build": "bun build src/index.ts --outdir dist --target bun && bun build src/mcp/permission-server.ts --outdir dist/mcp --target bun",
+    "build": "bun build src/index.ts --outdir dist --target bun && bun build src/mcp/permission-server.ts --outdir dist/mcp --target bun && bun build src/statusline/writer.ts --outdir dist/statusline --target bun",
     "start": "bun dist/index.js",
     "test": "bun test",
     "test:watch": "bun test --watch",

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -156,7 +156,7 @@ describe('Lifecycle Module', () => {
 
       await lifecycle.killSession(session, true, ctx);
 
-      expect(ctx.ops.unpersistSession).toHaveBeenCalledWith('thread-123');
+      expect(ctx.ops.unpersistSession).toHaveBeenCalledWith('test-platform:thread-123');
     });
 
     it('preserves persistence when not unpersisting', async () => {

--- a/src/statusline/writer.ts
+++ b/src/statusline/writer.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Status line writer for claude-threads
+ *
+ * This script is called by Claude Code's status line feature.
+ * It receives JSON data via stdin containing context window usage,
+ * writes it to a file for claude-threads to read, and outputs
+ * a minimal status line (or empty string to not affect user's status line).
+ *
+ * The file is written to /tmp/claude-threads-status-<session-id>.json
+ *
+ * Usage (configured in Claude Code settings):
+ *   statusLine: {
+ *     type: "command",
+ *     command: "node /path/to/writer.js <session-id>"
+ *   }
+ */
+
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+// Read session ID from command line args
+const sessionId = process.argv[2];
+if (!sessionId) {
+  // No session ID provided - output empty status line and exit
+  console.log('');
+  process.exit(0);
+}
+
+// Read JSON from stdin
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+
+    // Extract context window usage
+    const contextWindow = data.context_window;
+    if (contextWindow) {
+      const usage = contextWindow.current_usage;
+      const output = {
+        context_window_size: contextWindow.context_window_size,
+        total_input_tokens: contextWindow.total_input_tokens,
+        total_output_tokens: contextWindow.total_output_tokens,
+        current_usage: usage ? {
+          input_tokens: usage.input_tokens || 0,
+          output_tokens: usage.output_tokens || 0,
+          cache_creation_input_tokens: usage.cache_creation_input_tokens || 0,
+          cache_read_input_tokens: usage.cache_read_input_tokens || 0,
+        } : null,
+        model: data.model ? {
+          id: data.model.id,
+          display_name: data.model.display_name,
+        } : null,
+        cost: data.cost ? {
+          total_cost_usd: data.cost.total_cost_usd,
+        } : null,
+        timestamp: Date.now(),
+      };
+
+      // Write to temp file
+      const filePath = `/tmp/claude-threads-status-${sessionId}.json`;
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, JSON.stringify(output, null, 2));
+    }
+  } catch {
+    // Silently ignore parse errors
+  }
+
+  // Output empty string - don't interfere with user's status line
+  // If user has their own status line configured, this won't override it
+  console.log('');
+});


### PR DESCRIPTION
## Summary

- Uses Claude Code's status line feature to get accurate context window usage percentage
- Adds a status line writer script that receives context data from Claude Code
- Configures Claude CLI with `--settings` to use our status line writer
- Falls back to result event data if status line is unavailable

## Problem

The previous approach using result event tokens was inaccurate because:
1. The `usage` field in result events is cumulative across API calls
2. When Claude uses tools, tokens are counted multiple times (once per API call)

## Solution

Claude Code's status line feature receives a JSON payload with a `current_usage` object that contains accurate per-request token data:
- `input_tokens`
- `cache_creation_input_tokens`  
- `cache_read_input_tokens`

This properly reflects the actual context window consumption.

## Changes

- **`src/statusline/writer.ts`**: New script that receives Claude Code status line data via stdin and writes to `/tmp/claude-threads-status-<session-id>.json`
- **`src/claude/cli.ts`**: Added status line configuration via `--settings`, file watching, and `getStatusData()` method
- **`src/session/events.ts`**: Added `updateUsageFromStatusLine()` to read accurate context data periodically
- **`package.json`**: Updated build script to include statusline writer
- **`src/session/lifecycle.test.ts`**: Fixed pre-existing test with incorrect session ID format

## Test plan

- [x] Build succeeds
- [x] All tests pass (477 pass, 0 fail)
- [x] Lint passes
- [x] TypeScript check passes
- [ ] Manual testing with live session