### PR TITLE
feat: add update modal to CLI UI

### DIFF
--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -1,0 +1,60 @@
+/**
+ * Modal component - a centered overlay box
+ *
+ * Renders a bordered box with a title that overlays the terminal content.
+ * In Ink, we achieve this by rendering the modal as a separate Box that
+ * uses the full terminal width/height.
+ */
+import { Box, Text, useStdout } from 'ink';
+import type { ReactNode } from 'react';
+
+interface ModalProps {
+  /** Modal title displayed in the header */
+  title: string;
+  /** Content to display inside the modal */
+  children: ReactNode;
+  /** Hint text shown at the bottom (e.g., "Press u or Esc to close") */
+  hint?: string;
+}
+
+/**
+ * Modal overlay component
+ *
+ * Renders a centered bordered box. The parent component controls visibility
+ * by conditionally rendering the Modal.
+ */
+export function Modal({ title, children, hint }: ModalProps) {
+  const { stdout } = useStdout();
+  const terminalWidth = stdout?.columns ?? 80;
+
+  // Modal dimensions
+  const modalWidth = Math.min(50, terminalWidth - 4);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      paddingY={0}
+      width={modalWidth}
+    >
+      {/* Title bar */}
+      <Box justifyContent="center" marginBottom={1}>
+        <Text color="cyan" bold>{title}</Text>
+      </Box>
+
+      {/* Content */}
+      <Box flexDirection="column">
+        {children}
+      </Box>
+
+      {/* Hint at bottom */}
+      {hint && (
+        <Box justifyContent="center" marginTop={1}>
+          <Text dimColor>{hint}</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/components/UpdateModal.tsx
+++ b/src/ui/components/UpdateModal.tsx
@@ -1,0 +1,127 @@
+/**
+ * UpdateModal component - displays auto-update status in a modal overlay
+ *
+ * Shows different content based on the update status:
+ * - idle: "Up to date"
+ * - available: Shows new version available
+ * - scheduled: Shows scheduled restart time
+ * - installing: Shows installation in progress
+ * - pending_restart: Shows restart imminent
+ * - failed: Shows error message
+ * - deferred: Shows deferred until time
+ */
+import { Box, Text } from 'ink';
+import { Modal } from './Modal.js';
+import { Spinner } from './Spinner.js';
+import type { UpdatePanelState } from '../types.js';
+
+interface UpdateModalProps {
+  state: UpdatePanelState;
+}
+
+/**
+ * Format a date for display
+ */
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+/**
+ * Get status display info based on update state
+ */
+function getStatusDisplay(state: UpdatePanelState): {
+  icon: string;
+  label: string;
+  color: string;
+} {
+  switch (state.status) {
+    case 'idle':
+      return { icon: '✓', label: 'Up to date', color: 'green' };
+    case 'available':
+      return { icon: '🆕', label: 'Update available', color: 'green' };
+    case 'scheduled':
+      return { icon: '⏰', label: 'Restart scheduled', color: 'yellow' };
+    case 'installing':
+      return { icon: '📦', label: 'Installing...', color: 'cyan' };
+    case 'pending_restart':
+      return { icon: '🔄', label: 'Restarting...', color: 'yellow' };
+    case 'failed':
+      return { icon: '❌', label: 'Update failed', color: 'red' };
+    case 'deferred':
+      return { icon: '⏸️', label: 'Update deferred', color: 'gray' };
+    default:
+      return { icon: '?', label: 'Unknown', color: 'gray' };
+  }
+}
+
+/**
+ * Get the hint text based on update state
+ */
+function getHint(state: UpdatePanelState): string {
+  const canUpdate = state.status === 'available' || state.status === 'deferred';
+  if (canUpdate) {
+    return 'Press [Shift+U] to update now  |  [u] or [Esc] to close';
+  }
+  return 'Press [u] or [Esc] to close';
+}
+
+export function UpdateModal({ state }: UpdateModalProps) {
+  const statusDisplay = getStatusDisplay(state);
+  const hint = getHint(state);
+
+  return (
+    <Modal title="Update Status" hint={hint}>
+      {/* Version info */}
+      <Box flexDirection="column" gap={0}>
+        <Box>
+          <Text dimColor>Current version: </Text>
+          <Text bold>v{state.currentVersion}</Text>
+        </Box>
+
+        {state.latestVersion && state.latestVersion !== state.currentVersion && (
+          <Box>
+            <Text dimColor>Latest version:  </Text>
+            <Text bold color="green">v{state.latestVersion}</Text>
+          </Box>
+        )}
+      </Box>
+
+      {/* Status line */}
+      <Box marginTop={1}>
+        {state.status === 'installing' ? (
+          <Box gap={1}>
+            <Spinner type="dots" />
+            <Text color={statusDisplay.color}>{statusDisplay.label}</Text>
+          </Box>
+        ) : (
+          <Box gap={1}>
+            <Text>{statusDisplay.icon}</Text>
+            <Text color={statusDisplay.color}>{statusDisplay.label}</Text>
+          </Box>
+        )}
+      </Box>
+
+      {/* Additional info based on status */}
+      {state.status === 'scheduled' && state.scheduledRestartAt && (
+        <Box marginTop={1}>
+          <Text dimColor>Restart at: </Text>
+          <Text>{formatTime(state.scheduledRestartAt)}</Text>
+        </Box>
+      )}
+
+      {state.status === 'deferred' && state.deferredUntil && (
+        <Box marginTop={1}>
+          <Text dimColor>Deferred until: </Text>
+          <Text>{formatTime(state.deferredUntil)}</Text>
+        </Box>
+      )}
+
+      {state.status === 'failed' && state.errorMessage && (
+        <Box marginTop={1} flexDirection="column">
+          <Text color="red">Error:</Text>
+          <Text dimColor>{state.errorMessage}</Text>
+        </Box>
+      )}
+    </Modal>
+  );
+}

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -9,3 +9,5 @@ export { SessionLog } from './SessionLog.js';
 export { StatusLine } from './StatusLine.js';
 export { Spinner } from './Spinner.js';
 export { LogPanel } from './LogPanel.js';
+export { Modal } from './Modal.js';
+export { UpdateModal } from './UpdateModal.js';

--- a/src/ui/hooks/useKeyboard.ts
+++ b/src/ui/hooks/useKeyboard.ts
@@ -28,6 +28,10 @@ interface UseKeyboardOptions {
   onPermissionsToggle?: () => void;
   onChromeToggle?: () => void;
   onKeepAliveToggle?: () => void;
+  onUpdateModalToggle?: () => void;
+  onForceUpdate?: () => void;
+  // Modal state (for Escape key handling)
+  updateModalVisible?: boolean;
 }
 
 export function useKeyboard({
@@ -40,14 +44,28 @@ export function useKeyboard({
   onPermissionsToggle,
   onChromeToggle,
   onKeepAliveToggle,
+  onUpdateModalToggle,
+  onForceUpdate,
+  updateModalVisible,
 }: UseKeyboardOptions) {
   useInput((input, key) => {
+    // Escape key to close modal
+    if (key.escape && updateModalVisible) {
+      onUpdateModalToggle?.();
+      return;
+    }
     // Ctrl+C to quit - handle explicitly since Ink captures it in raw mode
     // Ctrl+C can appear as '\x03' (raw) or 'c' with key.ctrl
     if (input === '\x03' || (input === 'c' && key.ctrl)) {
       if (onQuit) {
         onQuit();
       }
+      return;
+    }
+
+    // Shift+U to force update
+    if (input === 'U') {
+      onForceUpdate?.();
       return;
     }
 
@@ -70,7 +88,7 @@ export function useKeyboard({
       }
     }
 
-    // Runtime toggles - d, p, c, k
+    // Runtime toggles - d, p, c, k, u
     switch (input.toLowerCase()) {
       case 'd':
         onDebugToggle?.();
@@ -83,6 +101,9 @@ export function useKeyboard({
         break;
       case 'k':
         onKeepAliveToggle?.();
+        break;
+      case 'u':
+        onUpdateModalToggle?.();
         break;
       case 'q':
         onQuit?.();

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -76,6 +76,7 @@ export async function startUI(options: StartUIOptions): Promise<UIInstance> {
     removeSession: handlers.removeSession,
     addLog: handlers.addLog,
     setPlatformStatus: handlers.setPlatformStatus,
+    setUpdateState: handlers.setUpdateState,
     waitUntilExit,
     getToggles: handlers.getToggles,
   };

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -54,6 +54,18 @@ export interface AppConfig {
 }
 
 /**
+ * Update panel state - tracks auto-update status for UI display
+ */
+export interface UpdatePanelState {
+  status: 'idle' | 'available' | 'scheduled' | 'installing' | 'pending_restart' | 'failed' | 'deferred';
+  currentVersion: string;
+  latestVersion?: string;
+  scheduledRestartAt?: Date;
+  errorMessage?: string;
+  deferredUntil?: Date;
+}
+
+/**
  * Runtime toggle state - can be changed via keyboard shortcuts
  */
 export interface ToggleState {
@@ -61,6 +73,7 @@ export interface ToggleState {
   skipPermissions: boolean;  // Default for new sessions
   chromeEnabled: boolean;    // Default for new sessions
   keepAliveEnabled: boolean;
+  updateModalVisible: boolean;  // Whether the update modal is shown
 }
 
 /**
@@ -72,6 +85,7 @@ export interface ToggleCallbacks {
   onChromeToggle?: (enabled: boolean) => void;
   onKeepAliveToggle?: (enabled: boolean) => void;
   onPlatformToggle?: (platformId: string, enabled: boolean) => void;
+  onForceUpdate?: () => void;
 }
 
 export interface AppState {
@@ -92,6 +106,7 @@ export interface UIInstance {
   removeSession: (sessionId: string) => void;
   addLog: (entry: Omit<LogEntry, 'id' | 'timestamp'>) => void;
   setPlatformStatus: (platformId: string, status: Partial<PlatformStatus>) => void;
+  setUpdateState: (state: UpdatePanelState) => void;
   waitUntilExit: () => Promise<void>;
   // Toggle state getters (for main logic to read current values)
   getToggles: () => ToggleState;


### PR DESCRIPTION
## Summary
- Add modal overlay for update status (press `u` to toggle)
- Add `Shift+U` keyboard shortcut to force immediate update
- Add `[u]pdate` indicator in StatusLine with color-coded status

## Changes
- New `Modal.tsx`: Generic reusable modal overlay component
- New `UpdateModal.tsx`: Update status display with dynamic hints
- Updated `useKeyboard.ts`: Handle `u`, `Escape`, and `Shift+U` keys
- Updated `StatusLine.tsx`: Show update status indicator
- Updated `types.ts`: Added `UpdatePanelState` interface
- Updated `App.tsx`: Integrated modal state and rendering
- Updated `index.ts`: Wired AutoUpdateManager events to UI

## Features
- Press `u` to show/hide update status modal
- Press `Escape` to close modal when open
- Press `Shift+U` to force update when available
- StatusLine shows color-coded `[u]pdate` indicator:
  - Green 🆕 when update available
  - Yellow 📦 when installing
  - Red ❌ when failed
  - Gray when idle/up-to-date

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 1038 tests pass (`bun test`)
- [ ] Manual test: press `u` to toggle modal
- [ ] Manual test: press `Escape` to close modal
- [ ] Manual test: press `Shift+U` when update available