### PR TITLE
Clean screen before update restart

### DIFF
--- a/src/auto-update/manager.ts
+++ b/src/auto-update/manager.ts
@@ -282,6 +282,11 @@ export class AutoUpdateManager extends EventEmitter {
 
       // Exit with special code to signal restart needed
       log.info(`🔄 Restarting for update to v${updateInfo.latestVersion}`);
+
+      // Clear screen for clean restart (in case prepareForRestart didn't)
+      process.stdout.write('\x1b[2J\x1b[H');  // Clear screen, cursor to home
+      process.stdout.write('\x1b[?25h');       // Restore cursor visibility
+
       process.exit(RESTART_EXIT_CODE);
     } else {
       const errorMsg = result.error ?? 'Unknown error';

--- a/src/index.ts
+++ b/src/index.ts
@@ -489,6 +489,10 @@ async function main() {
       for (const client of platforms.values()) {
         client.disconnect();
       }
+
+      // Clear screen and restore cursor before daemon restarts us
+      process.stdout.write('\x1b[2J\x1b[H');  // Clear screen, cursor to home
+      process.stdout.write('\x1b[?25h');       // Restore cursor visibility
     },
   });
 


### PR DESCRIPTION
## Summary
- Clear screen and restore cursor before the daemon restarts us
- New UI appears cleanly at the top instead of below the old UI remnants

## Problem
When the bot auto-updates and restarts, the old Ink UI stayed on screen and the new UI rendered below it, creating a messy appearance.

## Solution
Add ANSI escape sequences to clear the screen (`\x1b[2J\x1b[H`) and restore cursor (`\x1b[?25h`) before `process.exit()` during update restart.

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Manual test: trigger update, verify screen clears cleanly before new UI appears