### PR TITLE
Add image upload support for bug reports via Catbox.moe

### DIFF
--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -241,9 +241,10 @@ export async function handleMessage(
             return;
 
           case 'bug':
-            // Bug reporting
+            // Bug reporting - pass any attached images
             if (isAllowed) {
-              await session.reportBug(threadRoot, parsed.args, username);
+              const files = post.metadata?.files;
+              await session.reportBug(threadRoot, parsed.args, username, files);
             }
             return;
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1172,10 +1172,10 @@ export class SessionManager extends EventEmitter {
     await commands.enableInteractivePermissions(session, username, this.getContext());
   }
 
-  async reportBug(threadId: string, description: string | undefined, username: string): Promise<void> {
+  async reportBug(threadId: string, description: string | undefined, username: string, files?: PlatformFile[]): Promise<void> {
     const session = this.findSessionByThreadId(threadId);
     if (!session) return;
-    await commands.reportBug(session, description, username, this.getContext());
+    await commands.reportBug(session, description, username, this.getContext(), undefined, files);
   }
 
   async showUpdateStatus(threadId: string, _username: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Upload attached images to Catbox.moe (permanent, anonymous hosting)
- Include uploaded image URLs in GitHub issue body as markdown images
- Show upload progress and success/failure status in preview
- Gracefully handle upload failures (continues with other images, shows errors)

## How it works

1. User attaches an image to `!bug <description>` message
2. Bot downloads the image from chat platform
3. Bot uploads to Catbox.moe (anonymous, permanent hosting)
4. Uploaded image URLs are embedded in the GitHub issue body
5. Preview shows upload status before user approves

## Test plan

- [x] Unit tests for uploadImages (filter non-images, handle errors, preserve file info)
- [x] Unit tests for formatIssueBody with images
- [x] Unit tests for formatBugPreview with image status
- [x] All 1263 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)