### PR TITLE
Fix image attachments not appearing in bug reports

### DIFF
--- a/src/platform/mattermost/types.ts
+++ b/src/platform/mattermost/types.ts
@@ -31,6 +31,7 @@ export interface MattermostPost {
   message: string;
   type: string;
   props: Record<string, unknown>;
+  file_ids?: string[];  // File IDs (present in WebSocket events, metadata.files may be missing)
   metadata?: {
     embeds?: unknown[];
     files?: MattermostFile[];


### PR DESCRIPTION
## Summary

- Fix Mattermost WebSocket events not including file metadata for attachments
- When `file_ids` is present but `metadata.files` is missing, fetch file info from API
- Ensures images attached to `!bug` command are properly uploaded and included in GitHub issues

## Test plan

- [ ] Attach an image to a `!bug` message in Mattermost
- [ ] Verify the image is uploaded to Catbox.moe (shown in preview)
- [ ] Approve the bug report and verify the image appears in the GitHub issue

Closes #157