### PR TITLE
Remove continuation markers and improve code block handling

### DIFF
--- a/src/platform/slack/formatter.ts
+++ b/src/platform/slack/formatter.ts
@@ -31,7 +31,7 @@ export class SlackFormatter implements PlatformFormatter {
   formatCodeBlock(code: string, _language?: string): string {
     // Slack doesn't support language hints in code blocks well,
     // so we omit the language identifier
-    // NOTE: We add a trailing newline after the closing ``` to ensure proper
+    // NOTE: We add trailing newline after the closing ``` to ensure proper
     // rendering when followed by text. Without this, Slack may collapse
     // the text onto the same line as the code block closing.
     return `\`\`\`\n${code}\n\`\`\`\n`;


### PR DESCRIPTION
## Summary

- Remove "... (continued below)" marker from end of split messages
- Remove "(continued)" marker from start of continuation messages  
- Improve code block handling when splitting long messages

## Changes

When a message needs to be split and we're inside a code block:
- **Before**: Would close the code block with ` ``` ` in first message and reopen in continuation message, breaking the code block across two messages
- **After**: Splits BEFORE the code block starts, so the entire code block moves intact to the next message

If the code block starts at the very beginning of the message (can't split before it), we don't split at all and let the platform handle long message display (e.g., Mattermost's "Show More").

## Test plan

- [x] All existing tests pass (1142 tests)
- [x] Added tests for new code block splitting behavior
- [x] Build succeeds
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)