### PR TITLE
feat: add Claude CLI version check at startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ The session management is split into focused modules for maintainability:
 |------|---------|
 | `src/claude/cli.ts` | Spawns Claude CLI with platform-specific MCP config |
 | `src/claude/types.ts` | TypeScript types for Claude stream-json events |
+| `src/claude/version-check.ts` | Claude CLI version validation and compatibility check |
 
 ### Platform Layer
 | File | Purpose |
@@ -216,6 +217,28 @@ Configuration is stored in YAML at `~/.config/claude-threads/config.yaml`.
 | `SESSION_TIMEOUT_MS` | Idle session timeout in ms (default: `1800000` = 30 min) |
 | `DEBUG` | Set `1` for debug logging |
 | `CLAUDE_PATH` | Custom path to claude binary (default: `claude`) |
+
+### Claude CLI Version Requirements
+
+claude-threads requires a compatible version of the Claude CLI (`@anthropic-ai/claude-code`).
+
+**Compatible versions:** `>=2.0.74 <=2.0.76`
+
+The version is checked at startup. If an incompatible version is detected:
+- The bot will display an error message and exit
+- Use `--skip-version-check` to bypass (not recommended)
+
+To install a specific compatible version:
+```bash
+npm install -g @anthropic-ai/claude-code@2.0.76
+```
+
+The Claude CLI version is displayed:
+- At bot startup in the terminal
+- In the sticky channel message status bar
+- In each session's header table
+
+**Updating the version range:** Edit `CLAUDE_CLI_VERSION_RANGE` in `src/claude/version-check.ts` when testing with new Claude CLI versions.
 
 ## Development Commands
 

--- a/src/claude/version-check.test.ts
+++ b/src/claude/version-check.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  isVersionCompatible,
+  CLAUDE_CLI_VERSION_RANGE,
+  validateClaudeCli,
+} from './version-check.js';
+
+describe('version-check', () => {
+  describe('CLAUDE_CLI_VERSION_RANGE', () => {
+    it('is defined', () => {
+      expect(CLAUDE_CLI_VERSION_RANGE).toBeDefined();
+      expect(typeof CLAUDE_CLI_VERSION_RANGE).toBe('string');
+    });
+  });
+
+  describe('isVersionCompatible', () => {
+    it('returns true for versions in the valid range', () => {
+      expect(isVersionCompatible('2.0.74')).toBe(true);
+      expect(isVersionCompatible('2.0.75')).toBe(true);
+      expect(isVersionCompatible('2.0.76')).toBe(true);
+    });
+
+    it('returns false for versions outside the range', () => {
+      expect(isVersionCompatible('2.0.73')).toBe(false);
+      expect(isVersionCompatible('2.0.77')).toBe(false);
+      expect(isVersionCompatible('2.1.0')).toBe(false);
+      expect(isVersionCompatible('1.0.17')).toBe(false);
+    });
+
+    it('handles invalid version strings', () => {
+      expect(isVersionCompatible('')).toBe(false);
+      expect(isVersionCompatible('invalid')).toBe(false);
+    });
+  });
+
+  describe('validateClaudeCli', () => {
+    it('returns validation result with expected structure', () => {
+      const result = validateClaudeCli();
+
+      expect(result).toHaveProperty('installed');
+      expect(result).toHaveProperty('version');
+      expect(result).toHaveProperty('compatible');
+      expect(result).toHaveProperty('message');
+      expect(typeof result.installed).toBe('boolean');
+      expect(typeof result.compatible).toBe('boolean');
+      expect(typeof result.message).toBe('string');
+    });
+  });
+});

--- a/src/claude/version-check.ts
+++ b/src/claude/version-check.ts
@@ -1,0 +1,84 @@
+import { execSync } from 'child_process';
+import { satisfies, coerce } from 'semver';
+
+/**
+ * Known compatible Claude CLI version range.
+ *
+ * Update this when testing with new Claude CLI versions.
+ * - MIN: Oldest version known to work
+ * - MAX: Newest version known to work
+ */
+export const CLAUDE_CLI_VERSION_RANGE = '>=2.0.74 <=2.0.76';
+
+/**
+ * Get the installed Claude CLI version.
+ * Returns null if claude is not installed or version can't be determined.
+ */
+export function getClaudeCliVersion(): string | null {
+  const claudePath = process.env.CLAUDE_PATH || 'claude';
+
+  try {
+    const output = execSync(`${claudePath} --version`, {
+      encoding: 'utf8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    // Output format: "2.0.76 (Claude Code)" or just "2.0.76"
+    const match = output.match(/^([\d.]+)/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a version is compatible with claude-threads.
+ */
+export function isVersionCompatible(version: string): boolean {
+  const semverVersion = coerce(version);
+  if (!semverVersion) return false;
+
+  return satisfies(semverVersion, CLAUDE_CLI_VERSION_RANGE);
+}
+
+/**
+ * Validate Claude CLI installation and version.
+ * Returns an object with status and details.
+ */
+export function validateClaudeCli(): {
+  installed: boolean;
+  version: string | null;
+  compatible: boolean;
+  message: string;
+} {
+  const version = getClaudeCliVersion();
+
+  if (!version) {
+    return {
+      installed: false,
+      version: null,
+      compatible: false,
+      message: 'Claude CLI not found. Install it with: npm install -g @anthropic-ai/claude-code',
+    };
+  }
+
+  const compatible = isVersionCompatible(version);
+
+  if (!compatible) {
+    return {
+      installed: true,
+      version,
+      compatible: false,
+      message: `Claude CLI version ${version} is not compatible. Required: ${CLAUDE_CLI_VERSION_RANGE}\n` +
+        `Install a compatible version: npm install -g @anthropic-ai/claude-code@2.0.76`,
+    };
+  }
+
+  return {
+    installed: true,
+    version,
+    compatible: true,
+    message: `Claude CLI ${version} ✓`,
+  };
+}

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -28,6 +28,7 @@ import { postCancelled, postInfo, postWarning, postError, postSuccess, postSecur
 import { createLogger } from '../utils/logger.js';
 import { formatPullRequestLink } from '../utils/pr-detector.js';
 import { getCurrentBranch, isGitRepository } from '../git/worktree.js';
+import { getClaudeCliVersion } from '../claude/version-check.js';
 
 const log = createLogger('commands');
 
@@ -522,6 +523,12 @@ export async function updateSessionHeader(
 
   if (otherParticipants) {
     rows.push(`| 👥 **Participants** | ${otherParticipants} |`);
+  }
+
+  // Show Claude CLI version
+  const claudeVersion = getClaudeCliVersion();
+  if (claudeVersion) {
+    rows.push(`| 🤖 **Claude CLI** | \`${claudeVersion}\` |`);
   }
 
   rows.push(`| 🆔 **Session ID** | \`${session.claudeSessionId.substring(0, 8)}\` |`);

--- a/src/session/sticky-message.test.ts
+++ b/src/session/sticky-message.test.ts
@@ -98,8 +98,8 @@ describe('buildStickyMessage', () => {
     const sessions = new Map<string, Session>();
     const result = await buildStickyMessage(sessions, 'test-platform', testConfig);
 
-    // Should contain version
-    expect(result).toMatch(/`v\d+\.\d+\.\d+`/);
+    // Should contain version (with optional CLI version appended)
+    expect(result).toMatch(/`v\d+\.\d+\.\d+( · CLI \d+\.\d+\.\d+)?`/);
     // Should contain session count
     expect(result).toContain('`0/5 sessions`');
     // Should contain uptime

--- a/src/session/sticky-message.ts
+++ b/src/session/sticky-message.ts
@@ -15,6 +15,7 @@ import { formatUptime } from '../utils/uptime.js';
 import { VERSION } from '../version.js';
 import { createLogger } from '../utils/logger.js';
 import { formatPullRequestLink } from '../utils/pr-detector.js';
+import { getClaudeCliVersion } from '../claude/version-check.js';
 
 const log = createLogger('sticky');
 
@@ -274,8 +275,10 @@ async function buildStatusBar(
 ): Promise<string> {
   const items: string[] = [];
 
-  // Version
-  items.push(`\`v${VERSION}\``);
+  // Version (claude-threads + Claude CLI)
+  const claudeVersion = getClaudeCliVersion();
+  const versionStr = claudeVersion ? `v${VERSION} · CLI ${claudeVersion}` : `v${VERSION}`;
+  items.push(`\`${versionStr}\``);
 
   // Session count
   items.push(`\`${sessionCount}/${config.maxSessions} sessions\``);


### PR DESCRIPTION
## Summary

- Add version compatibility check for Claude CLI at bot startup
- Display Claude CLI version in terminal output, sticky message, and session headers
- Exit with error if incompatible version detected (bypass with `--skip-version-check`)
- Compatible versions: `>=2.0.74 <=2.0.76`

## Changes

- **New:** `src/claude/version-check.ts` - Version validation utility
- **New:** `src/claude/version-check.test.ts` - Tests for version checking
- **Modified:** `src/index.ts` - Add version check at startup
- **Modified:** `src/session/commands.ts` - Show CLI version in session header
- **Modified:** `src/session/sticky-message.ts` - Show CLI version in status bar
- **Modified:** `CLAUDE.md` - Document version requirements

## Test plan

- [ ] Start bot with compatible Claude CLI version (2.0.74-2.0.76) - should work
- [ ] Start bot with incompatible version - should show error and exit
- [ ] Start bot with `--skip-version-check` and incompatible version - should start with warning
- [ ] Verify version displays in terminal startup output
- [ ] Verify version displays in sticky channel message
- [ ] Verify version displays in session header table