### PR TITLE
fix(slack): escape tildes in strikethrough text

### DIFF
--- a/src/platform/slack/formatter.test.ts
+++ b/src/platform/slack/formatter.test.ts
@@ -81,6 +81,32 @@ describe('SlackFormatter', () => {
     });
   });
 
+  describe('formatStrikethrough', () => {
+    it('wraps text in tildes', () => {
+      expect(formatter.formatStrikethrough('hello')).toBe('~hello~');
+    });
+
+    it('escapes tildes in text to prevent formatting breakage', () => {
+      // Text containing ~ would break strikethrough in Slack
+      // e.g., ~Change to ~/.config~ would end strikethrough at the second ~
+      // Solution: insert zero-width space (U+200B) after each ~ to break pattern matching
+      // This preserves the actual ~ character for copy/paste
+      const result = formatter.formatStrikethrough('Change to ~/.config/path');
+      expect(result).toBe('~Change to ~\u200B/.config/path~');
+      // The zero-width space is invisible, so the tilde is preserved for copy/paste
+      expect(result).toContain('~');
+    });
+
+    it('escapes multiple tildes in text', () => {
+      expect(formatter.formatStrikethrough('~foo~ and ~bar~'))
+        .toBe('~~\u200Bfoo~\u200B and ~\u200Bbar~\u200B~');
+    });
+
+    it('handles text with no tildes', () => {
+      expect(formatter.formatStrikethrough('normal text')).toBe('~normal text~');
+    });
+  });
+
   describe('formatHeading', () => {
     it('uses bold text for headings (Slack has no native headings)', () => {
       // Slack doesn't have heading syntax, so all levels use bold

--- a/src/platform/slack/formatter.ts
+++ b/src/platform/slack/formatter.ts
@@ -67,7 +67,13 @@ export class SlackFormatter implements PlatformFormatter {
 
   formatStrikethrough(text: string): string {
     // Slack uses single tildes for strikethrough
-    return `~${text}~`;
+    // Problem: If the text contains ~ characters (e.g., ~/.config/path), Slack interprets
+    // them as the end of strikethrough formatting, breaking the display.
+    // Solution: Insert a zero-width space (U+200B) after each tilde in the content.
+    // This breaks Slack's pattern matching for strikethrough delimiters while preserving
+    // the actual ~ character for copy/paste. The zero-width space is invisible.
+    const escapedText = text.replace(/~/g, '~\u200B');
+    return `~${escapedText}~`;
   }
 
   formatHeading(text: string, _level: number): string {


### PR DESCRIPTION
## Summary

- Fix strikethrough formatting breaking when text contains tilde characters (e.g., `~/.config/path`)
- Insert zero-width space (U+200B) after internal tildes to break Slack's pattern matching while preserving the actual character for copy/paste

## Problem

In Slack mrkdwn, strikethrough uses single tildes (`~text~`). When the text contains tilde characters like in paths (`~/.claude-threads/worktrees/`), Slack interprets them as the end of strikethrough formatting.

**Before:** `~Change to ~/.config~` would render strikethrough only up to the second tilde, leaving the rest unformatted.

## Solution

Insert a zero-width space (`\u200B`) after each tilde inside the text. This:
1. Breaks Slack's pattern matching for strikethrough delimiters
2. Preserves the actual `~` character for copy/paste operations
3. Is invisible to users

## Test plan

- [x] Unit tests added for strikethrough with tildes
- [x] All existing tests pass (584 pass, 0 fail)
- [ ] Manual verification in Slack with task items containing paths like `~/.config`