### PR TITLE
feat(ui): improve spinner animations for different contexts

### DIFF
--- a/src/ui/components/CollapsibleSession.tsx
+++ b/src/ui/components/CollapsibleSession.tsx
@@ -80,12 +80,12 @@ export function CollapsibleSession(props: CollapsibleSessionProps) {
           <SessionLog logs={logs} />
           {session.status === 'starting' && (
             <Box marginTop={0}>
-              <Spinner label="Starting..." />
+              <Spinner label="Starting..." type="dots" />
             </Box>
           )}
           {session.isTyping && session.status !== 'starting' && (
             <Box marginTop={0}>
-              <Spinner label="Typing..." />
+              <Spinner label="Typing..." type="simpleDots" />
             </Box>
           )}
         </Box>

--- a/src/ui/components/Platforms.tsx
+++ b/src/ui/components/Platforms.tsx
@@ -14,7 +14,7 @@ export function Platforms({ platforms }: PlatformsProps) {
   if (platforms.size === 0) {
     return (
       <Box marginTop={1}>
-        <Spinner label="Connecting to platforms..." />
+        <Spinner label="Connecting to platforms..." type="dots" />
       </Box>
     );
   }
@@ -42,9 +42,12 @@ export function Platforms({ platforms }: PlatformsProps) {
           <Text dimColor>on</Text>
           <Text>{platform.displayName}</Text>
 
-          {/* Reconnecting indicator */}
+          {/* Reconnecting indicator with spinner */}
           {platform.reconnecting && (
-            <Text color="yellow">(reconnecting {platform.reconnectAttempts}...)</Text>
+            <Box gap={1}>
+              <Spinner type="dots" />
+              <Text color="yellow">reconnecting ({platform.reconnectAttempts})</Text>
+            </Box>
           )}
         </Box>
       ))}

--- a/src/ui/components/Spinner.tsx
+++ b/src/ui/components/Spinner.tsx
@@ -3,15 +3,21 @@
  */
 import { Box, Text } from 'ink';
 import { Spinner as InkSpinner } from '@inkjs/ui';
+import type { SpinnerName } from 'cli-spinners';
 
 interface SpinnerProps {
   label?: string;
+  /**
+   * Type of spinner animation.
+   * @default 'simpleDots' - typing-style dots animation (. .. ...)
+   */
+  type?: SpinnerName;
 }
 
-export function Spinner({ label }: SpinnerProps) {
+export function Spinner({ label, type = 'simpleDots' }: SpinnerProps) {
   return (
     <Box gap={1}>
-      <InkSpinner />
+      <InkSpinner type={type} />
       {label && <Text dimColor>{label}</Text>}
     </Box>
   );

--- a/src/ui/components/StatusLine.tsx
+++ b/src/ui/components/StatusLine.tsx
@@ -5,6 +5,7 @@
  * Visually separated from sessions with a line.
  */
 import { Box, Text } from 'ink';
+import { Spinner } from './Spinner.js';
 import type { ToggleState, PlatformStatus } from '../types.js';
 
 interface StatusLineProps {
@@ -86,7 +87,7 @@ export function StatusLine({
         {/* Bot status */}
         {shuttingDown ? (
           <Box gap={1}>
-            <Text color="yellow">⏻</Text>
+            <Spinner type="line" />
             <Text color="yellow">Shutting down...</Text>
           </Box>
         ) : ready ? (
@@ -96,7 +97,7 @@ export function StatusLine({
           </Box>
         ) : (
           <Box gap={1}>
-            <Text color="yellow">○</Text>
+            <Spinner type="dots" />
             <Text dimColor>Starting...</Text>
           </Box>
         )}


### PR DESCRIPTION
## Summary

- Use `simpleDots` (`. .. ...`) for typing indicator - matches familiar chat UX
- Use `dots` (`⠋⠙⠹`) for loading states (starting, connecting, reconnecting)  
- Use `line` (`-\|/`) for shutdown - subtle wind-down animation
- Add spinner to platform reconnecting indicator
- Add spinner to StatusLine starting/shutdown states

## Test plan

- [x] `bun test` passes (567 pass, 0 fail)
- [x] `bun run build` succeeds
- [ ] Manual test: start bot, observe spinners during startup
- [ ] Manual test: trigger reconnect, observe reconnecting spinner
- [ ] Manual test: start session, observe typing spinner when Claude responds
- [ ] Manual test: quit bot, observe shutdown spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)