### PR TITLE
ci: add smoke test to verify binary starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,6 @@ jobs:
         run: |
           test -f dist/index.js
           test -f dist/mcp/permission-server.js
+
+      - name: Smoke test - verify binary starts
+        run: bun dist/index.js --help


### PR DESCRIPTION
## Summary
- Adds a smoke test step to CI that runs `bun dist/index.js --help` after build
- Catches runtime import errors and CLI issues that type checking alone might miss

## Test plan
- [x] Verify lint passes
- [x] Verify typecheck passes  
- [x] Verify unit tests pass
- [ ] CI workflow runs successfully