### PR TITLE
Fix typing indicator overflow and reposition spinner

### DIFF
--- a/src/ui/components/SessionLog.tsx
+++ b/src/ui/components/SessionLog.tsx
@@ -34,13 +34,13 @@ export function SessionLog({ logs, maxLines = 20 }: SessionLogProps) {
   }
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" flexShrink={0}>
       {displayLogs.map((log) => (
-        <Box key={log.id}>
-          <Text color={getColorForLevel(log.level)} dimColor>
+        <Box key={log.id} flexShrink={0}>
+          <Text color={getColorForLevel(log.level)} dimColor wrap="truncate">
             [{padComponent(log.component)}]
           </Text>
-          <Text color={getColorForLevel(log.level)}>
+          <Text color={getColorForLevel(log.level)} wrap="truncate">
             {' '}{log.message}
           </Text>
         </Box>

--- a/src/ui/components/Spinner.tsx
+++ b/src/ui/components/Spinner.tsx
@@ -16,9 +16,9 @@ interface SpinnerProps {
 
 export function Spinner({ label, type = 'simpleDots' }: SpinnerProps) {
   return (
-    <Box gap={1}>
+    <Box gap={1} flexShrink={0}>
+      {label && <Text dimColor wrap="truncate">{label}</Text>}
       <InkSpinner type={type} />
-      {label && <Text dimColor>{label}</Text>}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Fix typing indicator overflow where text would wrap incorrectly (showing "eTyping..." on separate line)
- Reposition spinner to appear after the label instead of before (now shows "Typing... ." instead of ". Typing...")
- Add overflow protection to session logs to prevent them from overflowing onto the typing indicator

## Test plan
- [ ] Start a session and verify the typing indicator shows correctly without overflow
- [ ] Verify spinner dots appear after "Typing" text
- [ ] Verify long log messages are truncated instead of wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)