### PR TITLE
feat: shorten worktree paths in tool output to [branch]/path

### DIFF
--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -294,7 +294,8 @@ function formatEvent(
 
           if (text) parts.push(text);
         } else if (block.type === 'tool_use' && block.name) {
-          const formatted = sharedFormatToolUse(block.name, block.input || {}, session.platform.getFormatter(), { detailed: true });
+          const worktreeInfo = session.worktreeInfo ? { path: session.worktreeInfo.worktreePath, branch: session.worktreeInfo.branch } : undefined;
+          const formatted = sharedFormatToolUse(block.name, block.input || {}, session.platform.getFormatter(), { detailed: true, worktreeInfo });
           if (formatted) parts.push(formatted);
         } else if (block.type === 'thinking' && block.thinking) {
           // Extended thinking - show abbreviated version in blockquote
@@ -326,7 +327,8 @@ function formatEvent(
       if (tool.id) {
         session.activeToolStarts.set(tool.id, Date.now());
       }
-      return sharedFormatToolUse(tool.name, tool.input || {}, session.platform.getFormatter(), { detailed: true }) || null;
+      const worktreeInfo = session.worktreeInfo ? { path: session.worktreeInfo.worktreePath, branch: session.worktreeInfo.branch } : undefined;
+      return sharedFormatToolUse(tool.name, tool.input || {}, session.platform.getFormatter(), { detailed: true, worktreeInfo }) || null;
     }
     case 'tool_result': {
       const result = e.tool_result as { tool_use_id?: string; is_error?: boolean };


### PR DESCRIPTION
## Summary

- When working in a git worktree, tool output now shows shortened paths like `[feat/my-feature]/src/index.ts` instead of the full worktree path `~/.claude-threads/worktrees/Users-user-project--feat-my-feature-abc12345/src/index.ts`
- Uses session's known worktree info for reliable path shortening (instead of error-prone regex parsing)

## Changes

- Add `worktreeInfo` option to `FormatOptions` for path shortening
- Update `shortenPath()` to use session's known worktree path and branch  
- Pass `worktreeInfo` from session context in `events.ts`
- Add comprehensive test coverage for worktree path shortening

## Test plan

- [x] Unit tests pass (69 tests in tool-formatter.test.ts)
- [x] Full test suite passes (1048 tests)
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Manual testing in Mattermost with worktree sessions