### PR TITLE
fix: use atomic lock acquisition to prevent duplicate task lists

### DIFF
--- a/src/session/events.test.ts
+++ b/src/session/events.test.ts
@@ -218,7 +218,7 @@ describe('handleEvent with TodoWrite', () => {
     expect(session.tasksCompleted).toBe(false);
   });
 
-  test('sets tasksCompleted=true when all tasks are completed', () => {
+  test('sets tasksCompleted=true when all tasks are completed', async () => {
     const event = {
       type: 'assistant' as const,
       message: {
@@ -241,10 +241,13 @@ describe('handleEvent with TodoWrite', () => {
 
     handleEvent(session, event, ctx);
 
+    // Wait for async lock acquisition and processing
+    await new Promise(resolve => setTimeout(resolve, 10));
+
     expect(session.tasksCompleted).toBe(true);
   });
 
-  test('sets tasksCompleted=true when todos array is empty', () => {
+  test('sets tasksCompleted=true when todos array is empty', async () => {
     session.tasksPostId = 'existing_tasks_post';
 
     const event = {
@@ -264,6 +267,9 @@ describe('handleEvent with TodoWrite', () => {
     };
 
     handleEvent(session, event, ctx);
+
+    // Wait for async lock acquisition and processing
+    await new Promise(resolve => setTimeout(resolve, 10));
 
     expect(session.tasksCompleted).toBe(true);
   });


### PR DESCRIPTION
## Summary

Fixes the duplicate task list bug that was still occurring in v0.47.0 despite the previous fix in PR #122.

**Root cause:** The previous promise-lock implementation had a classic "check-then-act" race condition. When `taskListCreationPromise` was checked and a new promise was created in separate operations, two concurrent calls could both see "no lock" and both proceed to create task list posts.

**The fix:** Introduces `acquireTaskListLock()` which uses an atomic lock pattern:
- Immediately chains a new promise onto any existing promise (this happens synchronously in JS's single-threaded event loop)
- Returns a release function after waiting for the lock
- Ensures callers are properly serialized even when called concurrently

## Changes

- Added `acquireTaskListLock()` function in `streaming.ts` with atomic lock acquisition
- Updated `bumpTasksToBottomWithContent()` to use the new atomic lock
- Updated `bumpTasksToBottom()` to use the new atomic lock  
- Updated `handleTodoWrite()` in `events.ts` to use the new atomic lock
- Added comprehensive tests for the atomic lock behavior

## Test plan

- [x] All existing tests pass (1075 pass, 0 fail)
- [x] Added new tests for `acquireTaskListLock` that verify:
  - Atomic lock acquisition prevents check-then-act race
  - Multiple concurrent locks are properly serialized
  - Lock release allows next caller to proceed
- [x] Build succeeds
- [x] Lint passes