### PR TITLE
fix: use double newlines between content blocks for proper formatting

### DIFF
--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -298,7 +298,7 @@ function formatEvent(
           );
         }
       }
-      return parts.length > 0 ? parts.join('\n') : null;
+      return parts.length > 0 ? parts.join('\n\n') : null;
     }
     case 'tool_use': {
       const tool = e.tool_use as { id?: string; name: string; input?: Record<string, unknown> };

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -501,7 +501,9 @@ export class SessionManager extends EventEmitter {
 
   private appendContent(session: Session, text: string): void {
     if (!text) return;
-    session.pendingContent += text + '\n';
+    // Use double newlines for proper visual separation between content blocks
+    // This ensures code blocks, tool results, and text are properly separated
+    session.pendingContent += text + '\n\n';
     streaming.scheduleUpdate(session, (s) => this.flush(s));
   }
 


### PR DESCRIPTION
## Summary
- Fixed newline formatting issues in both Mattermost and Slack
- Content blocks (text, tool uses, tool results, code blocks) now have proper visual separation
- Code blocks with triple backticks now render correctly

## Changes
- `appendContent()` in `manager.ts` now adds double newlines (`\n\n`) between content blocks
- `events.ts` joins multiple parts with double newlines for proper separation

## Problem
When Claude sends consecutive content blocks, they were joined with only single newlines. This caused:
- Code blocks (triple backticks) not rendering correctly
- Consecutive items appearing on the same line  
- Content lacking proper visual separation in both platforms

## Test plan
- [ ] Start a session and ask Claude to generate code - verify code blocks render properly
- [ ] Verify consecutive tool invocations have proper spacing
- [ ] Test on both Mattermost and Slack platforms