### PR TITLE
fix: shorten worktree paths in UI messages using [branch]/ format

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -29,6 +29,7 @@ import { createLogger } from '../utils/logger.js';
 import { formatPullRequestLink } from '../utils/pr-detector.js';
 import { getCurrentBranch, isGitRepository } from '../git/worktree.js';
 import { getClaudeCliVersion } from '../claude/version-check.js';
+import { shortenPath } from '../utils/tool-formatter.js';
 
 const log = createLogger('commands');
 
@@ -257,7 +258,11 @@ export async function changeDirectory(
     return;
   }
 
-  const shortDir = absoluteDir.replace(process.env.HOME || '', '~');
+  // Use worktree-aware path shortening if in a worktree
+  const worktreeContext = session.worktreeInfo
+    ? { path: session.worktreeInfo.worktreePath, branch: session.worktreeInfo.branch }
+    : undefined;
+  const shortDir = shortenPath(absoluteDir, undefined, worktreeContext);
   sessionLog(session).info(`📂 Changing directory to ${shortDir}`);
 
   // Update session working directory
@@ -506,8 +511,11 @@ export async function updateSessionHeader(
 
   const formatter = session.platform.getFormatter();
 
-  // Use session's working directory
-  const shortDir = session.workingDir.replace(process.env.HOME || '', '~');
+  // Use session's working directory (with worktree-aware shortening)
+  const worktreeContext = session.worktreeInfo
+    ? { path: session.worktreeInfo.worktreePath, branch: session.worktreeInfo.branch }
+    : undefined;
+  const shortDir = shortenPath(session.workingDir, undefined, worktreeContext);
   // Check session-level permission override
   const isInteractive = !ctx.config.skipPermissions || session.forceInteractivePermissions;
   const permMode = isInteractive ? '🔐 Interactive' : '⚡ Auto';

--- a/src/session/reactions.ts
+++ b/src/session/reactions.ts
@@ -17,6 +17,7 @@ import {
 import { postCurrentQuestion } from './events.js';
 import { withErrorHandling } from './error-handler.js';
 import { createLogger } from '../utils/logger.js';
+import { shortenPath } from '../utils/tool-formatter.js';
 
 const log = createLogger('reactions');
 
@@ -307,7 +308,7 @@ export async function handleExistingWorktreeReaction(
     return false;
   }
 
-  const shortPath = pending.worktreePath.replace(process.env.HOME || '', '~');
+  const shortPath = shortenPath(pending.worktreePath, undefined, { path: pending.worktreePath, branch: pending.branch });
 
   const formatter = session.platform.getFormatter();
 


### PR DESCRIPTION
## Summary
- Use `shortenPath` function to display worktree paths as `[branch]/` instead of full paths like `~/.claude-threads/worktrees/Users-user-project-abc`
- Updated worktree.ts, commands.ts, and reactions.ts to use worktree-aware path shortening
- Makes UI messages much more readable when working in git worktrees

## Test plan
- [x] Build passes
- [x] All 1065 unit tests pass
- [x] ESLint passes
- [x] `shortenPath` already has comprehensive test coverage in `tool-formatter.test.ts`