### PR TITLE
Fix !kill to preserve sessions and not restart in daemon mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,8 @@ function wirePlatformEvents(
       },
       onKill: (username) => {
         ui.addLog({ level: 'error', component: '🔴', message: `EMERGENCY SHUTDOWN initiated by @${username}` });
-        process.exit(1);
+        // Exit with code 0 so daemon doesn't restart us
+        process.exit(0);
       },
     });
   });

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -45,7 +45,7 @@ function createMockSessionManager() {
     isUserAllowedInSession: mock(() => true),
     getActiveThreadIds: mock(() => []),
     getPersistedSession: mock(() => undefined),
-    killAllSessionsAndUnpersist: mock(() => {}),
+    killAllSessions: mock(async () => {}),
     cancelSession: mock(async () => {}),
     interruptSession: mock(async () => {}),
     inviteUser: mock(async () => {}),
@@ -103,7 +103,7 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.killAllSessionsAndUnpersist).toHaveBeenCalled();
+      expect(session.killAllSessions).toHaveBeenCalled();
       expect(client.disconnect).toHaveBeenCalled();
       expect(onKill).toHaveBeenCalledWith('admin');
     });
@@ -122,7 +122,7 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.killAllSessionsAndUnpersist).not.toHaveBeenCalled();
+      expect(session.killAllSessions).not.toHaveBeenCalled();
       expect(client.createPost).toHaveBeenCalled();
     });
 
@@ -143,7 +143,7 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.killAllSessionsAndUnpersist).toHaveBeenCalled();
+      expect(session.killAllSessions).toHaveBeenCalled();
     });
   });
 
@@ -812,7 +812,7 @@ describe('handleMessage', () => {
       // First call is the confirmation to the thread where !kill was issued
       expect((client.createPost as any).mock.calls[0][0]).toContain('EMERGENCY SHUTDOWN');
       expect((client.createPost as any).mock.calls[0][0]).toContain('killing 2 active sessions');
-      expect(session.killAllSessionsAndUnpersist).toHaveBeenCalled();
+      expect(session.killAllSessions).toHaveBeenCalled();
     });
 
     test('posts confirmation even with no active sessions', async () => {
@@ -836,7 +836,7 @@ describe('handleMessage', () => {
       // Should have posted confirmation even with no active sessions
       expect(client.createPost).toHaveBeenCalledTimes(1);
       expect((client.createPost as any).mock.calls[0][0]).toContain('killing 0 active sessions');
-      expect(session.killAllSessionsAndUnpersist).toHaveBeenCalled();
+      expect(session.killAllSessions).toHaveBeenCalled();
     });
 
     test('does not duplicate notification when kill issued from active session thread', async () => {
@@ -865,7 +865,7 @@ describe('handleMessage', () => {
       expect((client.createPost as any).mock.calls[0][1]).toBe('thread1');
       // Second call is notification to thread2 only
       expect((client.createPost as any).mock.calls[1][1]).toBe('thread2');
-      expect(session.killAllSessionsAndUnpersist).toHaveBeenCalled();
+      expect(session.killAllSessions).toHaveBeenCalled();
     });
 
     test('continues kill even if notifying a thread fails', async () => {
@@ -896,7 +896,7 @@ describe('handleMessage', () => {
       await handleMessage(client, session, post, user, options);
 
       // Kill should still proceed
-      expect(session.killAllSessionsAndUnpersist).toHaveBeenCalled();
+      expect(session.killAllSessions).toHaveBeenCalled();
       expect(onKill).toHaveBeenCalledWith('admin');
     });
   });

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -26,10 +26,10 @@ export interface MessageHandlerOptions {
   platformId: string;
   logger?: MessageHandlerLogger;
   /**
-   * Called when !kill command is executed. In production this calls process.exit(1).
+   * Called when !kill command is executed. In production this calls process.exit(0).
    * In tests this can just disconnect without exiting.
    */
-  onKill?: (username: string) => void;
+  onKill?: (username: string) => void | Promise<void>;
 }
 
 /**
@@ -83,10 +83,10 @@ export async function handleMessage(
         }
       }
       logger?.error(`EMERGENCY SHUTDOWN initiated by @${username}`);
-      session.killAllSessionsAndUnpersist();
+      await session.killAllSessions();
       client.disconnect();
       // Call the kill callback (production calls process.exit, tests just return)
-      onKill?.(username);
+      await onKill?.(username);
       return;
     }
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -229,15 +229,8 @@ describe('SessionManager', () => {
   });
 
   describe('killAllSessions', () => {
-    test('does nothing when no sessions', async () => {
-      await manager.killAllSessions();
-      // Should not throw
-    });
-  });
-
-  describe('killAllSessionsAndUnpersist', () => {
     test('does nothing when no sessions', () => {
-      manager.killAllSessionsAndUnpersist();
+      manager.killAllSessions();
       // Should not throw
     });
   });

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1377,16 +1377,6 @@ export class SessionManager extends EventEmitter {
     }
   }
 
-  killAllSessionsAndUnpersist(): void {
-    for (const session of this.sessions.values()) {
-      this.stopTyping(session);
-      session.claude.kill();
-      this.unpersistSession(session.sessionId);
-    }
-    this.sessions.clear();
-    this.postIndex.clear();
-  }
-
   isUserAllowedInSession(threadId: string, username: string): boolean {
     const session = this.findSessionByThreadId(threadId);
     if (!session) {


### PR DESCRIPTION
## Summary

- Remove duplicate sync `killAllSessions()`, use existing async version from lifecycle module
- Await `killAllSessions()` in message handler
- Change exit code from 1 to 0 so daemon doesn't auto-restart

## Problem

Previously `!kill` would:
1. Delete persisted sessions (calling `unpersistSession()` for each)
2. Exit with code 1

In daemon mode, exit code 1 with `--restart-on-error` would trigger an immediate restart, defeating the purpose of an emergency shutdown.

## Solution

Now `!kill`:
1. Preserves sessions (they remain persisted and can resume after manual restart)
2. Exits with code 0 (daemon treats this as clean exit, no restart)

## Test plan

- [x] Unit tests pass
- [x] Build succeeds
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)