### PR TITLE
feat: Show pause/shutdown status in pinned channel message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -374,6 +374,9 @@ async function main() {
     // Set shutdown flag FIRST to prevent race conditions with exit events
     session.setShuttingDown();
 
+    // Update sticky messages to show shutdown state
+    await session.updateAllStickyMessages();
+
     // Post shutdown message to active sessions (updates existing timeout posts or creates new ones)
     const activeCount = session.getActiveThreadIds().length;
     if (activeCount > 0) {


### PR DESCRIPTION
## Summary

- When a platform is paused (via Shift+1-9 toggle), the sticky channel message shows "⏸️ Platform paused" with a note that sessions will resume when re-enabled
- When the bot is shutting down, the sticky message shows "🛑 Shutting down..." with a note that sessions will resume on restart
- Session list is hidden during these states to avoid showing stale information

This gives users clear feedback about the bot's state directly in the channel.

## Test plan

- [ ] Start the bot with active sessions
- [ ] Press Shift+1 to pause a platform - verify sticky message shows paused state
- [ ] Press Shift+1 again to re-enable - verify sticky message returns to normal
- [ ] Press Ctrl+C to shutdown - verify sticky message shows shutdown state before exit