### PR TITLE
feat: Enhanced subagent display with live elapsed time and toggle

### DIFF
--- a/src/session/error-handler.test.ts
+++ b/src/session/error-handler.test.ts
@@ -68,6 +68,7 @@ function createMockSession(): Session {
     // Timers
     updateTimer: null,
     typingTimer: null,
+    subagentUpdateTimer: null,
 
     // Flags
     timeoutWarningPosted: false,

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -67,6 +67,9 @@ function createMockSession(overrides?: Partial<Session>): Session {
     sessionAllowedUsers: new Set(['testuser']),
     workingDir: '/test',
     activeSubagents: new Map(),
+    updateTimer: null,
+    typingTimer: null,
+    subagentUpdateTimer: null,
     isResumed: false,
     sessionStartPostId: 'start-post-id',
     currentPostContent: '',
@@ -273,11 +276,30 @@ describe('Session State Management', () => {
 
     expect(session.activeSubagents.size).toBe(0);
 
-    session.activeSubagents.set('tool-1', 'post-1');
-    session.activeSubagents.set('tool-2', 'post-2');
+    const subagent1 = {
+      postId: 'post-1',
+      startTime: Date.now(),
+      description: 'Test task 1',
+      subagentType: 'general',
+      isMinimized: false,
+      isComplete: false,
+      lastUpdateTime: Date.now(),
+    };
+    const subagent2 = {
+      postId: 'post-2',
+      startTime: Date.now(),
+      description: 'Test task 2',
+      subagentType: 'Explore',
+      isMinimized: false,
+      isComplete: false,
+      lastUpdateTime: Date.now(),
+    };
+
+    session.activeSubagents.set('tool-1', subagent1);
+    session.activeSubagents.set('tool-2', subagent2);
 
     expect(session.activeSubagents.size).toBe(2);
-    expect(session.activeSubagents.get('tool-1')).toBe('post-1');
+    expect(session.activeSubagents.get('tool-1')?.postId).toBe('post-1');
   });
 
   it('tracks session allowed users', () => {

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -54,7 +54,7 @@ function mutablePostIndex(ctx: SessionContext): Map<string, string> {
 }
 
 /**
- * Clean up session timers (updateTimer and statusBarTimer).
+ * Clean up session timers (updateTimer, statusBarTimer, subagentUpdateTimer).
  * Call this before removing a session from the map.
  */
 function cleanupSessionTimers(session: Session): void {
@@ -65,6 +65,10 @@ function cleanupSessionTimers(session: Session): void {
   if (session.statusBarTimer) {
     clearInterval(session.statusBarTimer);
     session.statusBarTimer = null;
+  }
+  if (session.subagentUpdateTimer) {
+    clearInterval(session.subagentUpdateTimer);
+    session.subagentUpdateTimer = null;
   }
 }
 
@@ -320,6 +324,7 @@ export async function startSession(
     activeSubagents: new Map(),
     updateTimer: null,
     typingTimer: null,
+    subagentUpdateTimer: null,
     timeoutWarningPosted: false,
     isRestarting: false,
     isResumed: false,
@@ -527,6 +532,7 @@ export async function resumeSession(
     activeSubagents: new Map(),
     updateTimer: null,
     typingTimer: null,
+    subagentUpdateTimer: null,
     timeoutWarningPosted: false,
     isRestarting: false,
     isResumed: true,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -23,7 +23,7 @@ import {
   isCancelEmoji,
   isEscapeEmoji,
   isResumeEmoji,
-  isTaskToggleEmoji,
+  isMinimizeToggleEmoji,
   getNumberEmojiIndex,
 } from '../utils/emoji.js';
 import { normalizeEmojiName } from '../platform/utils.js';
@@ -545,9 +545,16 @@ export class SessionManager extends EventEmitter {
     }
 
     // Handle task list toggle reactions (minimize/expand) - state-based on both add and remove
-    if (session.tasksPostId === postId && isTaskToggleEmoji(emojiName)) {
+    if (session.tasksPostId === postId && isMinimizeToggleEmoji(emojiName)) {
       await reactions.handleTaskToggleReaction(session, action, this.getContext());
       return;
+    }
+
+    // Handle subagent toggle reactions (minimize/expand) - state-based on both add and remove
+    // Uses same emoji as task toggle (🔽)
+    if (isMinimizeToggleEmoji(emojiName)) {
+      const handled = await events.handleSubagentToggleReaction(session, postId, action);
+      if (handled) return;
     }
 
     // Handle bug report emoji reaction on error posts (only on add)

--- a/src/session/reactions.test.ts
+++ b/src/session/reactions.test.ts
@@ -104,6 +104,7 @@ function createTestSession(platform: PlatformClient): Session {
     activeSubagents: new Map(),
     updateTimer: null,
     typingTimer: null,
+    subagentUpdateTimer: null,
     timeoutWarningPosted: false,
     isRestarting: false,
     isResumed: false,

--- a/src/session/reactions.ts
+++ b/src/session/reactions.ts
@@ -12,7 +12,7 @@ import {
   isDenialEmoji,
   isAllowAllEmoji,
   getNumberEmojiIndex,
-  TASK_TOGGLE_EMOJIS,
+  MINIMIZE_TOGGLE_EMOJIS,
   isBugReportEmoji,
 } from '../utils/emoji.js';
 import { postCurrentQuestion } from './events.js';
@@ -266,7 +266,7 @@ export async function handleTaskToggleReaction(
 
   // Ensure the toggle emoji is present (may have been removed during toggle)
   try {
-    await session.platform.addReaction(tasksPostId, TASK_TOGGLE_EMOJIS[0]);
+    await session.platform.addReaction(tasksPostId, MINIMIZE_TOGGLE_EMOJIS[0]);
   } catch {
     // Ignore errors - emoji may already exist or reaction failed
   }

--- a/src/session/sticky-message.test.ts
+++ b/src/session/sticky-message.test.ts
@@ -74,6 +74,7 @@ function createMockSession(overrides: Partial<Session> = {}): Session {
     activeSubagents: new Map(),
     updateTimer: null,
     typingTimer: null,
+    subagentUpdateTimer: null,
     timeoutWarningPosted: false,
     isRestarting: false,
     isResumed: false,

--- a/src/session/streaming.test.ts
+++ b/src/session/streaming.test.ts
@@ -111,6 +111,7 @@ function createTestSession(platform: PlatformClient): Session {
     activeSubagents: new Map(),
     updateTimer: null,
     typingTimer: null,
+    subagentUpdateTimer: null,
     timeoutWarningPosted: false,
     isRestarting: false,
     isResumed: false,

--- a/src/session/streaming.ts
+++ b/src/session/streaming.ts
@@ -9,7 +9,7 @@ import type { PlatformClient, PlatformFile, PlatformFormatter } from '../platfor
 import { truncateMessageSafely } from '../platform/utils.js';
 import type { Session } from './types.js';
 import type { ContentBlock } from '../claude/cli.js';
-import { TASK_TOGGLE_EMOJIS } from '../utils/emoji.js';
+import { MINIMIZE_TOGGLE_EMOJIS } from '../utils/emoji.js';
 import { createLogger } from '../utils/logger.js';
 import { withErrorHandling } from './error-handler.js';
 import { updateLastMessage } from './post-helpers.js';
@@ -505,7 +505,7 @@ async function bumpTasksToBottomWithContent(
 
     // Remove the toggle emoji from the old task post before repurposing it
     try {
-      await session.platform.removeReaction(oldTasksPostId, TASK_TOGGLE_EMOJIS[0]);
+      await session.platform.removeReaction(oldTasksPostId, MINIMIZE_TOGGLE_EMOJIS[0]);
     } catch (err) {
       sessionLog(session).debug(`Could not remove toggle emoji: ${err}`);
     }
@@ -539,7 +539,7 @@ async function bumpTasksToBottomWithContent(
 
       const newTasksPost = await session.platform.createInteractivePost(
         displayContent,
-        [TASK_TOGGLE_EMOJIS[0]], // Always add toggle emoji
+        [MINIMIZE_TOGGLE_EMOJIS[0]], // Always add toggle emoji
         session.threadId
       );
       session.tasksPostId = newTasksPost.id;
@@ -614,7 +614,7 @@ export async function bumpTasksToBottom(
 
     const newPost = await session.platform.createInteractivePost(
       displayContent,
-      [TASK_TOGGLE_EMOJIS[0]], // Always add toggle emoji
+      [MINIMIZE_TOGGLE_EMOJIS[0]], // Always add toggle emoji
       session.threadId
     );
     session.tasksPostId = newPost.id;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -118,6 +118,19 @@ export interface PendingUpdatePrompt {
   postId: string;
 }
 
+/**
+ * Active subagent tracking with extended metadata for display
+ */
+export interface ActiveSubagent {
+  postId: string;           // Post ID in chat
+  startTime: number;        // Date.now() when started
+  description: string;      // Full prompt text
+  subagentType: string;     // 'general-purpose', 'Explore', etc.
+  isMinimized: boolean;     // Toggle state (like tasksMinimized)
+  isComplete: boolean;      // True when subagent has finished
+  lastUpdateTime: number;   // Last time we updated the post (for debouncing)
+}
+
 // =============================================================================
 // Session Type
 // =============================================================================
@@ -170,11 +183,12 @@ export interface Session {
   lastTasksContent: string | null;  // Last task list content (for re-posting when bumping to bottom)
   tasksCompleted: boolean;  // True when all tasks are done (stops sticky behavior)
   tasksMinimized: boolean;  // True when task list is minimized (show only progress)
-  activeSubagents: Map<string, string>;  // toolUseId -> postId
+  activeSubagents: Map<string, ActiveSubagent>;  // toolUseId -> subagent metadata
 
   // Timers (per-session)
   updateTimer: ReturnType<typeof setTimeout> | null;
   typingTimer: ReturnType<typeof setInterval> | null;
+  subagentUpdateTimer: ReturnType<typeof setInterval> | null;  // For updating elapsed time
 
   // Timeout warning state
   timeoutWarningPosted: boolean;

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -28,8 +28,8 @@ export const ESCAPE_EMOJIS = ['double_vertical_bar', 'pause_button', 'pause'] as
 /** Emojis for resuming a timed-out session */
 export const RESUME_EMOJIS = ['arrows_counterclockwise', 'arrow_forward', 'repeat'] as const;
 
-/** Emojis for toggling task list visibility (minimize/expand) */
-export const TASK_TOGGLE_EMOJIS = ['arrow_down_small', 'small_red_triangle_down'] as const;
+/** Emojis for toggling visibility (minimize/expand) - used for task lists and subagents */
+export const MINIMIZE_TOGGLE_EMOJIS = ['arrow_down_small', 'small_red_triangle_down'] as const;
 
 /** Bug report emoji for quick error reporting */
 export const BUG_REPORT_EMOJI = 'bug' as const;
@@ -77,10 +77,10 @@ export function isResumeEmoji(emoji: string): boolean {
 }
 
 /**
- * Check if the emoji indicates task list toggle (minimize/expand)
+ * Check if the emoji indicates minimize/expand toggle (used for tasks and subagents)
  */
-export function isTaskToggleEmoji(emoji: string): boolean {
-  return (TASK_TOGGLE_EMOJIS as readonly string[]).includes(emoji);
+export function isMinimizeToggleEmoji(emoji: string): boolean {
+  return (MINIMIZE_TOGGLE_EMOJIS as readonly string[]).includes(emoji);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Live elapsed time** - Subagents now show elapsed time that updates every 5 seconds while running (e.g., "⏳ 12s" → "⏳ 17s")
- **Collapsible prompt** - Click the 🔽 emoji to toggle between expanded (shows full prompt) and minimized view
- **Completion summary** - When done, shows final elapsed time (e.g., "✅ 47s")
- **Renamed emoji constants** - `TASK_TOGGLE_EMOJIS` → `MINIMIZE_TOGGLE_EMOJIS` since it's now used by both task lists and subagents

## Display Examples

**Running (expanded):**
```
🤖 Subagent (general-purpose) ⏳ 12s
📋 Prompt:
> Find how subagents are displayed in the chat output...
🔽
```

**Running (minimized):**
```
🤖 Subagent (general-purpose) ⏳ 12s 🔽
```

**Completed:**
```
🤖 Subagent (general-purpose) ✅ 47s 🔽
```

## Test plan

- [x] All 1308 unit tests pass
- [x] Build succeeds
- [x] Lint passes (only pre-existing warnings)
- [ ] Manual testing: Start a session that triggers subagent tasks
- [ ] Verify elapsed time updates every ~5s
- [ ] Verify 🔽 toggle works (click to minimize/expand)
- [ ] Verify timer stops when subagent completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)