### PR TITLE
Fix !update emoji reactions not triggering updates

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -678,7 +678,8 @@ export interface AutoUpdateManagerInterface {
  */
 export async function showUpdateStatus(
   session: Session,
-  updateManager: AutoUpdateManagerInterface | null
+  updateManager: AutoUpdateManagerInterface | null,
+  ctx: SessionContext
 ): Promise<void> {
   const formatter = session.platform.getFormatter();
 
@@ -727,6 +728,8 @@ export async function showUpdateStatus(
 
   // Store pending update prompt for reaction handling
   session.pendingUpdatePrompt = { postId: post.id };
+  // Register post in index so reactions can find the session
+  ctx.ops.registerPost(post.id, session.threadId);
 }
 
 /**

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1219,7 +1219,7 @@ export class SessionManager extends EventEmitter {
   async showUpdateStatus(threadId: string, _username: string): Promise<void> {
     const session = this.findSessionByThreadId(threadId);
     if (!session) return;
-    await commands.showUpdateStatus(session, this.autoUpdateManager);
+    await commands.showUpdateStatus(session, this.autoUpdateManager, this.getContext());
   }
 
   async forceUpdateNow(threadId: string, username: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Fixed `showUpdateStatus` (the `!update` command) missing `registerPost()` call after creating interactive post
- Without post registration, reaction handler couldn't find the session and silently ignored reactions
- Same fix pattern as #124 but for the `!update` command path

## Test plan
- [x] Build passes
- [x] All 1300 tests pass
- [ ] Deploy and test `!update` command in Mattermost - verify 👍/👎 reactions trigger update/defer

🤖 Generated with [Claude Code](https://claude.ai/code)