### PR TITLE
Update status bars: remove session count, add keep-alive indicator

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -469,7 +469,6 @@ export async function updateSessionHeader(
     statusItems.push(`\`💰 $${stats.totalCostUSD.toFixed(2)}\``);
   }
 
-  statusItems.push(`\`${session.sessionNumber}/${ctx.config.maxSessions}\``);
   statusItems.push(`\`${permMode}\``);
   if (ctx.config.chromeEnabled) {
     statusItems.push('`🌐 Chrome`');

--- a/src/session/sticky-message.ts
+++ b/src/session/sticky-message.ts
@@ -17,6 +17,7 @@ import { VERSION } from '../version.js';
 import { createLogger } from '../utils/logger.js';
 import { formatPullRequestLink } from '../utils/pr-detector.js';
 import { getClaudeCliVersion } from '../claude/version-check.js';
+import { keepAlive } from '../utils/keep-alive.js';
 
 const log = createLogger('sticky');
 
@@ -296,6 +297,11 @@ async function buildStatusBar(
   // Debug mode
   if (config.debug) {
     items.push('`🐛 Debug`');
+  }
+
+  // Keep-alive status
+  if (keepAlive.isActive()) {
+    items.push('`💓 Keep-alive`');
   }
 
   // Battery status (if available)


### PR DESCRIPTION
## Summary
- Remove session count (e.g., "2/5") from thread status bar - this info is redundant since users can see active sessions in the channel sticky message
- Add keep-alive indicator (`💓 Keep-alive`) to channel sticky message status bar when sleep prevention is active

## Test plan
- [ ] Start a session and verify the thread header no longer shows session count
- [ ] Verify the channel sticky message shows "💓 Keep-alive" when a session is active
- [ ] Verify keep-alive indicator disappears when all sessions end