### PR TITLE
Clean screen on normal shutdown too

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -597,6 +597,10 @@ async function main() {
     for (const client of platforms.values()) {
       client.disconnect();
     }
+
+    // Clear screen and restore cursor for clean exit
+    process.stdout.write('\x1b[2J\x1b[H');  // Clear screen, cursor to home
+    process.stdout.write('\x1b[?25h');       // Restore cursor visibility
     // Don't call process.exit() here - let the signal handler do it after we resolve
   };
 


### PR DESCRIPTION
## Summary
- Adds screen clear to normal shutdown path (Ctrl+C, SIGINT, SIGTERM)
- Complements #144 which only cleared screen on update restart

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Manual test: run `bun start`, then Ctrl+C - screen should clear completely