### PR TITLE
Fix sticky message install command and add website link

### DIFF
--- a/src/session/sticky-message.test.ts
+++ b/src/session/sticky-message.test.ts
@@ -99,7 +99,7 @@ describe('buildStickyMessage', () => {
     expect(result).toContain('Active Claude Threads');
     expect(result).toContain('No active sessions');
     expect(result).toContain('Mention me to start a session');
-    expect(result).toContain('npm i -g claude-threads');
+    expect(result).toContain('bun install -g claude-threads');
   });
 
   it('shows status bar with version and session count', async () => {

--- a/src/session/sticky-message.ts
+++ b/src/session/sticky-message.ts
@@ -544,7 +544,7 @@ export async function buildStickyMessage(
     }
 
     lines.push('');
-    lines.push(`${formatter.formatItalic('Mention me to start a session')} · ${formatter.formatCode('npm i -g claude-threads')}`);
+    lines.push(`${formatter.formatItalic('Mention me to start a session')} · ${formatter.formatCode('bun install -g claude-threads')} · ${formatter.formatLink('claude-threads.run', 'https://claude-threads.run/')}`);
 
     return lines.join('\n');
   }
@@ -629,7 +629,7 @@ export async function buildStickyMessage(
   }
 
   lines.push('');
-  lines.push(`${formatter.formatItalic('Mention me to start a session')} · ${formatter.formatCode('npm i -g claude-threads')}`);
+  lines.push(`${formatter.formatItalic('Mention me to start a session')} · ${formatter.formatCode('bun install -g claude-threads')} · ${formatter.formatLink('claude-threads.run', 'https://claude-threads.run/')}`);
 
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary

- Change `npm i -g claude-threads` to `bun install -g claude-threads` in the sticky message footer for consistency with README, update-notifier, and website
- Add link to https://claude-threads.run/ in the footer

## Background

The `npm` install command was an oversight from the initial sticky message implementation - other parts of the codebase already used `bun`. This fix aligns the sticky message with the rest of the project.

## Test plan

- [x] Unit tests pass
- [x] Build succeeds
- [x] Lint passes