### PR TITLE
docs: add files:read scope and Slack app manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ platforms:
 - Requires both a Bot Token (`xoxb-`) and App Token (`xapp-`) for Socket Mode
 - `allowedUsers` uses Slack usernames (not user IDs) for consistency with Mattermost
 - User mentions in messages use Slack user IDs (e.g., `<@U0123ALICE>`) - the bot handles this automatically
-- Bot Token scopes required: `channels:history`, `channels:read`, `chat:write`, `reactions:read`, `reactions:write`, `users:read`
+- Bot Token scopes required: `channels:history`, `channels:read`, `chat:write`, `files:read`, `reactions:read`, `reactions:write`, `users:read`
 - App Token scope: `connections:write` (Socket Mode must be enabled in the Slack app)
 
 Configuration is stored in YAML only - no `.env` file support.

--- a/docs/SLACK_SETUP.md
+++ b/docs/SLACK_SETUP.md
@@ -2,20 +2,40 @@
 
 This guide covers setting up a Slack app for claude-threads with Socket Mode.
 
-## 1. Create Slack App
+## Quick Setup (Recommended)
+
+Use the app manifest to configure everything automatically:
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App**
+2. Choose **From an app manifest**
+3. Select your workspace
+4. Paste the contents of [`slack-app-manifest.yaml`](slack-app-manifest.yaml)
+5. Click **Create**
+6. Go to **Basic Information** → **App-Level Tokens** → **Generate Token**
+   - Name it (e.g., "socket-mode") and add the `connections:write` scope
+   - Save this token - it starts with `xapp-`
+7. Go to **Install App** → **Install to Workspace** and authorize
+8. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
+9. Continue to [Get Channel ID](#6-get-channel-id) below
+
+## Manual Setup
+
+If you prefer to configure manually, follow these steps:
+
+### 1. Create Slack App
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and click **Create New App**
 2. Choose **From scratch**
 3. Name your app (e.g., "Claude Code") and select your workspace
 
-## 2. Enable Socket Mode
+### 2. Enable Socket Mode
 
 1. Go to **Socket Mode** in the left sidebar
 2. Toggle **Enable Socket Mode** to On
 3. Create an **App-Level Token** with the `connections:write` scope
 4. Save this token - it starts with `xapp-`
 
-## 3. Add Bot Scopes
+### 3. Add Bot Scopes
 
 Go to **OAuth & Permissions** and add these **Bot Token Scopes**:
 
@@ -24,13 +44,14 @@ Go to **OAuth & Permissions** and add these **Bot Token Scopes**:
 | `channels:history` | Read messages in channels |
 | `channels:read` | View basic channel info |
 | `chat:write` | Send messages |
+| `files:read` | Read file uploads (for image attachments) |
 | `pins:read` | Read pinned messages |
 | `pins:write` | Pin/unpin messages |
 | `reactions:read` | Read emoji reactions |
 | `reactions:write` | Add emoji reactions |
 | `users:read` | View users and their info |
 
-## 4. Enable Events
+### 4. Enable Events
 
 1. Go to **Event Subscriptions**
 2. Toggle **Enable Events** to On
@@ -39,7 +60,7 @@ Go to **OAuth & Permissions** and add these **Bot Token Scopes**:
    - `reaction_added` - Reaction added to messages
    - `reaction_removed` - Reaction removed from messages
 
-## 5. Install to Workspace
+### 5. Install to Workspace
 
 1. Go to **Install App**
 2. Click **Install to Workspace** and authorize

--- a/docs/slack-app-manifest.yaml
+++ b/docs/slack-app-manifest.yaml
@@ -1,0 +1,34 @@
+display_information:
+  name: Claude Code
+  description: Chat with Claude Code through Slack
+  background_color: "#4a154b"
+
+features:
+  bot_user:
+    display_name: Claude Code
+    always_online: true
+
+oauth_config:
+  scopes:
+    bot:
+      - channels:history
+      - channels:read
+      - chat:write
+      - files:read
+      - pins:read
+      - pins:write
+      - reactions:read
+      - reactions:write
+      - users:read
+
+settings:
+  event_subscriptions:
+    bot_events:
+      - message.channels
+      - reaction_added
+      - reaction_removed
+  interactivity:
+    is_enabled: false
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false


### PR DESCRIPTION
## Summary
- Add missing `files:read` scope for Slack image uploads to documentation
- Create `slack-app-manifest.yaml` for one-click app setup
- Reorganize SLACK_SETUP.md with "Quick Setup" section using the manifest

## Test plan
- [ ] Verify manifest creates working Slack app when imported
- [ ] Verify `files:read` scope enables image upload handling

Closes: N/A