### PR TITLE
Fix Slack msg_too_long errors with safe message truncation

### DIFF
--- a/src/platform/utils.test.ts
+++ b/src/platform/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import {
   getPlatformIcon,
   truncateMessage,
+  truncateMessageSafely,
   splitMessage,
   extractMentions,
   isMentioned,
@@ -41,6 +42,60 @@ describe('truncateMessage', () => {
 
   it('truncates with ellipsis', () => {
     expect(truncateMessage('hello world', 8)).toBe('hello...');
+  });
+});
+
+describe('truncateMessageSafely', () => {
+  it('returns original if within limit', () => {
+    expect(truncateMessageSafely('hello', 100)).toBe('hello');
+  });
+
+  it('truncates with default indicator', () => {
+    const result = truncateMessageSafely('a'.repeat(200), 100);
+    expect(result).toContain('... (truncated)');
+    expect(result.length).toBeLessThanOrEqual(100);
+  });
+
+  it('uses custom truncation indicator', () => {
+    const result = truncateMessageSafely('a'.repeat(200), 100, '_truncated_');
+    expect(result).toContain('_truncated_');
+    expect(result.length).toBeLessThanOrEqual(100);
+  });
+
+  it('closes open code blocks when truncating', () => {
+    const content = '```javascript\nconst x = 1;\nconst y = 2;\n' + 'a'.repeat(200);
+    const result = truncateMessageSafely(content, 100);
+
+    // Count ``` markers - should be even (properly closed)
+    const markers = (result.match(/```/g) || []).length;
+    expect(markers % 2).toBe(0);
+    expect(result).toContain('... (truncated)');
+  });
+
+  it('does not add extra closing when code block is already closed', () => {
+    const content = '```javascript\nconst x = 1;\n```\n\nSome text after\n' + 'a'.repeat(200);
+    const result = truncateMessageSafely(content, 100);
+
+    // Count ``` markers - should be even (properly closed)
+    const markers = (result.match(/```/g) || []).length;
+    expect(markers % 2).toBe(0);
+  });
+
+  it('handles multiple code blocks with last one open', () => {
+    const content = '```js\ncode1\n```\n\nText\n\n```python\ncode2\n' + 'a'.repeat(200);
+    const result = truncateMessageSafely(content, 120);
+
+    // Count ``` markers - should be even (properly closed)
+    const markers = (result.match(/```/g) || []).length;
+    expect(markers % 2).toBe(0);
+  });
+
+  it('handles content with no code blocks', () => {
+    const content = 'Just plain text without any code blocks ' + 'a'.repeat(200);
+    const result = truncateMessageSafely(content, 100);
+
+    expect(result).not.toContain('```');
+    expect(result).toContain('... (truncated)');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `truncateMessageSafely()` helper that properly closes open code blocks when truncating
- Applies truncation at Slack client level (`createPost`/`updatePost`) as a safety net
- Applies truncation in `streaming.ts` for repurposed task posts
- Adds 7 comprehensive tests for the new truncation function

## Problem

Messages exceeding Slack's 12K character limit were causing `msg_too_long` API errors, particularly when repurposing task posts with long content. Additionally, truncating in the middle of a code block left malformed markdown.

## Solution

The fix works by:
1. Detecting if truncation happens inside a code block (counting ``` markers)
2. Properly closing the code block before adding the truncation indicator
3. Reserving space for closing markers and indicator text

## Test plan

- [x] All existing tests pass (1149 tests)
- [x] 7 new tests for `truncateMessageSafely()` covering edge cases
- [x] 100% function coverage, 99% line coverage for utils.ts
- [ ] Manual testing with Slack to verify long messages are properly truncated

🤖 Generated with [Claude Code](https://claude.ai/code)