### PR TITLE
feat: Add platform toggle from UI using Shift+1-9

### DIFF
--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -69,6 +69,13 @@ export interface PlatformClient extends EventEmitter {
    */
   disconnect(): void;
 
+  /**
+   * Prepare for reconnection after intentional disconnect
+   * Resets internal state (intentionalDisconnect flag, reconnect attempts)
+   * so that connect() will work again.
+   */
+  prepareForReconnect(): void;
+
   // ============================================================================
   // User Management
   // ============================================================================

--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -733,4 +733,15 @@ export class MattermostClient extends EventEmitter implements PlatformClient {
       this.ws = null;
     }
   }
+
+  /**
+   * Prepare for reconnection after intentional disconnect.
+   * Resets the intentional disconnect flag and reconnect attempts
+   * so that connect() will work again.
+   */
+  prepareForReconnect(): void {
+    wsLogger.debug('Preparing for reconnect (resetting intentional disconnect flag)');
+    this.isIntentionalDisconnect = false;
+    this.reconnectAttempts = 0;
+  }
 }

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -665,6 +665,17 @@ export class SlackClient extends EventEmitter implements PlatformClient {
     }
   }
 
+  /**
+   * Prepare for reconnection after intentional disconnect.
+   * Resets the intentional disconnect flag and reconnect attempts
+   * so that connect() will work again.
+   */
+  prepareForReconnect(): void {
+    wsLogger.debug('Preparing for reconnect (resetting intentional disconnect flag)');
+    this.isIntentionalDisconnect = false;
+    this.reconnectAttempts = 0;
+  }
+
   // ============================================================================
   // User Management
   // ============================================================================

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -38,6 +38,7 @@ export function App({ config, onStateReady, onResizeReady, onQuit, toggleCallbac
     addLog,
     toggleSession,
     setPlatformStatus,
+    togglePlatformEnabled,
     getLogsForSession,
     getGlobalLogs,
   } = useAppState(config);
@@ -88,6 +89,12 @@ export function App({ config, onStateReady, onResizeReady, onQuit, toggleCallbac
     });
   }, [toggleCallbacks]);
 
+  // Platform toggle handler - toggles enabled state and calls callback
+  const handlePlatformToggle = React.useCallback((platformId: string) => {
+    const newEnabled = togglePlatformEnabled(platformId);
+    toggleCallbacks?.onPlatformToggle?.(platformId, newEnabled);
+  }, [togglePlatformEnabled, toggleCallbacks]);
+
   // Getter for external access to toggle state
   const getToggles = React.useCallback(() => toggles, [toggles]);
 
@@ -116,10 +123,15 @@ export function App({ config, onStateReady, onResizeReady, onQuit, toggleCallbac
   // Get session IDs for keyboard handling
   const sessionIds = Array.from(state.sessions.keys());
 
+  // Get platform IDs for keyboard handling (Shift+1-9)
+  const platformIds = Array.from(state.platforms.keys());
+
   // Handle keyboard input
   useKeyboard({
     sessionIds,
+    platformIds,
     onToggle: toggleSession,
+    onPlatformToggle: handlePlatformToggle,
     onQuit,
     onDebugToggle: handleDebugToggle,
     onPermissionsToggle: handlePermissionsToggle,
@@ -186,6 +198,7 @@ export function App({ config, onStateReady, onResizeReady, onQuit, toggleCallbac
         shuttingDown={state.shuttingDown}
         sessionCount={state.sessions.size}
         toggles={toggles}
+        platforms={state.platforms}
       />
     </Box>
   );

--- a/src/ui/hooks/useAppState.ts
+++ b/src/ui/hooks/useAppState.ts
@@ -95,6 +95,7 @@ export function useAppState(initialConfig: AppConfig) {
         connected: false,
         reconnecting: false,
         reconnectAttempts: 0,
+        enabled: true,  // Platforms start enabled by default
       };
       platforms.set(platformId, { ...current, ...status });
       return { ...prev, platforms };
@@ -109,6 +110,21 @@ export function useAppState(initialConfig: AppConfig) {
     return state.logs.filter((log) => !log.sessionId);
   }, [state.logs]);
 
+  // Toggle platform enabled state, returns new enabled state
+  const togglePlatformEnabled = useCallback((platformId: string): boolean => {
+    let newEnabled = false;
+    setState((prev) => {
+      const platforms = new Map(prev.platforms);
+      const current = platforms.get(platformId);
+      if (current) {
+        newEnabled = !current.enabled;
+        platforms.set(platformId, { ...current, enabled: newEnabled });
+      }
+      return { ...prev, platforms };
+    });
+    return newEnabled;
+  }, []);
+
   return {
     state,
     setReady,
@@ -119,6 +135,7 @@ export function useAppState(initialConfig: AppConfig) {
     addLog,
     toggleSession,
     setPlatformStatus,
+    togglePlatformEnabled,
     getLogsForSession,
     getGlobalLogs,
   };

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -3,9 +3,25 @@
  */
 import { useInput } from 'ink';
 
+// Map Shift+number characters to their index (0-8 for platforms 1-9)
+// On US keyboard: Shift+1='!', Shift+2='@', etc.
+const SHIFT_NUMBER_MAP: Record<string, number> = {
+  '!': 0, // Shift+1
+  '@': 1, // Shift+2
+  '#': 2, // Shift+3
+  $: 3, // Shift+4
+  '%': 4, // Shift+5
+  '^': 5, // Shift+6
+  '&': 6, // Shift+7
+  '*': 7, // Shift+8
+  '(': 8, // Shift+9
+};
+
 interface UseKeyboardOptions {
   sessionIds: string[];
+  platformIds: string[];
   onToggle: (sessionId: string) => void;
+  onPlatformToggle?: (platformId: string) => void;
   onQuit?: () => void;
   // Runtime toggle handlers
   onDebugToggle?: () => void;
@@ -16,7 +32,9 @@ interface UseKeyboardOptions {
 
 export function useKeyboard({
   sessionIds,
+  platformIds,
   onToggle,
+  onPlatformToggle,
   onQuit,
   onDebugToggle,
   onPermissionsToggle,
@@ -29,6 +47,16 @@ export function useKeyboard({
     if (input === '\x03' || (input === 'c' && key.ctrl)) {
       if (onQuit) {
         onQuit();
+      }
+      return;
+    }
+
+    // Shift+number keys to toggle platforms (!, @, #, $, %, ^, &, *, ()
+    const platformIndex = SHIFT_NUMBER_MAP[input];
+    if (platformIndex !== undefined && onPlatformToggle) {
+      const platformId = platformIds[platformIndex];
+      if (platformId) {
+        onPlatformToggle(platformId);
       }
       return;
     }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -40,6 +40,7 @@ export interface PlatformStatus {
   connected: boolean;
   reconnecting: boolean;
   reconnectAttempts: number;
+  enabled: boolean;  // Whether the platform is enabled (accepting messages)
 }
 
 export interface AppConfig {
@@ -70,6 +71,7 @@ export interface ToggleCallbacks {
   onPermissionsToggle?: (skipPermissions: boolean) => void;
   onChromeToggle?: (enabled: boolean) => void;
   onKeepAliveToggle?: (enabled: boolean) => void;
+  onPlatformToggle?: (platformId: string, enabled: boolean) => void;
 }
 
 export interface AppState {


### PR DESCRIPTION
## Summary
- Add ability to toggle individual platforms on/off from terminal UI using Shift+1-9 keys
- When disabled: sessions are paused, platform disconnects, UI shows gray state
- When re-enabled: platform reconnects, paused sessions auto-resume

## Features
- **Keyboard shortcuts**: Shift+1-9 to toggle platforms (matches session expand 1-9)
- **Session handling**: Active sessions pause on disable, resume on re-enable
- **Visual feedback**: StatusLine shows platform state with colors (green=connected, gray=disabled, yellow=reconnecting, red=error)

## Test plan
- [ ] Verify Shift+1 toggles first platform off (turns gray, disconnects)
- [ ] Verify active sessions are paused when platform is disabled
- [ ] Verify Shift+1 toggles platform back on (reconnects, turns green)
- [ ] Verify paused sessions resume automatically
- [ ] Run `bun test` - all 536 tests pass