### PR TITLE
fix: Persist sessions before update restart

### DIFF
--- a/src/auto-update/manager.test.ts
+++ b/src/auto-update/manager.test.ts
@@ -27,6 +27,7 @@ describe('auto-update/manager', () => {
       broadcastUpdate: mock((_msgBuilder: unknown) => Promise.resolve()),
       postAskMessage: mock(() => Promise.resolve()),
       refreshUI: mock(() => Promise.resolve()),
+      prepareForRestart: mock(() => Promise.resolve()),
     };
   });
 
@@ -253,6 +254,28 @@ describe('auto-update/manager', () => {
         await manager.checkNow();
 
         expect(emittedStatus).toBe('available');
+        manager.stop();
+      });
+    });
+
+    describe('forceUpdate()', () => {
+      it('returns early when no update is available', async () => {
+        // Mock fetch to return no update
+        globalThis.fetch = mockFetch(() =>
+          Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ version: '0.0.1' }),
+          } as Response)
+        );
+
+        const manager = new AutoUpdateManager(config, callbacks);
+
+        // Should not throw, just return early
+        await manager.forceUpdate();
+
+        // prepareForRestart should NOT have been called
+        expect(callbacks.prepareForRestart).not.toHaveBeenCalled();
+
         manager.stop();
       });
     });

--- a/src/auto-update/manager.ts
+++ b/src/auto-update/manager.ts
@@ -44,6 +44,9 @@ export interface AutoUpdateCallbacks {
 
   /** Trigger UI update (sticky message, status bar, etc.) */
   refreshUI: () => Promise<void>;
+
+  /** Prepare for restart (persist sessions, disconnect platforms) */
+  prepareForRestart: () => Promise<void>;
 }
 
 /**
@@ -273,6 +276,9 @@ export class AutoUpdateManager extends EventEmitter {
 
       // Give a moment for the message to be sent
       await new Promise(resolve => setTimeout(resolve, 1000));
+
+      // Prepare for restart (persist sessions, disconnect platforms)
+      await this.callbacks.prepareForRestart();
 
       // Exit with special code to signal restart needed
       log.info(`🔄 Restarting for update to v${updateInfo.latestVersion}`);


### PR DESCRIPTION
## Summary

- **Fixed session loss on update** - When `!update now` was triggered, sessions were not persisted before restart, causing them to be lost

## Problem

The update flow called `process.exit(RESTART_EXIT_CODE)` directly in `performUpdate()` without going through the proper shutdown sequence. The normal shutdown flow sets `isShuttingDown = true` which triggers session persistence in `handleExit()`, but the update flow bypassed this entirely.

## Solution

Added a `prepareForRestart` callback to `AutoUpdateCallbacks` that:
1. Sets the shutdown flag to preserve session persistence
2. Calls `killAllSessions()` which persists sessions due to the shutdown flag
3. Disconnects platforms cleanly

The callback is invoked by `performUpdate()` before `process.exit()`, ensuring sessions are saved to disk.

## Test plan

- [x] All 1173 unit tests pass
- [x] Added test for `forceUpdate()` returns early when no update available
- [ ] Manual test: Start bot with active session, run `!update now`, verify session resumes after restart

🤖 Generated with [Claude Code](https://claude.ai/code)