### PR TITLE
feat: pin active task post for easy access

### DIFF
--- a/src/session/events.test.ts
+++ b/src/session/events.test.ts
@@ -56,6 +56,8 @@ function createMockPlatform() {
         createAt: Date.now(),
       };
     }),
+    pinPost: mock(async (_postId: string): Promise<void> => {}),
+    unpinPost: mock(async (_postId: string): Promise<void> => {}),
     sendTyping: mock(() => {}),
     getFormatter: () => createMockFormatter(),
     posts,
@@ -290,6 +292,9 @@ describe('handleEvent with TodoWrite', () => {
     };
 
     handleEvent(session, event, ctx);
+
+    // Wait for async operations to complete
+    await new Promise(resolve => setTimeout(resolve, 10));
 
     // tasksCompleted should be true
     expect(session.tasksCompleted).toBe(true);

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -453,13 +453,21 @@ async function handleTodoWrite(
         { action: 'Update tasks', session }
       );
       session.lastTasksContent = completedMsg;
+      // Unpin completed task post
+      await session.platform.unpinPost(tasksPostId).catch(() => {});
     }
     return;
   }
 
   // Check if all tasks are completed
   const allCompleted = todos.every((t) => t.status === 'completed');
+  const wasCompleted = session.tasksCompleted;
   session.tasksCompleted = allCompleted;
+
+  // Unpin task post when all tasks complete
+  if (allCompleted && !wasCompleted && session.tasksPostId) {
+    await session.platform.unpinPost(session.tasksPostId).catch(() => {});
+  }
 
   // Count progress
   const completed = todos.filter((t) => t.status === 'completed').length;
@@ -551,6 +559,8 @@ async function handleTodoWrite(
       session.tasksPostId = post.id;
       // Register the task post so reaction clicks are routed to this session
       ctx.ops.registerPost(post.id, session.threadId);
+      // Pin the task post for easy access
+      await session.platform.pinPost(post.id).catch(() => {});
     }
   }
   // Update sticky message with new task progress

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -821,6 +821,12 @@ export async function handleExit(
 
   ctx.ops.stopTyping(session);
   cleanupSessionTimers(session);
+
+  // Unpin task post on session exit
+  if (session.tasksPostId) {
+    await session.platform.unpinPost(session.tasksPostId).catch(() => {});
+  }
+
   await ctx.ops.flush(session);
 
   if (code !== 0 && code !== null) {
@@ -864,6 +870,11 @@ export async function killSession(
 
   ctx.ops.stopTyping(session);
   session.claude.kill();
+
+  // Unpin task post on session kill
+  if (session.tasksPostId) {
+    await session.platform.unpinPost(session.tasksPostId).catch(() => {});
+  }
 
   // Clean up session from maps
   ctx.ops.emitSessionRemove(session.sessionId);

--- a/src/session/streaming.test.ts
+++ b/src/session/streaming.test.ts
@@ -68,6 +68,8 @@ function createMockPlatform() {
     removeReaction: mock(async (_postId: string, _emojiName: string): Promise<void> => {
       // Mock - do nothing
     }),
+    pinPost: mock(async (_postId: string): Promise<void> => {}),
+    unpinPost: mock(async (_postId: string): Promise<void> => {}),
     sendTyping: mock(() => {}),
     getFormatter: mock(() => createMockFormatter()),
     posts,

--- a/src/session/streaming.ts
+++ b/src/session/streaming.ts
@@ -434,6 +434,9 @@ async function bumpTasksToBottomWithContent(
     sessionLog(session).debug(`Could not remove toggle emoji: ${err}`);
   }
 
+  // Unpin the old task post before repurposing it
+  await session.platform.unpinPost(oldTasksPostId).catch(() => {});
+
   // Repurpose the task list post for the new content
   await withErrorHandling(
     () => session.platform.updatePost(oldTasksPostId, newContent),
@@ -456,6 +459,8 @@ async function bumpTasksToBottomWithContent(
     sessionLog(session).debug(`Created new task post ${newTasksPost.id.substring(0, 8)}`);
     // Register the new task post so reaction clicks are routed to this session
     registerPost(newTasksPost.id, session.threadId);
+    // Pin the new task post
+    await session.platform.pinPost(newTasksPost.id).catch(() => {});
   } else {
     // No task content to re-post, clear the task post ID
     session.tasksPostId = null;
@@ -492,6 +497,9 @@ export async function bumpTasksToBottom(
   sessionLog(session).debug(`Bumping tasks: deleting old post ${oldPostId.substring(0, 8)}`);
 
   try {
+    // Unpin the old task post before deleting
+    await session.platform.unpinPost(session.tasksPostId).catch(() => {});
+
     // Delete the old task post
     await session.platform.deletePost(session.tasksPostId);
 
@@ -510,6 +518,8 @@ export async function bumpTasksToBottom(
     if (registerPost) {
       registerPost(newPost.id, session.threadId);
     }
+    // Pin the new task post
+    await session.platform.pinPost(newPost.id).catch(() => {});
   } catch (err) {
     sessionLog(session).error(`Failed to bump tasks to bottom: ${err}`);
   }


### PR DESCRIPTION
## Summary

- Pin task posts to make them easily accessible in the channel
- Only the active (current) task post is pinned - repurposed task posts are not
- Unpin when tasks complete or session ends

## Pin Lifecycle

- **Pin** when task post is created
- **Unpin** when all tasks complete
- **Unpin old → Pin new** when task post is "bumped" to bottom
- **Unpin old** when repurposed (old post becomes content, new task created)
- **Unpin** on session exit/kill

## Test plan

- [ ] Start session with tasks → verify task post is pinned
- [ ] Complete all tasks → verify task post is unpinned
- [ ] Send follow-up causing bump → verify old unpinned, new pinned
- [ ] End session → verify task post is unpinned
- [ ] Multiple sessions → each has own pinned task post