### PR TITLE
Fix title and tag suggestions timing out

### DIFF
--- a/src/session/tag-suggest.test.ts
+++ b/src/session/tag-suggest.test.ts
@@ -340,7 +340,7 @@ describe('suggestSessionTags', () => {
     expect(mockQuickQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'haiku',
-        timeout: 2000,
+        timeout: 15000,
       })
     );
     // Check prompt contains the user message

--- a/src/session/tag-suggest.ts
+++ b/src/session/tag-suggest.ts
@@ -12,7 +12,7 @@ import { createLogger } from '../utils/logger.js';
 const log = createLogger('tag-suggest');
 
 /** Default timeout for tag suggestions (ms) */
-const SUGGESTION_TIMEOUT = 2000;
+const SUGGESTION_TIMEOUT = 15000;
 
 /** Maximum number of tags per session */
 const MAX_TAGS = 3;

--- a/src/session/title-suggest.test.ts
+++ b/src/session/title-suggest.test.ts
@@ -376,7 +376,7 @@ describe('suggestSessionMetadata', () => {
     expect(mockQuickQuery).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'haiku',
-        timeout: 3000,
+        timeout: 15000,
       })
     );
     // Check prompt contains the user message

--- a/src/session/title-suggest.ts
+++ b/src/session/title-suggest.ts
@@ -12,7 +12,7 @@ import { createLogger } from '../utils/logger.js';
 const log = createLogger('title-suggest');
 
 /** Default timeout for title suggestions (ms) */
-const SUGGESTION_TIMEOUT = 3000;
+const SUGGESTION_TIMEOUT = 15000;
 
 /** Minimum title length */
 const MIN_TITLE_LENGTH = 3;


### PR DESCRIPTION
## Summary
- Fixed title suggestions timing out (increased timeout from 3s to 15s)
- Fixed tag suggestions timing out (increased timeout from 2s to 15s)

## Problem
The Claude CLI takes approximately 6-8 seconds to start up and respond. The title and tag suggestion modules added in PR #175 had timeouts that were too aggressive:
- `title-suggest.ts`: 3000ms (3 seconds)
- `tag-suggest.ts`: 2000ms (2 seconds)

This caused all suggestions to consistently fail with timeout errors.

## Solution
Increased the timeouts to 15000ms (15 seconds), matching the fix applied to `branch-suggest.ts` in v0.53.1 (commit d3c4c1c).

## Test plan
- [x] Verified `quickQuery` works with 15s timeout
- [x] Tested `suggestSessionMetadata` - now returns valid title/description
- [x] Tested `suggestSessionTags` - now returns valid tags
- [x] All 1378 unit tests pass
- [x] Lint passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)