### PR TITLE
Fix downloadFile losing 'this' context in bug report uploads

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -843,14 +843,14 @@ export async function reportBug(
   let imageUrls: string[] = [];
   let imageErrors: string[] = [];
 
-  const downloadFile = session.platform.downloadFile;
+  const downloadFile = session.platform.downloadFile?.bind(session.platform);
   if (attachedFiles && attachedFiles.length > 0 && downloadFile) {
     // Show upload progress
     await postInfo(session, `📤 Uploading ${attachedFiles.length} image(s)...`);
 
     const uploadResults = await uploadImages(
       attachedFiles,
-      (fileId) => downloadFile(fileId)
+      downloadFile
     );
 
     imageUrls = uploadResults


### PR DESCRIPTION
## Summary

- Fix `downloadFile` method losing its `this` context when passed as callback
- Error was: `undefined is not an object (evaluating 'this.url')`
- Solution: bind the method to the platform instance before passing

## Test plan

- [ ] Attach an image to a `!bug` message in Mattermost
- [ ] Verify the image uploads successfully (no error in preview)
- [ ] Approve the bug report and verify the image appears in the GitHub issue

Fixes #157