### PR TITLE
fix: show dim indicator for disabled platforms instead of red

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,7 +351,7 @@ async function main() {
           client.disconnect();
           // Persist disabled state
           sessionStore.setPlatformEnabled(platformId, false);
-          ui.setPlatformStatus(platformId, { connected: false });
+          ui.setPlatformStatus(platformId, { connected: false, reconnecting: false });
           ui.addLog({ level: 'info', component: 'toggle', message: `✓ Platform ${platformId} disabled` });
         }
       },

--- a/src/ui/components/Platforms.tsx
+++ b/src/ui/components/Platforms.tsx
@@ -27,7 +27,9 @@ export function Platforms({ platforms }: PlatformsProps) {
           <Text>{getPlatformIcon(platform.platformType || 'mattermost')}</Text>
 
           {/* Connection status indicator */}
-          {platform.reconnecting ? (
+          {!platform.enabled ? (
+            <Text dimColor>○</Text>
+          ) : platform.reconnecting ? (
             <Text color="yellow">◌</Text>
           ) : platform.connected ? (
             <Text color="green">●</Text>
@@ -36,11 +38,11 @@ export function Platforms({ platforms }: PlatformsProps) {
           )}
 
           {/* Bot name */}
-          <Text color="cyan">@{platform.botName}</Text>
+          <Text color={platform.enabled ? "cyan" : undefined} dimColor={!platform.enabled}>@{platform.botName}</Text>
 
           {/* Platform display name */}
           <Text dimColor>on</Text>
-          <Text>{platform.displayName}</Text>
+          <Text dimColor={!platform.enabled}>{platform.displayName}</Text>
 
           {/* Reconnecting indicator with spinner */}
           {platform.reconnecting && (


### PR DESCRIPTION
## Summary

- Show a dim gray circle `○` for disabled platforms instead of red (which looked like an error state)
- Dim the bot name and display name when a platform is disabled
- Makes it visually clear that a platform is intentionally disabled, not failed

## Test plan

- [ ] Disable a platform with Shift+1 (or similar) and verify the indicator is gray/dim, not red
- [ ] Re-enable the platform and verify the indicator returns to green
- [ ] Verify reconnecting platforms still show yellow indicator with spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)