### PR TITLE
fix: prevent duplicate task list posts in Slack

### DIFF
--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -218,6 +218,9 @@ export interface Session {
   // Last message posted to the thread (for jump-to-bottom links)
   lastMessageId?: string;
   lastMessageTs?: string;  // For Slack: timestamp of last message (needed for permalink)
+
+  // Task list creation lock (prevents duplicate posts from concurrent TodoWrite events)
+  taskListCreationPromise?: Promise<void>;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Fixes the issue where task lists appear twice in Slack threads
- Root cause: `handleEvent` doesn't await async handlers, allowing multiple concurrent `handleTodoWrite` calls to race and both create new task list posts
- Solution: Add a promise-based lock to prevent concurrent task list creation

## Changes
- Add `taskListCreationPromise` field to Session type for locking  
- Wait for any in-progress creation before proceeding in `handleTodoWrite`
- Set the promise lock before creating, release it after completion
- Add regression test for concurrent TodoWrite events

## Test plan
- [x] All existing tests pass (1039 tests)
- [x] New regression test verifies concurrent TodoWrite events only create one post
- [x] Build passes
- [ ] Manual testing in Slack to verify fix