### PR TITLE
Support Claude CLI 2.1.x series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.10] - 2026-01-09
+
+### Changed
+- **Support Claude CLI 2.1.x** - Updated version compatibility range from `>=2.0.74 <=2.1.1` to `>=2.0.74 <2.2.0` to support all 2.1.x releases
+
 ## [0.48.9] - 2026-01-08
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "0.48.5",
+  "version": "0.48.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "0.48.5",
+      "version": "0.48.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/src/claude/version-check.test.ts
+++ b/src/claude/version-check.test.ts
@@ -22,12 +22,14 @@ describe('version-check', () => {
       expect(isVersionCompatible('2.0.76')).toBe(true);
       expect(isVersionCompatible('2.1.0')).toBe(true);
       expect(isVersionCompatible('2.1.1')).toBe(true);
+      expect(isVersionCompatible('2.1.2')).toBe(true);
+      expect(isVersionCompatible('2.1.99')).toBe(true);
     });
 
     it('returns false for versions outside the range', () => {
       expect(isVersionCompatible('2.0.73')).toBe(false);
-      expect(isVersionCompatible('2.1.2')).toBe(false);
       expect(isVersionCompatible('2.2.0')).toBe(false);
+      expect(isVersionCompatible('3.0.0')).toBe(false);
       expect(isVersionCompatible('1.0.17')).toBe(false);
     });
 

--- a/src/claude/version-check.ts
+++ b/src/claude/version-check.ts
@@ -8,7 +8,7 @@ import { satisfies, coerce } from 'semver';
  * - MIN: Oldest version known to work
  * - MAX: Newest version known to work
  */
-export const CLAUDE_CLI_VERSION_RANGE = '>=2.0.74 <=2.1.1';
+export const CLAUDE_CLI_VERSION_RANGE = '>=2.0.74 <2.2.0';
 
 /**
  * Get the installed Claude CLI version.


### PR DESCRIPTION
## Summary
- Updated version compatibility range from `>=2.0.74 <=2.1.1` to `>=2.0.74 <2.2.0` to support all 2.1.x releases
- Updated tests to reflect new version range

## Test plan
- [x] Version check tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)