### PR TITLE
feat: add emoji reactions for update now/defer

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -692,15 +692,22 @@ export async function showUpdateStatus(
     statusLine = `Mode: ${config.autoRestartMode}`;
   }
 
-  await postInfo(session,
+  const message =
     `🔄 ${formatter.formatBold('Update available')}\n\n` +
     `Current: v${updateInfo.currentVersion}\n` +
     `Latest: v${updateInfo.latestVersion}\n` +
     `${statusLine}\n\n` +
-    `Commands:\n` +
-    `• ${formatter.formatCode('!update now')} - Update immediately\n` +
-    `• ${formatter.formatCode('!update defer')} - Defer for 1 hour`
+    `React: 👍 Update now | 👎 Defer for 1 hour`;
+
+  // Create interactive post with reaction options
+  const post = await session.platform.createInteractivePost(
+    message,
+    [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0]],
+    session.threadId
   );
+
+  // Store pending update prompt for reaction handling
+  session.pendingUpdatePrompt = { postId: post.id };
 }
 
 /**

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -470,6 +470,25 @@ export class SessionManager extends EventEmitter {
       if (handled) return;
     }
 
+    // Handle update prompt reactions (only on add)
+    if (action === 'added' && session.pendingUpdatePrompt?.postId === postId) {
+      if (this.autoUpdateManager) {
+        const updateHandler: reactions.UpdateReactionHandler = {
+          forceUpdate: () => this.autoUpdateManager!.forceUpdate(),
+          deferUpdate: (minutes: number) => this.autoUpdateManager!.deferUpdate(minutes),
+        };
+        const handled = await reactions.handleUpdateReaction(
+          session,
+          postId,
+          emojiName,
+          username,
+          this.getContext(),
+          updateHandler
+        );
+        if (handled) return;
+      }
+    }
+
     // Handle context prompt reactions (only on add)
     if (action === 'added' && session.pendingContextPrompt?.postId === postId) {
       await this.handleContextPromptReaction(session, emojiName, username);

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -92,6 +92,13 @@ export interface PendingExistingWorktreePrompt {
   username: string;  // User who triggered the prompt
 }
 
+/**
+ * Pending update prompt asking user to update now or defer
+ */
+export interface PendingUpdatePrompt {
+  postId: string;
+}
+
 // =============================================================================
 // Session Type
 // =============================================================================
@@ -189,6 +196,9 @@ export interface Session {
   // Thread context prompt support
   pendingContextPrompt?: PendingContextPrompt; // Waiting for context selection
   needsContextPromptOnNextMessage?: boolean;   // Offer context prompt on next follow-up message (after !cd)
+
+  // Update prompt support
+  pendingUpdatePrompt?: PendingUpdatePrompt; // Waiting for user to confirm update now/defer
 
   // Resume support
   lifecyclePostId?: string;  // Post ID of timeout message (for resume via reaction)


### PR DESCRIPTION
## Summary
- The `!update` command now shows an interactive message with emoji reactions
- Users can tap 👍 to update immediately or 👎 to defer for 1 hour
- Much easier to respond on mobile than typing `!update now` or `!update defer`

## Changes
- Add `PendingUpdatePrompt` type and `pendingUpdatePrompt` field to Session
- Modify `showUpdateStatus()` to create interactive post with reactions
- Add `handleUpdateReaction()` handler in reactions.ts
- Wire up reaction handling in manager.ts

## Test plan
- [x] Added 9 new unit tests for `handleUpdateReaction`
- [x] All 1065 tests pass
- [x] Lint passes (0 errors)
- [ ] Manual test: run `!update` and verify emoji reactions appear
- [ ] Manual test: tap 👍 and verify update triggers
- [ ] Manual test: tap 👎 and verify update defers