### PR TITLE
Reduce excessive Slack API logging from sticky message cleanup

### DIFF
--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -238,7 +238,6 @@ export class SlackClient extends EventEmitter implements PlatformClient {
       throw new Error(`Slack API error: ${data.error}`);
     }
 
-    log.debug(`API ${method} ${endpoint} -> ok`);
     return data;
   }
 
@@ -1002,11 +1001,11 @@ export class SlackClient extends EventEmitter implements PlatformClient {
 
   /**
    * Get a post by ID.
+   * Note: This makes an API call per post. For bulk operations, prefer getPinnedPosts
+   * which returns all pinned post IDs in a single call.
    */
   async getPost(postId: string): Promise<PlatformPost | null> {
     try {
-      log.debug(`Fetching post ${postId.substring(0, 12)}`);
-
       // Use conversations.history with latest/oldest to get a specific message
       const response = await this.api<ConversationsHistoryResponse>(
         'GET',


### PR DESCRIPTION
## Summary

- Add throttling to `cleanupOldStickyMessages` (max once per 5 min per platform)
- Filter cleanup to only check posts from the last hour (using Slack timestamps)
- Remove verbose "Fetching post" and "API -> ok" debug logs
- Add `forceRun` parameter to bypass throttle at startup
- Run startup cleanup in background (non-blocking)

## Problem

The `cleanupOldStickyMessages()` function was being called on every sticky message bump, causing:
- A `pins.list` API call
- N × `conversations.history` API calls (one per pinned post)
- Excessive log spam in the UI

## Solution

1. **Throttling**: Cleanup now only runs once per 5 minutes per platform
2. **Time-based filtering**: Only checks posts from the last hour (older orphaned stickies are rare)
3. **Non-blocking startup**: Cleanup runs in background at startup

## Test plan

- [x] All 1173 unit tests pass
- [x] Build succeeds
- [ ] Manual testing: verify reduced log output in active channel

🤖 Generated with [Claude Code](https://claude.ai/code)