### PR TITLE
fix(slack): disable link previews in messages

### DIFF
--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -853,11 +853,24 @@ export class SlackClient extends EventEmitter implements PlatformClient {
 
   /**
    * Create a new post/message.
+   * @param message - Message text
+   * @param threadId - Optional thread parent ID
+   * @param options - Optional settings (e.g., unfurl control)
    */
-  async createPost(message: string, threadId?: string): Promise<PlatformPost> {
+  async createPost(
+    message: string,
+    threadId?: string,
+    options?: { unfurl?: boolean }
+  ): Promise<PlatformPost> {
+    // Disable unfurling for channel-level posts (sticky message) by default
+    // Thread messages can have previews unless explicitly disabled
+    const shouldUnfurl = options?.unfurl ?? (threadId !== undefined);
+
     const body: Record<string, unknown> = {
       channel: this.channelId,
       text: message,
+      unfurl_links: shouldUnfurl,
+      unfurl_media: shouldUnfurl,
     };
 
     if (threadId) {
@@ -899,13 +912,15 @@ export class SlackClient extends EventEmitter implements PlatformClient {
 
   /**
    * Create a post with reaction options for user interaction.
+   * Used for task lists, permission prompts, etc. - disables link previews.
    */
   async createInteractivePost(
     message: string,
     reactions: string[],
     threadId?: string
   ): Promise<PlatformPost> {
-    const post = await this.createPost(message, threadId);
+    // Disable unfurling for interactive posts (task lists, prompts, etc.)
+    const post = await this.createPost(message, threadId, { unfurl: false });
 
     // Add each reaction option, continuing even if some fail
     for (const emoji of reactions) {


### PR DESCRIPTION
## Summary
- Disable URL unfurling selectively for Slack messages:
  - **Channel-level posts** (sticky message): no previews by default
  - **Interactive posts** (task lists, permission prompts): explicitly no previews
  - **Regular thread messages**: previews enabled (can share useful links)
- This keeps the UI cleaner for system messages while allowing Claude's responses to include link previews when sharing relevant URLs

## Test plan
- [ ] Deploy and verify the sticky channel message no longer shows URL previews
- [ ] Verify task list messages don't show previews
- [ ] Verify Claude's regular responses in threads can still show link previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)