### PR TITLE
fix: use bun instead of npm for auto-update installation

### DIFF
--- a/src/auto-update/installer.test.ts
+++ b/src/auto-update/installer.test.ts
@@ -161,7 +161,9 @@ describe('auto-update/installer', () => {
     it('returns rollback command with version', () => {
       const instructions = getRollbackInstructions('1.0.0');
 
-      expect(instructions).toContain('npm install -g claude-threads@1.0.0');
+      // Uses bun on non-Windows, npm on Windows
+      const expectedCmd = process.platform === 'win32' ? 'npm' : 'bun';
+      expect(instructions).toContain(`${expectedCmd} install -g claude-threads@1.0.0`);
     });
   });
 
@@ -217,7 +219,7 @@ describe('auto-update/installer', () => {
       });
     });
 
-    // Note: We don't test install() directly as it runs npm install -g
+    // Note: We don't test install() directly as it runs bun/npm install -g
     // which would actually modify the system. Integration tests would cover this.
   });
 });

--- a/src/auto-update/types.ts
+++ b/src/auto-update/types.ts
@@ -107,7 +107,7 @@ export type UpdateStatus =
   | 'idle'            // No update in progress
   | 'available'       // Update detected, waiting for right time
   | 'scheduled'       // Restart scheduled (countdown active)
-  | 'installing'      // npm install in progress
+  | 'installing'      // bun install in progress
   | 'pending_restart' // Install complete, waiting for restart
   | 'failed'          // Installation failed
   | 'deferred';       // User deferred the update

--- a/src/claude/version-check.ts
+++ b/src/claude/version-check.ts
@@ -65,7 +65,7 @@ export function validateClaudeCli(): {
       installed: false,
       version: null,
       compatible: false,
-      message: 'Claude CLI not found. Install it with: npm install -g @anthropic-ai/claude-code',
+      message: 'Claude CLI not found. Install it with: bun install -g @anthropic-ai/claude-code',
     };
   }
 
@@ -77,7 +77,7 @@ export function validateClaudeCli(): {
       version,
       compatible: false,
       message: `Claude CLI version ${version} is not compatible. Required: ${CLAUDE_CLI_VERSION_RANGE}\n` +
-        `Install a compatible version: npm install -g @anthropic-ai/claude-code@2.0.76`,
+        `Install a compatible version: bun install -g @anthropic-ai/claude-code@2.0.76`,
     };
   }
 

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -614,7 +614,7 @@ export async function updateSessionHeader(
   // Check for available updates
   const updateInfo = getUpdateInfo();
   const updateNotice = updateInfo
-    ? `\n> ⚠️ ${formatter.formatBold('Update available:')} v${updateInfo.current} → v${updateInfo.latest} - Run ${formatter.formatCode('npm install -g claude-threads')}\n`
+    ? `\n> ⚠️ ${formatter.formatBold('Update available:')} v${updateInfo.current} → v${updateInfo.latest} - Run ${formatter.formatCode('bun install -g claude-threads')}\n`
     : '';
 
   // Get "What's new" from release notes

--- a/src/update-notifier.ts
+++ b/src/update-notifier.ts
@@ -19,7 +19,7 @@ export function checkForUpdates(): void {
     // Show CLI notification
     notifier.notify({
       message: `Update available: {currentVersion} → {latestVersion}
-Run: npm install -g claude-threads`,
+Run: bun install -g claude-threads`,
     });
   } catch {
     // Silently fail - update checking is not critical


### PR DESCRIPTION
## Summary

- Fixed auto-update to use `bun install -g` instead of `npm install -g`
- Updated all user-facing install messages to reference bun
- Keeps npm fallback on Windows where bun may not be available

## Problem

The auto-update system was using `npm install -g` but the package is installed via bun (at `~/.bun/bin/claude-threads`). This caused updates to install to npm's global directory while the bot continued running from bun's install location, making updates appear successful but not actually take effect.

## Test plan

- [x] All 1057 unit tests pass
- [x] Lint and typecheck pass
- [ ] Manual test: run `!update now` and verify bot actually updates to new version