### PR TITLE
Add confirmation message when !kill command is executed

### DIFF
--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -62,8 +62,20 @@ export async function handleMessage(
         await client.createPost(`⛔ Only authorized users can use ${formatter.formatCode('!kill')}`, threadRoot);
         return;
       }
-      // Notify all active sessions before killing
+      // Post confirmation to the channel where !kill was issued
+      const activeCount = session.getActiveThreadIds().length;
+      try {
+        await client.createPost(
+          `🔴 ${formatter.formatBold('EMERGENCY SHUTDOWN')} initiated by ${formatter.formatUserMention(username)} - killing ${activeCount} active session${activeCount !== 1 ? 's' : ''}`,
+          threadRoot
+        );
+      } catch {
+        /* ignore - we're shutting down anyway */
+      }
+
+      // Notify all other active sessions before killing
       for (const tid of session.getActiveThreadIds()) {
+        if (tid === threadRoot) continue; // Skip the thread where we already posted
         try {
           await client.createPost(`🔴 ${formatter.formatBold('EMERGENCY SHUTDOWN')} by ${formatter.formatUserMention(username)}`, tid);
         } catch {


### PR DESCRIPTION
## Summary
- Posts confirmation message to the channel/thread where `!kill` is issued
- Shows number of active sessions being killed (e.g., "killing 2 active sessions")
- Avoids duplicate notifications when kill is issued from within an active session thread

## Test plan
- [x] Unit tests added for new behavior
- [x] Test: confirmation posts even with no active sessions
- [x] Test: no duplicate notification when kill issued from active session thread
- [ ] Manual test in Mattermost

Fixes #165