### PR TITLE
Improve worktree creation failure handling with retry option

### DIFF
--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -11,6 +11,7 @@ export type {
   PendingQuestionSet,
   PendingMessageApproval,
   PendingExistingWorktreePrompt,
+  PendingWorktreeFailurePrompt,
 } from './types.js';
 export type { PendingContextPrompt } from './context-prompt.js';
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1261,6 +1261,7 @@ export class SessionManager extends EventEmitter {
     await worktreeModule.createAndSwitchToWorktree(session, branch, username, {
       skipPermissions: this.skipPermissions,
       chromeEnabled: this.chromeEnabled,
+      worktreeMode: this.worktreeMode,
       handleEvent: (tid, e) => this.handleEvent(tid, e),
       handleExit: (tid, code) => this.handleExit(tid, code),
       updateSessionHeader: (s) => this.updateSessionHeader(s),

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -94,6 +94,16 @@ export interface PendingExistingWorktreePrompt {
 }
 
 /**
+ * Pending prompt after worktree creation failed, asking user what to do
+ */
+export interface PendingWorktreeFailurePrompt {
+  postId: string;
+  failedBranch: string;
+  errorMessage: string;
+  username: string;  // User who triggered the original request
+}
+
+/**
  * Pending update prompt asking user to update now or defer
  */
 export interface PendingUpdatePrompt {
@@ -193,6 +203,7 @@ export interface Session {
   worktreeResponsePostId?: string;          // Post ID of user's worktree branch response (to exclude from context)
   firstPrompt?: string;                     // First user message, sent again after mid-session worktree creation
   pendingExistingWorktreePrompt?: PendingExistingWorktreePrompt; // Waiting for user to confirm joining existing worktree
+  pendingWorktreeFailurePrompt?: PendingWorktreeFailurePrompt;  // Waiting for user to decide after worktree creation failed
 
   // Thread context prompt support
   pendingContextPrompt?: PendingContextPrompt; // Waiting for context selection


### PR DESCRIPTION
## Summary

- When worktree creation fails, now shows an interactive prompt instead of automatically falling back to main repo
- Displays user-friendly error messages based on specific failure types (branch already checked out, permission denied, disk space, etc.)
- Users can retry with a different branch name or skip to continue in main repo
- In `require` mode, only retry is available (no skip option)

## Test plan

- [x] Unit tests pass (1277 tests)
- [x] Tests added for failure handling scenarios
- [x] Tests added for retry functionality
- [x] Tests added for `require` mode behavior
- [ ] Manual testing: trigger worktree creation failure (e.g., try branch that's already checked out)
- [ ] Verify retry with different branch works
- [ ] Verify skip continues in main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)