### PR TITLE
Fix reconnecting mode display in platforms UI

### DIFF
--- a/src/ui/components/Platforms.tsx
+++ b/src/ui/components/Platforms.tsx
@@ -42,16 +42,17 @@ export function Platforms({ platforms }: PlatformsProps) {
           {/* Bot name */}
           <Text color={platform.enabled ? "cyan" : undefined} dimColor={!platform.enabled}>@{platform.botName}</Text>
 
-          {/* Platform display name */}
-          <Text dimColor>on</Text>
-          <Text dimColor={!platform.enabled}>{platform.displayName}</Text>
-
-          {/* Reconnecting indicator with spinner */}
-          {platform.reconnecting && (
-            <Box gap={1}>
+          {/* Platform display name - show reconnecting status inline if reconnecting */}
+          {platform.reconnecting ? (
+            <>
               <Spinner type="dots" />
               <Text color="yellow">reconnecting ({platform.reconnectAttempts})</Text>
-            </Box>
+            </>
+          ) : (
+            <>
+              <Text dimColor>on</Text>
+              <Text dimColor={!platform.enabled}>{platform.displayName}</Text>
+            </>
           )}
         </Box>
       ))}


### PR DESCRIPTION
## Summary
- Fix misaligned UI display when a platform is in reconnecting state
- Show spinner and reconnect status inline instead of appending after platform name

**Before:** `2. S ◌ @bot on Slack Test : reconnecting (10)` (messy, misaligned)
**After:** `2. S ◌ @bot ⠋ reconnecting (10)` (clean, aligned)

## Test plan
- [ ] Start the bot with a platform that disconnects/reconnects
- [ ] Verify the reconnecting status displays cleanly inline
- [ ] Verify normal connected state still shows "on {displayName}"

🤖 Generated with [Claude Code](https://claude.com/claude-code)