### PR TITLE
feat: Add sticky plan approval message

### DIFF
--- a/src/session/commands.test.ts
+++ b/src/session/commands.test.ts
@@ -148,6 +148,7 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
       registerWorktreeUser: mock(() => {}),
       unregisterWorktreeUser: mock(() => {}),
       hasOtherSessionsUsingWorktree: mock(() => false),
+      bumpAllStickyPosts: mock(async () => {}),
     },
   };
 }

--- a/src/session/context.ts
+++ b/src/session/context.ts
@@ -118,6 +118,9 @@ export interface SessionOperations {
   /** Move task list to bottom of thread */
   bumpTasksToBottom(session: Session): Promise<void>;
 
+  /** Bump all sticky posts (plan approval, task list) to bottom in correct order */
+  bumpAllStickyPosts(session: Session): Promise<void>;
+
   // ---------------------------------------------------------------------------
   // Persistence
   // ---------------------------------------------------------------------------

--- a/src/session/events.test.ts
+++ b/src/session/events.test.ts
@@ -153,6 +153,7 @@ function createSessionContext(): SessionContext {
       registerWorktreeUser: mock(() => {}),
       unregisterWorktreeUser: mock(() => {}),
       hasOtherSessionsUsingWorktree: mock(() => false),
+      bumpAllStickyPosts: mock(async () => {}),
     },
   };
 }

--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -18,8 +18,8 @@ import {
 import {
   shouldFlushEarly,
   MIN_BREAK_THRESHOLD,
-  acquireTaskListLock,
 } from './streaming.js';
+import { acquireStickyLock } from './sticky-thread.js';
 import { withErrorHandling } from './error-handler.js';
 import { resetSessionActivity, updateLastMessage } from './post-helpers.js';
 import type { SessionContext } from './context.js';
@@ -518,9 +518,10 @@ async function handleExitPlanMode(
   session.currentPostId = null;
   session.pendingContent = '';
 
-  // Post approval message with reactions
+  // Build approval message with horizontal rule for visual separation
   const formatter = session.platform.getFormatter();
   const message =
+    `${formatter.formatHorizontalRule()}\n` +
     `✅ ${formatter.formatBold('Plan ready for approval')}\n\n` +
     `👍 Approve and start building\n` +
     `👎 Request changes\n\n` +
@@ -540,7 +541,8 @@ async function handleExitPlanMode(
   // Track this for reaction handling
   // Note: toolUseId is stored but not used - Claude Code CLI handles ExitPlanMode internally,
   // so we send a user message instead of a tool_result when the user approves
-  session.pendingApproval = { postId: post.id, type: 'plan', toolUseId };
+  // Store content for recreation when bumping to keep approval at bottom
+  session.pendingApproval = { postId: post.id, type: 'plan', toolUseId, content: message };
 
   // Stop typing while waiting
   ctx.ops.stopTyping(session);
@@ -566,7 +568,7 @@ async function handleTodoWrite(
   // Acquire the lock atomically at the start - this prevents race conditions
   // where multiple concurrent calls could both see tasksPostId as null and
   // both proceed to create task posts.
-  const releaseLock = await acquireTaskListLock(session);
+  const releaseLock = await acquireStickyLock(session);
 
   try {
     await handleTodoWriteWithLock(session, input, ctx);

--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -17,3 +17,15 @@ export type { PendingContextPrompt } from './context-prompt.js';
 // Pending prompts utilities (reusable for displaying pending states)
 export type { PendingPrompt } from './sticky-message.js';
 export { getPendingPrompts, formatPendingPrompts } from './sticky-message.js';
+
+// Sticky thread utilities (for task list and plan approval management)
+export {
+  bumpTasksToBottom,
+  bumpTasksToBottomWithContent,
+  bumpPlanApprovalToBottom,
+  bumpAllStickyPosts,
+  hasActiveStickyPosts,
+  hasActiveTasks,
+  acquireStickyLock,
+  acquireTaskListLock, // Backward compatibility alias
+} from './sticky-thread.js';

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -137,6 +137,7 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
       registerWorktreeUser: mock(() => {}),
       unregisterWorktreeUser: mock(() => {}),
       hasOtherSessionsUsingWorktree: mock(() => false),
+      bumpAllStickyPosts: mock(async () => {}),
     },
   };
 }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -35,6 +35,7 @@ import {
 
 // Import extracted modules
 import * as streaming from './streaming.js';
+import * as stickyThread from './sticky-thread.js';
 import * as events from './events.js';
 import * as reactions from './reactions.js';
 import * as commands from './commands.js';
@@ -247,6 +248,7 @@ export class SessionManager extends EventEmitter {
       stopTyping: (s) => this.stopTyping(s),
       buildMessageContent: (t, p, f) => this.buildMessageContent(t, p, f),
       bumpTasksToBottom: (s) => this.bumpTasksToBottom(s),
+      bumpAllStickyPosts: (s) => this.bumpAllStickyPosts(s),
 
       // Persistence
       persistSession: (s) => this.persistSession(s),
@@ -632,7 +634,11 @@ export class SessionManager extends EventEmitter {
   }
 
   private async bumpTasksToBottom(session: Session): Promise<void> {
-    return streaming.bumpTasksToBottom(session, (pid, tid) => this.registerPost(pid, tid));
+    return stickyThread.bumpTasksToBottom(session, (pid, tid) => this.registerPost(pid, tid));
+  }
+
+  private async bumpAllStickyPosts(session: Session): Promise<void> {
+    return stickyThread.bumpAllStickyPosts(session, (pid, tid) => this.registerPost(pid, tid));
   }
 
   // ---------------------------------------------------------------------------

--- a/src/session/reactions.test.ts
+++ b/src/session/reactions.test.ts
@@ -174,6 +174,7 @@ function createMockContext(): SessionContext {
       registerWorktreeUser: mock(() => {}),
       unregisterWorktreeUser: mock(() => {}),
       hasOtherSessionsUsingWorktree: mock(() => false),
+      bumpAllStickyPosts: mock(async () => {}),
     },
   };
 }

--- a/src/session/sticky-thread.test.ts
+++ b/src/session/sticky-thread.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Tests for sticky-thread.ts - thread-level sticky post management
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import type { Session } from './types.js';
+import type { PlatformClient, PlatformPost } from '../platform/index.js';
+import {
+  acquireStickyLock,
+  bumpPlanApprovalToBottom,
+  bumpTasksToBottom,
+  bumpTasksToBottomWithContent,
+  bumpAllStickyPosts,
+  hasActiveStickyPosts,
+  hasActiveTasks,
+  getTaskDisplayContent,
+  getMinimizedTaskContent,
+} from './sticky-thread.js';
+
+// Helper to create a mock platform
+function createMockPlatform(): PlatformClient {
+  let postCounter = 0;
+  return {
+    createPost: mock(async (_content: string, threadId: string): Promise<PlatformPost> => ({
+      id: `post_${++postCounter}`,
+      platformId: 'test-platform',
+      channelId: 'channel1',
+      userId: 'bot',
+      message: _content,
+      rootId: threadId,
+      createAt: Date.now(),
+    })),
+    createInteractivePost: mock(async (_content: string, _reactions: string[], threadId: string): Promise<PlatformPost> => ({
+      id: `post_${++postCounter}`,
+      platformId: 'test-platform',
+      channelId: 'channel1',
+      userId: 'bot',
+      message: _content,
+      rootId: threadId,
+      createAt: Date.now(),
+    })),
+    updatePost: mock(async () => {}),
+    deletePost: mock(async () => {}),
+    pinPost: mock(async () => {}),
+    unpinPost: mock(async () => {}),
+    addReaction: mock(async () => {}),
+    removeReaction: mock(async () => {}),
+    getFormatter: () => ({
+      formatBold: (text: string) => `**${text}**`,
+      formatItalic: (text: string) => `_${text}_`,
+      formatCode: (text: string) => `\`${text}\``,
+      formatCodeBlock: (text: string, lang?: string) => `\`\`\`${lang || ''}\n${text}\n\`\`\``,
+      formatUserMention: (username: string) => `@${username}`,
+      formatHorizontalRule: () => '---',
+      formatMarkdown: (text: string) => text,
+      formatLink: (text: string, url: string) => `[${text}](${url})`,
+    }),
+    getMessageLimits: () => ({
+      maxLength: 16000,
+      softThreshold: 6000,
+      hardThreshold: 12000,
+    }),
+  } as unknown as PlatformClient;
+}
+
+// Helper to create a test session
+function createTestSession(platform: PlatformClient): Session {
+  return {
+    platformId: 'test-platform',
+    threadId: 'thread1',
+    sessionId: 'test-platform:thread1',
+    claudeSessionId: 'claude-123',
+    startedBy: 'testuser',
+    startedAt: new Date(),
+    lastActivityAt: new Date(),
+    sessionNumber: 1,
+    platform,
+    workingDir: '/test',
+    claude: {} as Session['claude'],
+    currentPostId: null,
+    currentPostContent: '',
+    pendingContent: '',
+    pendingApproval: null,
+    pendingQuestionSet: null,
+    pendingMessageApproval: null,
+    planApproved: false,
+    sessionAllowedUsers: new Set(['testuser']),
+    forceInteractivePermissions: false,
+    sessionStartPostId: null,
+    tasksPostId: null,
+    lastTasksContent: null,
+    tasksCompleted: false,
+    tasksMinimized: false,
+    activeSubagents: new Map(),
+    updateTimer: null,
+    typingTimer: null,
+    timeoutWarningPosted: false,
+    isRestarting: false,
+    isResumed: false,
+    resumeFailCount: 0,
+    wasInterrupted: false,
+    hasClaudeResponded: false,
+    inProgressTaskStart: null,
+    activeToolStarts: new Map(),
+    messageCount: 0,
+    isProcessing: false,
+    statusBarTimer: null,
+  };
+}
+
+describe('acquireStickyLock', () => {
+  let session: Session;
+  let platform: PlatformClient;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+  });
+
+  test('returns release function immediately when no lock exists', async () => {
+    const release = await acquireStickyLock(session);
+    expect(typeof release).toBe('function');
+    release();
+  });
+
+  test('serializes concurrent calls', async () => {
+    const order: number[] = [];
+
+    // Start first lock
+    const release1Promise = acquireStickyLock(session);
+    const release1 = await release1Promise;
+    order.push(1);
+
+    // Start second lock (should wait)
+    const release2Promise = acquireStickyLock(session);
+
+    // First lock still held, second should be waiting
+    setTimeout(() => {
+      order.push(2);
+      release1();
+    }, 10);
+
+    const release2 = await release2Promise;
+    order.push(3);
+    release2();
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  test('sets both stickyPostLock and taskListCreationPromise for compatibility', async () => {
+    const release = await acquireStickyLock(session);
+    expect(session.stickyPostLock).toBeDefined();
+    expect(session.taskListCreationPromise).toBeDefined();
+    release();
+  });
+});
+
+describe('hasActiveTasks', () => {
+  let session: Session;
+  let platform: PlatformClient;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+  });
+
+  test('returns false when no task post', () => {
+    expect(hasActiveTasks(session)).toBe(false);
+  });
+
+  test('returns false when no task content', () => {
+    session.tasksPostId = 'task_post';
+    expect(hasActiveTasks(session)).toBe(false);
+  });
+
+  test('returns false when tasks completed', () => {
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = 'content';
+    session.tasksCompleted = true;
+    expect(hasActiveTasks(session)).toBe(false);
+  });
+
+  test('returns true when active tasks exist', () => {
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = 'content';
+    session.tasksCompleted = false;
+    expect(hasActiveTasks(session)).toBe(true);
+  });
+});
+
+describe('hasActiveStickyPosts', () => {
+  let session: Session;
+  let platform: PlatformClient;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+  });
+
+  test('returns false when no sticky posts', () => {
+    expect(hasActiveStickyPosts(session)).toBe(false);
+  });
+
+  test('returns true when plan approval pending', () => {
+    session.pendingApproval = {
+      postId: 'plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      content: 'Plan content',
+    };
+    expect(hasActiveStickyPosts(session)).toBe(true);
+  });
+
+  test('returns true when active tasks exist', () => {
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = 'content';
+    expect(hasActiveStickyPosts(session)).toBe(true);
+  });
+
+  test('returns true when both exist', () => {
+    session.pendingApproval = {
+      postId: 'plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      content: 'Plan content',
+    };
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = 'content';
+    expect(hasActiveStickyPosts(session)).toBe(true);
+  });
+
+  test('returns false when plan approval has no content', () => {
+    session.pendingApproval = {
+      postId: 'plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      // No content - can't bump
+    };
+    expect(hasActiveStickyPosts(session)).toBe(false);
+  });
+});
+
+describe('bumpPlanApprovalToBottom', () => {
+  let session: Session;
+  let platform: PlatformClient;
+  let registerPost: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+    registerPost = mock(() => {});
+  });
+
+  test('does nothing when no pending approval', async () => {
+    await bumpPlanApprovalToBottom(session, registerPost);
+    expect(platform.deletePost).not.toHaveBeenCalled();
+    expect(platform.createInteractivePost).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when approval type is not plan', async () => {
+    session.pendingApproval = {
+      postId: 'action_post',
+      type: 'action',
+      toolUseId: 'tool1',
+      content: 'content',
+    };
+    await bumpPlanApprovalToBottom(session, registerPost);
+    expect(platform.deletePost).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when no content stored', async () => {
+    session.pendingApproval = {
+      postId: 'plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      // No content
+    };
+    await bumpPlanApprovalToBottom(session, registerPost);
+    expect(platform.deletePost).not.toHaveBeenCalled();
+  });
+
+  test('bumps plan approval to bottom', async () => {
+    session.pendingApproval = {
+      postId: 'old_plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      content: 'Plan approval content',
+    };
+
+    await bumpPlanApprovalToBottom(session, registerPost);
+
+    // Should delete old post
+    expect(platform.deletePost).toHaveBeenCalledWith('old_plan_post');
+    // Should create new post with same content
+    expect(platform.createInteractivePost).toHaveBeenCalledWith(
+      'Plan approval content',
+      expect.any(Array),
+      'thread1'
+    );
+    // Should update postId
+    expect(session.pendingApproval?.postId).toBe('post_1');
+    // Should register new post
+    expect(registerPost).toHaveBeenCalledWith('post_1', 'thread1');
+  });
+});
+
+describe('bumpTasksToBottom', () => {
+  let session: Session;
+  let platform: PlatformClient;
+  let registerPost: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+    registerPost = mock(() => {});
+  });
+
+  test('does nothing when no task post', async () => {
+    await bumpTasksToBottom(session, registerPost);
+    expect(platform.deletePost).not.toHaveBeenCalled();
+  });
+
+  test('does nothing when tasks completed', async () => {
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = 'content';
+    session.tasksCompleted = true;
+    await bumpTasksToBottom(session, registerPost);
+    expect(platform.deletePost).not.toHaveBeenCalled();
+  });
+
+  test('bumps task list to bottom', async () => {
+    session.tasksPostId = 'old_task_post';
+    session.lastTasksContent = '📋 **Tasks** (0/1 · 0%)\n○ Do something';
+
+    await bumpTasksToBottom(session, registerPost);
+
+    // Should unpin and delete old post
+    expect(platform.unpinPost).toHaveBeenCalledWith('old_task_post');
+    expect(platform.deletePost).toHaveBeenCalledWith('old_task_post');
+    // Should create new post
+    expect(platform.createInteractivePost).toHaveBeenCalled();
+    // Should update tasksPostId
+    expect(session.tasksPostId).toBe('post_1');
+    // Should pin new post
+    expect(platform.pinPost).toHaveBeenCalledWith('post_1');
+    // Should register new post
+    expect(registerPost).toHaveBeenCalledWith('post_1', 'thread1');
+  });
+});
+
+describe('bumpTasksToBottomWithContent', () => {
+  let session: Session;
+  let platform: PlatformClient;
+  let registerPost: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+    registerPost = mock(() => {});
+  });
+
+  test('repurposes task post for new content', async () => {
+    session.tasksPostId = 'old_task_post';
+    session.lastTasksContent = '📋 **Tasks** (0/1 · 0%)\n○ Do something';
+
+    const newPostId = await bumpTasksToBottomWithContent(session, 'New content', registerPost);
+
+    // Should return old task post id (repurposed)
+    expect(newPostId).toBe('old_task_post');
+    // Should update old post with new content
+    expect(platform.updatePost).toHaveBeenCalledWith('old_task_post', 'New content');
+    // Should remove toggle emoji from repurposed post
+    expect(platform.removeReaction).toHaveBeenCalled();
+    // Should create new task post at bottom
+    expect(platform.createInteractivePost).toHaveBeenCalled();
+    // Should update tasksPostId to new post
+    expect(session.tasksPostId).toBe('post_1');
+  });
+});
+
+describe('bumpAllStickyPosts', () => {
+  let session: Session;
+  let platform: PlatformClient;
+  let registerPost: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+    registerPost = mock(() => {});
+  });
+
+  test('does nothing when no sticky posts', async () => {
+    await bumpAllStickyPosts(session, registerPost);
+    expect(platform.deletePost).not.toHaveBeenCalled();
+    expect(platform.createInteractivePost).not.toHaveBeenCalled();
+  });
+
+  test('bumps only plan approval when no tasks', async () => {
+    session.pendingApproval = {
+      postId: 'plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      content: 'Plan content',
+    };
+
+    await bumpAllStickyPosts(session, registerPost);
+
+    // Should bump plan approval
+    expect(platform.deletePost).toHaveBeenCalledWith('plan_post');
+    expect(platform.createInteractivePost).toHaveBeenCalledTimes(1);
+  });
+
+  test('bumps only tasks when no plan approval', async () => {
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = '📋 **Tasks** (0/1 · 0%)\n○ Do something';
+
+    await bumpAllStickyPosts(session, registerPost);
+
+    // Should bump task list
+    expect(platform.deletePost).toHaveBeenCalledWith('task_post');
+    expect(platform.createInteractivePost).toHaveBeenCalledTimes(1);
+  });
+
+  test('bumps plan approval before task list', async () => {
+    const deleteOrder: string[] = [];
+    (platform.deletePost as ReturnType<typeof mock>).mockImplementation(async (postId: string) => {
+      deleteOrder.push(postId);
+    });
+
+    session.pendingApproval = {
+      postId: 'plan_post',
+      type: 'plan',
+      toolUseId: 'tool1',
+      content: 'Plan content',
+    };
+    session.tasksPostId = 'task_post';
+    session.lastTasksContent = '📋 **Tasks** (0/1 · 0%)\n○ Do something';
+
+    await bumpAllStickyPosts(session, registerPost);
+
+    // Plan should be bumped first, then tasks
+    expect(deleteOrder).toEqual(['plan_post', 'task_post']);
+  });
+});
+
+describe('getTaskDisplayContent', () => {
+  let session: Session;
+  let platform: PlatformClient;
+
+  beforeEach(() => {
+    platform = createMockPlatform();
+    session = createTestSession(platform);
+  });
+
+  test('returns empty string when no content', () => {
+    expect(getTaskDisplayContent(session)).toBe('');
+  });
+
+  test('returns full content when not minimized', () => {
+    session.lastTasksContent = '📋 **Tasks** (0/1 · 0%)\n○ Do something';
+    session.tasksMinimized = false;
+    expect(getTaskDisplayContent(session)).toBe('📋 **Tasks** (0/1 · 0%)\n○ Do something');
+  });
+
+  test('returns minimized content when minimized', () => {
+    session.lastTasksContent = '📋 **Tasks** (1/2 · 50%)\n✓ Done\n🔄 **In progress**';
+    session.tasksMinimized = true;
+    const result = getTaskDisplayContent(session);
+    expect(result).toContain('📋');
+    expect(result).toContain('(1/2 · 50%)');
+    expect(result).toContain('🔽');
+  });
+});
+
+describe('getMinimizedTaskContent', () => {
+  test('extracts progress from content', () => {
+    const formatter = {
+      formatHorizontalRule: () => '---',
+      formatBold: (text: string) => `**${text}**`,
+    };
+    const content = '📋 **Tasks** (3/5 · 60%)\n✓ Task 1\n✓ Task 2\n✓ Task 3\n○ Task 4\n○ Task 5';
+    const result = getMinimizedTaskContent(content, formatter as ReturnType<PlatformClient['getFormatter']>);
+    expect(result).toContain('(3/5 · 60%)');
+    expect(result).toContain('🔽');
+  });
+
+  test('includes current task name', () => {
+    const formatter = {
+      formatHorizontalRule: () => '---',
+      formatBold: (text: string) => `**${text}**`,
+    };
+    const content = '📋 **Tasks** (1/3 · 33%)\n✓ Done\n🔄 **Working on this** (45s)\n○ Next';
+    const result = getMinimizedTaskContent(content, formatter as ReturnType<PlatformClient['getFormatter']>);
+    expect(result).toContain('Working on this');
+    expect(result).toContain('(45s)');
+  });
+});

--- a/src/session/sticky-thread.ts
+++ b/src/session/sticky-thread.ts
@@ -1,0 +1,412 @@
+/**
+ * Thread-level sticky post management
+ *
+ * Manages posts that should stay at the bottom of a thread:
+ * - Plan approval: Just above task list while pending
+ * - Task list: Always at the very bottom while not completed
+ *
+ * Order (bottom to top): [content] [plan approval] [task list]
+ */
+
+import type { PlatformFormatter } from '../platform/index.js';
+import type { Session } from './types.js';
+import { TASK_TOGGLE_EMOJIS, APPROVAL_EMOJIS, DENIAL_EMOJIS } from '../utils/emoji.js';
+import { withErrorHandling } from './error-handler.js';
+import { updateLastMessage } from './post-helpers.js';
+import { createLogger } from '../utils/logger.js';
+import { truncateMessageSafely } from '../platform/utils.js';
+
+const log = createLogger('sticky-thread');
+
+/** Get session-scoped logger for routing to correct UI panel */
+function sessionLog(session: Session) {
+  return log.forSession(session.sessionId);
+}
+
+// ---------------------------------------------------------------------------
+// Lock management
+// ---------------------------------------------------------------------------
+
+/**
+ * Acquire the sticky post lock in an atomic manner.
+ *
+ * This function solves the race condition where multiple concurrent calls
+ * could both see the lock as undefined and both proceed to modify sticky posts.
+ * By chaining the new promise onto the existing one (or creating a new chain
+ * if none exists) in a single synchronous operation, we ensure that all
+ * callers properly serialize their access.
+ *
+ * The key insight is that in JavaScript's event loop, synchronous code runs
+ * atomically (no interleaving). By immediately setting the new promise in
+ * the same synchronous block where we check for existing promises, we prevent
+ * the race condition where two callers both see "no lock" simultaneously.
+ *
+ * @param session - The session to acquire the lock for
+ * @returns A promise that resolves to a release function when the lock is acquired
+ */
+export async function acquireStickyLock(session: Session): Promise<() => void> {
+  let resolveCreation: (() => void) | undefined;
+
+  // Create a new promise that will be resolved when the caller releases the lock
+  const newPromise = new Promise<void>((resolve) => {
+    resolveCreation = resolve;
+  });
+
+  // Get the existing promise (may be undefined)
+  // Support both old and new field names for backward compatibility
+  const existingPromise = session.stickyPostLock ?? session.taskListCreationPromise;
+
+  // CRITICAL: This is the atomic part - we immediately set the new promise
+  // so any subsequent callers will see it and wait on it.
+  // We chain onto the existing promise (if any) so operations serialize.
+  const chainedPromise = existingPromise
+    ? existingPromise.then(() => newPromise)
+    : newPromise;
+
+  // Set both fields for compatibility
+  session.stickyPostLock = chainedPromise;
+  session.taskListCreationPromise = chainedPromise;
+
+  // Wait for our turn (if there was an existing promise, wait for it)
+  if (existingPromise) {
+    await existingPromise;
+  }
+
+  // Now we have the lock - return the release function
+  return () => {
+    if (resolveCreation) {
+      resolveCreation();
+    }
+    // Note: we don't clear the lock here because other callers may have
+    // already chained onto it. The promise chain will naturally resolve
+    // and eventually be garbage collected.
+  };
+}
+
+// Backward compatibility alias
+export { acquireStickyLock as acquireTaskListLock };
+
+// ---------------------------------------------------------------------------
+// Task display helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the minimized task list message from the full content.
+ * Format: "---\n📋 **Tasks** (X/Y · Z%) · 🔄 TaskName 🔽"
+ */
+export function getMinimizedTaskContent(fullContent: string, formatter: PlatformFormatter): string {
+  // Parse progress from content (format: "📋 **Tasks** (X/Y · Z%)")
+  const progressMatch = fullContent.match(/\((\d+)\/(\d+) · (\d+)%\)/);
+  const completed = progressMatch ? parseInt(progressMatch[1], 10) : 0;
+  const total = progressMatch ? parseInt(progressMatch[2], 10) : 0;
+  const pct = progressMatch ? parseInt(progressMatch[3], 10) : 0;
+
+  // Find current in-progress task
+  // Match both ** (Mattermost) and * (Slack) bold formatting
+  const inProgressMatch = fullContent.match(/🔄 \*{1,2}([^*]+)\*{1,2}(?:\s*\((\d+)s\))?/);
+  let currentTaskText = '';
+  if (inProgressMatch) {
+    const taskName = inProgressMatch[1];
+    const elapsed = inProgressMatch[2] ? ` (${inProgressMatch[2]}s)` : '';
+    currentTaskText = ` · 🔄 ${taskName}${elapsed}`;
+  }
+
+  return `${formatter.formatHorizontalRule()}\n📋 ${formatter.formatBold('Tasks')} (${completed}/${total} · ${pct}%)${currentTaskText} 🔽`;
+}
+
+/**
+ * Get the task content to display based on minimized state.
+ * If minimized, returns the compact summary; otherwise the full content.
+ */
+export function getTaskDisplayContent(session: Session): string {
+  if (!session.lastTasksContent) {
+    return '';
+  }
+  const formatter = session.platform.getFormatter();
+  return session.tasksMinimized
+    ? getMinimizedTaskContent(session.lastTasksContent, formatter)
+    : session.lastTasksContent;
+}
+
+// ---------------------------------------------------------------------------
+// Plan approval bumping
+// ---------------------------------------------------------------------------
+
+/**
+ * Bump the plan approval message to the bottom of the thread.
+ *
+ * Call this when new content is posted to keep the plan approval prompt
+ * visible at the bottom while it's pending.
+ *
+ * @param session - The session
+ * @param registerPost - Callback to register the new post for reaction routing
+ */
+export async function bumpPlanApprovalToBottom(
+  session: Session,
+  registerPost: (postId: string, threadId: string) => void
+): Promise<void> {
+  // Early exit if no pending plan approval
+  if (!session.pendingApproval || session.pendingApproval.type !== 'plan') {
+    return;
+  }
+
+  // Need content to recreate the post
+  if (!session.pendingApproval.content) {
+    sessionLog(session).debug('No plan approval content stored, cannot bump');
+    return;
+  }
+
+  // Acquire the lock atomically
+  const releaseLock = await acquireStickyLock(session);
+
+  try {
+    // Re-check after acquiring lock (state may have changed)
+    if (!session.pendingApproval || session.pendingApproval.type !== 'plan') {
+      return;
+    }
+
+    const oldPostId = session.pendingApproval.postId;
+    const content = session.pendingApproval.content;
+
+    sessionLog(session).debug(`Bumping plan approval: deleting old post ${oldPostId.substring(0, 8)}`);
+
+    // Delete the old post
+    await session.platform.deletePost(oldPostId);
+
+    // Create new post at bottom with the same content and reactions
+    const newPost = await session.platform.createInteractivePost(
+      content,
+      [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0]],
+      session.threadId
+    );
+
+    // Update the post ID
+    session.pendingApproval.postId = newPost.id;
+    sessionLog(session).debug(`Created new plan approval post ${newPost.id.substring(0, 8)}`);
+
+    // Register for reaction routing
+    registerPost(newPost.id, session.threadId);
+
+    // Track for jump-to-bottom links
+    updateLastMessage(session, newPost);
+  } catch (err) {
+    sessionLog(session).error(`Failed to bump plan approval: ${err}`);
+  } finally {
+    releaseLock();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task list bumping
+// ---------------------------------------------------------------------------
+
+/**
+ * Bump the task list to the bottom by reusing its post for new content.
+ *
+ * When we need to create a new post and a task list exists, we:
+ * 1. Update the task list post with the new content (repurposing it)
+ * 2. Create a fresh task list post at the bottom
+ *
+ * This keeps the task list visually at the bottom without deleting messages.
+ *
+ * @param session - The session
+ * @param newContent - Content to put in the repurposed post
+ * @param registerPost - Callback to register post for reaction routing
+ * @returns The post ID that now contains the content (was the task list post)
+ */
+export async function bumpTasksToBottomWithContent(
+  session: Session,
+  newContent: string,
+  registerPost: (postId: string, threadId: string) => void
+): Promise<string> {
+  // Acquire the lock atomically - this prevents race conditions where
+  // multiple concurrent calls could both proceed simultaneously.
+  const releaseLock = await acquireStickyLock(session);
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- caller checks tasksPostId exists
+    const oldTasksPostId = session.tasksPostId!;
+    const oldTasksContent = session.lastTasksContent;
+
+    sessionLog(session).debug(`Bumping tasks to bottom, repurposing post ${oldTasksPostId.substring(0, 8)}`);
+
+    // Get platform-specific message size limits
+    const { maxLength: MAX_POST_LENGTH } = session.platform.getMessageLimits();
+
+    // Safety truncation if content exceeds platform limits
+    let contentToPost = newContent;
+    if (contentToPost.length > MAX_POST_LENGTH) {
+      sessionLog(session).warn(`Content too long for repurposed post (${contentToPost.length}), truncating`);
+      const formatter = session.platform.getFormatter();
+      contentToPost = truncateMessageSafely(
+        contentToPost,
+        MAX_POST_LENGTH,
+        formatter.formatItalic('... (truncated)')
+      );
+    }
+
+    // Remove the toggle emoji from the old task post before repurposing it
+    try {
+      await session.platform.removeReaction(oldTasksPostId, TASK_TOGGLE_EMOJIS[0]);
+    } catch (err) {
+      sessionLog(session).debug(`Could not remove toggle emoji: ${err}`);
+    }
+
+    // Unpin the old task post before repurposing it
+    await session.platform.unpinPost(oldTasksPostId).catch(() => {});
+
+    // Repurpose the task list post for the new content
+    await withErrorHandling(
+      () => session.platform.updatePost(oldTasksPostId, contentToPost),
+      { action: 'Repurpose task post', session }
+    );
+    registerPost(oldTasksPostId, session.threadId);
+
+    // Create a new task list post at the bottom (if we have content to show)
+    if (oldTasksContent) {
+      // Preserve the minimized state for content, but always add the toggle emoji
+      // (emoji is always present as a clickable button; user clicks to toggle)
+      const displayContent = getTaskDisplayContent(session);
+
+      const newTasksPost = await session.platform.createInteractivePost(
+        displayContent,
+        [TASK_TOGGLE_EMOJIS[0]], // Always add toggle emoji
+        session.threadId
+      );
+      session.tasksPostId = newTasksPost.id;
+      sessionLog(session).debug(`Created new task post ${newTasksPost.id.substring(0, 8)}`);
+      // Register the new task post so reaction clicks are routed to this session
+      registerPost(newTasksPost.id, session.threadId);
+      // Track for jump-to-bottom links
+      updateLastMessage(session, newTasksPost);
+      // Pin the new task post
+      await session.platform.pinPost(newTasksPost.id).catch(() => {});
+    } else {
+      // No task content to re-post, clear the task post ID
+      session.tasksPostId = null;
+    }
+
+    return oldTasksPostId;
+  } finally {
+    // Release the lock so other callers can proceed
+    releaseLock();
+  }
+}
+
+/**
+ * Bump the task list to the bottom of the thread.
+ *
+ * Call this when a user sends a follow-up message to keep the task list
+ * below user messages. Deletes the old task post and creates a new one.
+ *
+ * @param session - The session
+ * @param registerPost - Callback to register the new post for reaction routing
+ */
+export async function bumpTasksToBottom(
+  session: Session,
+  registerPost?: (postId: string, threadId: string) => void
+): Promise<void> {
+  // Early exit checks (before acquiring lock)
+  if (!session.tasksPostId || !session.lastTasksContent) {
+    sessionLog(session).debug('No task list to bump');
+    return; // No task list to bump
+  }
+
+  // Don't bump completed task lists - they can stay where they are
+  if (session.tasksCompleted) {
+    sessionLog(session).debug('Tasks completed, not bumping');
+    return;
+  }
+
+  // Acquire the lock atomically - this prevents race conditions where
+  // multiple concurrent calls could both proceed simultaneously.
+  const releaseLock = await acquireStickyLock(session);
+
+  try {
+    // Re-check conditions after acquiring lock (state may have changed)
+    if (!session.tasksPostId || !session.lastTasksContent || session.tasksCompleted) {
+      sessionLog(session).debug('Task list state changed while waiting for lock');
+      return;
+    }
+    const oldPostId = session.tasksPostId;
+    sessionLog(session).debug(`Bumping tasks: deleting old post ${oldPostId.substring(0, 8)}`);
+
+    // Unpin the old task post before deleting
+    await session.platform.unpinPost(session.tasksPostId).catch(() => {});
+
+    // Delete the old task post
+    await session.platform.deletePost(session.tasksPostId);
+
+    // Create a new task post at the bottom, preserving minimized state for content
+    // but always adding the toggle emoji (it's always present as a clickable button)
+    const displayContent = getTaskDisplayContent(session);
+
+    const newPost = await session.platform.createInteractivePost(
+      displayContent,
+      [TASK_TOGGLE_EMOJIS[0]], // Always add toggle emoji
+      session.threadId
+    );
+    session.tasksPostId = newPost.id;
+    sessionLog(session).debug(`Created new task post ${newPost.id.substring(0, 8)}`);
+    // Register the task post so reaction clicks are routed to this session
+    if (registerPost) {
+      registerPost(newPost.id, session.threadId);
+    }
+    // Track for jump-to-bottom links
+    updateLastMessage(session, newPost);
+    // Pin the new task post
+    await session.platform.pinPost(newPost.id).catch(() => {});
+  } catch (err) {
+    sessionLog(session).error(`Failed to bump tasks to bottom: ${err}`);
+  } finally {
+    // Release the lock so other callers can proceed
+    releaseLock();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unified sticky post management
+// ---------------------------------------------------------------------------
+
+/**
+ * Bump all sticky posts to the bottom in correct order.
+ *
+ * This ensures:
+ * 1. Plan approval is bumped first (if pending)
+ * 2. Task list is bumped last (so it's always at the very bottom)
+ *
+ * Call this when new content is posted to keep sticky posts at the bottom.
+ *
+ * @param session - The session
+ * @param registerPost - Callback to register posts for reaction routing
+ */
+export async function bumpAllStickyPosts(
+  session: Session,
+  registerPost: (postId: string, threadId: string) => void
+): Promise<void> {
+  // Bump plan approval first (if pending)
+  if (session.pendingApproval?.type === 'plan' && session.pendingApproval.content) {
+    await bumpPlanApprovalToBottom(session, registerPost);
+  }
+
+  // Bump task list last (so it stays at very bottom)
+  if (session.tasksPostId && session.lastTasksContent && !session.tasksCompleted) {
+    await bumpTasksToBottom(session, registerPost);
+  }
+}
+
+/**
+ * Check if there are any active sticky posts that would need bumping.
+ */
+export function hasActiveStickyPosts(session: Session): boolean {
+  const hasPlanApproval = session.pendingApproval?.type === 'plan' && !!session.pendingApproval.content;
+  const hasTaskList = !!session.tasksPostId && !!session.lastTasksContent && !session.tasksCompleted;
+  return hasPlanApproval || hasTaskList;
+}
+
+/**
+ * Check if the session has an active (non-completed) task list.
+ */
+export function hasActiveTasks(session: Session): boolean {
+  return !!session.tasksPostId && !!session.lastTasksContent && !session.tasksCompleted;
+}

--- a/src/session/streaming.ts
+++ b/src/session/streaming.ts
@@ -5,117 +5,28 @@
  * Implements logical message breaking to avoid content collapse on chat platforms.
  */
 
-import type { PlatformClient, PlatformFile, PlatformFormatter } from '../platform/index.js';
+import type { PlatformClient, PlatformFile } from '../platform/index.js';
 import { truncateMessageSafely } from '../platform/utils.js';
 import type { Session } from './types.js';
 import type { ContentBlock } from '../claude/cli.js';
-import { TASK_TOGGLE_EMOJIS } from '../utils/emoji.js';
 import { createLogger } from '../utils/logger.js';
 import { withErrorHandling } from './error-handler.js';
 import { updateLastMessage } from './post-helpers.js';
+import {
+  bumpTasksToBottomWithContent,
+  hasActiveTasks,
+  bumpPlanApprovalToBottom,
+} from './sticky-thread.js';
+
+// Re-export for backward compatibility
+export { acquireStickyLock as acquireTaskListLock } from './sticky-thread.js';
+export { bumpTasksToBottom, bumpTasksToBottomWithContent } from './sticky-thread.js';
 
 const log = createLogger('streaming');
-
-// ---------------------------------------------------------------------------
-// Task list lock utilities
-// ---------------------------------------------------------------------------
-
-/**
- * Acquire the task list lock in an atomic manner.
- *
- * This function solves the race condition where multiple concurrent calls
- * could both see `taskListCreationPromise` as undefined and both proceed
- * to create task lists. By chaining the new promise onto the existing one
- * (or creating a new chain if none exists) in a single synchronous operation,
- * we ensure that all callers properly serialize their access.
- *
- * The key insight is that in JavaScript's event loop, synchronous code runs
- * atomically (no interleaving). By immediately setting the new promise in
- * the same synchronous block where we check for existing promises, we prevent
- * the race condition where two callers both see "no lock" simultaneously.
- *
- * @param session - The session to acquire the lock for
- * @returns A promise that resolves to a release function when the lock is acquired
- */
-export async function acquireTaskListLock(session: Session): Promise<() => void> {
-  let resolveCreation: (() => void) | undefined;
-
-  // Create a new promise that will be resolved when the caller releases the lock
-  const newPromise = new Promise<void>((resolve) => {
-    resolveCreation = resolve;
-  });
-
-  // Get the existing promise (may be undefined)
-  const existingPromise = session.taskListCreationPromise;
-
-  // CRITICAL: This is the atomic part - we immediately set the new promise
-  // so any subsequent callers will see it and wait on it.
-  // We chain onto the existing promise (if any) so operations serialize.
-  session.taskListCreationPromise = existingPromise
-    ? existingPromise.then(() => newPromise)
-    : newPromise;
-
-  // Wait for our turn (if there was an existing promise, wait for it)
-  if (existingPromise) {
-    await existingPromise;
-  }
-
-  // Now we have the lock - return the release function
-  return () => {
-    if (resolveCreation) {
-      resolveCreation();
-    }
-    // Note: we don't clear taskListCreationPromise here because other
-    // callers may have already chained onto it. The promise chain will
-    // naturally resolve and eventually be garbage collected.
-  };
-}
 
 /** Get session-scoped logger for routing to correct UI panel */
 function sessionLog(session: Session) {
   return log.forSession(session.sessionId);
-}
-
-// ---------------------------------------------------------------------------
-// Task display helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Compute the minimized task list message from the full content.
- * Format: "---\n📋 **Tasks** (X/Y · Z%) · 🔄 TaskName 🔽"
- */
-function getMinimizedTaskContent(fullContent: string, formatter: PlatformFormatter): string {
-  // Parse progress from content (format: "📋 **Tasks** (X/Y · Z%)")
-  const progressMatch = fullContent.match(/\((\d+)\/(\d+) · (\d+)%\)/);
-  const completed = progressMatch ? parseInt(progressMatch[1], 10) : 0;
-  const total = progressMatch ? parseInt(progressMatch[2], 10) : 0;
-  const pct = progressMatch ? parseInt(progressMatch[3], 10) : 0;
-
-  // Find current in-progress task
-  // Match both ** (Mattermost) and * (Slack) bold formatting
-  const inProgressMatch = fullContent.match(/🔄 \*{1,2}([^*]+)\*{1,2}(?:\s*\((\d+)s\))?/);
-  let currentTaskText = '';
-  if (inProgressMatch) {
-    const taskName = inProgressMatch[1];
-    const elapsed = inProgressMatch[2] ? ` (${inProgressMatch[2]}s)` : '';
-    currentTaskText = ` · 🔄 ${taskName}${elapsed}`;
-  }
-
-  return `${formatter.formatHorizontalRule()}\n📋 ${formatter.formatBold('Tasks')} (${completed}/${total} · ${pct}%)${currentTaskText} 🔽`;
-}
-
-/**
- * Get the task content to display based on minimized state.
- * If minimized, returns the compact summary; otherwise the full content.
- */
-function getTaskDisplayContent(session: Session): string {
-  if (!session.lastTasksContent) {
-    return '';
-  }
-  const formatter = session.platform.getFormatter();
-  return session.tasksMinimized
-    ? getMinimizedTaskContent(session.lastTasksContent, formatter)
-    : session.lastTasksContent;
 }
 
 // ---------------------------------------------------------------------------
@@ -459,170 +370,6 @@ export function stopTyping(session: Session): void {
 }
 
 /**
- * Bump the task list to the bottom by reusing its post for new content.
- *
- * When we need to create a new post and a task list exists, we:
- * 1. Update the task list post with the new content (repurposing it)
- * 2. Create a fresh task list post at the bottom
- *
- * This keeps the task list visually at the bottom without deleting messages.
- *
- * @param session - The session
- * @param newContent - Content to put in the repurposed post
- * @param registerPost - Callback to register post for reaction routing
- * @returns The post ID that now contains the content (was the task list post)
- */
-async function bumpTasksToBottomWithContent(
-  session: Session,
-  newContent: string,
-  registerPost: (postId: string, threadId: string) => void
-): Promise<string> {
-  // Acquire the lock atomically - this prevents race conditions where
-  // multiple concurrent calls could both proceed simultaneously.
-  const releaseLock = await acquireTaskListLock(session);
-
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- caller checks tasksPostId exists
-    const oldTasksPostId = session.tasksPostId!;
-    const oldTasksContent = session.lastTasksContent;
-
-    sessionLog(session).debug(`Bumping tasks to bottom, repurposing post ${oldTasksPostId.substring(0, 8)}`);
-
-    // Get platform-specific message size limits
-    const { maxLength: MAX_POST_LENGTH } = session.platform.getMessageLimits();
-
-    // Safety truncation if content exceeds platform limits
-    let contentToPost = newContent;
-    if (contentToPost.length > MAX_POST_LENGTH) {
-      sessionLog(session).warn(`Content too long for repurposed post (${contentToPost.length}), truncating`);
-      const formatter = session.platform.getFormatter();
-      contentToPost = truncateMessageSafely(
-        contentToPost,
-        MAX_POST_LENGTH,
-        formatter.formatItalic('... (truncated)')
-      );
-    }
-
-    // Remove the toggle emoji from the old task post before repurposing it
-    try {
-      await session.platform.removeReaction(oldTasksPostId, TASK_TOGGLE_EMOJIS[0]);
-    } catch (err) {
-      sessionLog(session).debug(`Could not remove toggle emoji: ${err}`);
-    }
-
-    // Unpin the old task post before repurposing it
-    await session.platform.unpinPost(oldTasksPostId).catch(() => {});
-
-    // Repurpose the task list post for the new content
-    await withErrorHandling(
-      () => session.platform.updatePost(oldTasksPostId, contentToPost),
-      { action: 'Repurpose task post', session }
-    );
-    registerPost(oldTasksPostId, session.threadId);
-
-    // Create a new task list post at the bottom (if we have content to show)
-    if (oldTasksContent) {
-      // Preserve the minimized state for content, but always add the toggle emoji
-      // (emoji is always present as a clickable button; user clicks to toggle)
-      const displayContent = getTaskDisplayContent(session);
-
-      const newTasksPost = await session.platform.createInteractivePost(
-        displayContent,
-        [TASK_TOGGLE_EMOJIS[0]], // Always add toggle emoji
-        session.threadId
-      );
-      session.tasksPostId = newTasksPost.id;
-      sessionLog(session).debug(`Created new task post ${newTasksPost.id.substring(0, 8)}`);
-      // Register the new task post so reaction clicks are routed to this session
-      registerPost(newTasksPost.id, session.threadId);
-      // Track for jump-to-bottom links
-      updateLastMessage(session, newTasksPost);
-      // Pin the new task post
-      await session.platform.pinPost(newTasksPost.id).catch(() => {});
-    } else {
-      // No task content to re-post, clear the task post ID
-      session.tasksPostId = null;
-    }
-
-    return oldTasksPostId;
-  } finally {
-    // Release the lock so other callers can proceed
-    releaseLock();
-  }
-}
-
-/**
- * Bump the task list to the bottom of the thread.
- *
- * Call this when a user sends a follow-up message to keep the task list
- * below user messages. Deletes the old task post and creates a new one.
- *
- * @param session - The session
- * @param registerPost - Callback to register the new post for reaction routing
- */
-export async function bumpTasksToBottom(
-  session: Session,
-  registerPost?: (postId: string, threadId: string) => void
-): Promise<void> {
-  // Early exit checks (before acquiring lock)
-  if (!session.tasksPostId || !session.lastTasksContent) {
-    sessionLog(session).debug('No task list to bump');
-    return; // No task list to bump
-  }
-
-  // Don't bump completed task lists - they can stay where they are
-  if (session.tasksCompleted) {
-    sessionLog(session).debug('Tasks completed, not bumping');
-    return;
-  }
-
-  // Acquire the lock atomically - this prevents race conditions where
-  // multiple concurrent calls could both proceed simultaneously.
-  const releaseLock = await acquireTaskListLock(session);
-
-  try {
-    // Re-check conditions after acquiring lock (state may have changed)
-    if (!session.tasksPostId || !session.lastTasksContent || session.tasksCompleted) {
-      sessionLog(session).debug('Task list state changed while waiting for lock');
-      return;
-    }
-    const oldPostId = session.tasksPostId;
-    sessionLog(session).debug(`Bumping tasks: deleting old post ${oldPostId.substring(0, 8)}`);
-
-    // Unpin the old task post before deleting
-    await session.platform.unpinPost(session.tasksPostId).catch(() => {});
-
-    // Delete the old task post
-    await session.platform.deletePost(session.tasksPostId);
-
-    // Create a new task post at the bottom, preserving minimized state for content
-    // but always adding the toggle emoji (it's always present as a clickable button)
-    const displayContent = getTaskDisplayContent(session);
-
-    const newPost = await session.platform.createInteractivePost(
-      displayContent,
-      [TASK_TOGGLE_EMOJIS[0]], // Always add toggle emoji
-      session.threadId
-    );
-    session.tasksPostId = newPost.id;
-    sessionLog(session).debug(`Created new task post ${newPost.id.substring(0, 8)}`);
-    // Register the task post so reaction clicks are routed to this session
-    if (registerPost) {
-      registerPost(newPost.id, session.threadId);
-    }
-    // Track for jump-to-bottom links
-    updateLastMessage(session, newPost);
-    // Pin the new task post
-    await session.platform.pinPost(newPost.id).catch(() => {});
-  } catch (err) {
-    sessionLog(session).error(`Failed to bump tasks to bottom: ${err}`);
-  } finally {
-    // Release the lock so other callers can proceed
-    releaseLock();
-  }
-}
-
-/**
  * Flush pending content to the platform.
  *
  * Handles:
@@ -771,9 +518,11 @@ export async function flush(
 
     // Create the continuation post if there's content
     if (remainder) {
+      // Bump plan approval first if pending (keep it at bottom)
+      await bumpPlanApprovalToBottom(session, registerPost);
+
       // If we have an active (non-completed) task list, reuse its post and bump it to the bottom
-      const hasActiveTasks = session.tasksPostId && session.lastTasksContent && !session.tasksCompleted;
-      if (hasActiveTasks) {
+      if (hasActiveTasks(session)) {
         const postId = await bumpTasksToBottomWithContent(session, remainder, registerPost);
         session.currentPostId = postId;
       } else {
@@ -815,9 +564,11 @@ export async function flush(
     }
   } else {
     // Need to create a new post
+    // Bump plan approval first if pending (keep it at bottom)
+    await bumpPlanApprovalToBottom(session, registerPost);
+
     // If we have an active (non-completed) task list, reuse its post and bump it to the bottom
-    const hasActiveTasks = session.tasksPostId && session.lastTasksContent && !session.tasksCompleted;
-    if (hasActiveTasks) {
+    if (hasActiveTasks(session)) {
       const postId = await bumpTasksToBottomWithContent(session, content, registerPost);
       session.currentPostId = postId;
     } else {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -71,6 +71,7 @@ export interface PendingApproval {
   postId: string;
   type: 'plan' | 'action';
   toolUseId: string;
+  content?: string;  // Message content for recreation when bumping
 }
 
 /**
@@ -229,7 +230,11 @@ export interface Session {
   lastMessageId?: string;
   lastMessageTs?: string;  // For Slack: timestamp of last message (needed for permalink)
 
-  // Task list creation lock (prevents duplicate posts from concurrent TodoWrite events)
+  // Sticky post lock (prevents duplicate posts from concurrent updates)
+  // Used by both task list and plan approval bumping
+  stickyPostLock?: Promise<void>;
+
+  // DEPRECATED: Use stickyPostLock instead. Kept for backward compatibility.
   taskListCreationPromise?: Promise<void>;
 }
 


### PR DESCRIPTION
## Summary

- Plan approval message now stays at the bottom of the thread while pending (similar to task list behavior)
- Fixes confusing UX where approval prompt appeared above the plan content
- Creates new `sticky-thread.ts` module with unified sticky post logic for both task list and plan approval

## Changes

- **New module**: `src/session/sticky-thread.ts` - unified sticky post management
- **Plan approval bumping**: Deletes and recreates plan approval at bottom when new content is posted
- **Visual improvement**: Plan approval now has horizontal rule (`---`) for visual separation
- **Correct ordering**: Plan approval bumps first, then task list (task list always at very bottom)
- **Shared lock**: Both task list and plan approval use the same lock to prevent race conditions

## Test plan

- [x] All 1201 unit tests pass
- [x] Added 29 new tests for sticky-thread module
- [x] TypeScript compilation succeeds
- [x] ESLint passes
- [ ] Manual testing: Start session in plan mode, verify approval appears below plan content
- [ ] Manual testing: Send follow-up while plan pending, verify approval bumps to bottom

Generated with [Claude Code](https://claude.ai/code)