### PR TITLE
feat: display compaction status in Mattermost

### DIFF
--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -304,9 +304,28 @@ function formatEvent(
 
       return null;
     }
-    case 'system':
+    case 'system': {
       if (e.subtype === 'error') return `❌ ${e.error}`;
+
+      // Handle compaction status events
+      if (e.subtype === 'status' && e.status === 'compacting') {
+        return `🗜️ **Compacting context...** *(freeing up memory)*`;
+      }
+
+      // Handle compact_boundary event - marks when compaction is complete
+      if (e.subtype === 'compact_boundary') {
+        const metadata = e.compact_metadata as { trigger?: string; pre_tokens?: number } | undefined;
+        const trigger = metadata?.trigger || 'auto';
+        const preTokens = metadata?.pre_tokens;
+        let info = trigger === 'manual' ? 'manual' : 'auto';
+        if (preTokens && preTokens > 0) {
+          info += `, ${Math.round(preTokens / 1000)}k tokens`;
+        }
+        return `✅ **Context compacted** *(${info})*`;
+      }
+
       return null;
+    }
     case 'user': {
       // Handle local command output (e.g., /context, /cost responses)
       const msg = e.message as { content?: string };


### PR DESCRIPTION
## Summary
- Show when Claude CLI is compacting context: 🗜️ **Compacting context...** *(freeing up memory)*
- Show when compaction completes: ✅ **Context compacted** *(manual)* or *(auto, 150k tokens)*
- Handle `compact_boundary` events with metadata (trigger type, pre-compaction token count)

Previously, compaction happened silently which could be confusing to users.

## Test plan
- [x] Run test suite - all 496 tests pass
- [x] Added 6 new tests for compaction event handling
- [ ] Manually test `!compact` command in Mattermost
- [ ] Verify auto-compaction displays correctly when context fills up