### PR TITLE
feat: Preserve runtime settings across daemon auto-restarts

### DIFF
--- a/src/auto-update/installer.ts
+++ b/src/auto-update/installer.ts
@@ -10,7 +10,7 @@ import { dirname, resolve } from 'path';
 import { homedir } from 'os';
 import { createLogger } from '../utils/logger.js';
 import { VERSION } from '../version.js';
-import type { PersistedUpdateState, UpdateInfo } from './types.js';
+import type { PersistedUpdateState, RuntimeSettings, UpdateInfo } from './types.js';
 import { UPDATE_STATE_FILENAME } from './types.js';
 
 const log = createLogger('installer');
@@ -85,6 +85,32 @@ export function checkJustUpdated(): { previousVersion: string; currentVersion: s
   }
 
   return null;
+}
+
+/**
+ * Save runtime settings (to restore after daemon restart).
+ */
+export function saveRuntimeSettings(settings: RuntimeSettings): void {
+  const state = loadUpdateState();
+  saveUpdateState({ ...state, runtimeSettings: settings });
+}
+
+/**
+ * Get saved runtime settings.
+ */
+export function getRuntimeSettings(): RuntimeSettings | undefined {
+  return loadUpdateState().runtimeSettings;
+}
+
+/**
+ * Clear runtime settings (after restoring them on daemon restart).
+ */
+export function clearRuntimeSettings(): void {
+  const state = loadUpdateState();
+  if (state.runtimeSettings) {
+    delete state.runtimeSettings;
+    saveUpdateState(state);
+  }
 }
 
 /**

--- a/src/auto-update/types.ts
+++ b/src/auto-update/types.ts
@@ -112,6 +112,21 @@ export type UpdateStatus =
   | 'failed'          // Installation failed
   | 'deferred';       // User deferred the update
 
+/** Runtime settings that can be toggled via UI */
+export interface RuntimeSettings {
+  /** Skip permission prompts (auto-approve) */
+  skipPermissions?: boolean;
+
+  /** Enable Claude in Chrome integration */
+  chromeEnabled?: boolean;
+
+  /** Enable keep-alive pings */
+  keepAliveEnabled?: boolean;
+
+  /** Enable debug logging */
+  debugEnabled?: boolean;
+}
+
 /** Persisted update state (survives restarts) */
 export interface PersistedUpdateState {
   /** Previous version before update (for rollback instructions) */
@@ -131,6 +146,9 @@ export interface PersistedUpdateState {
 
   /** Deferred until this time (ISO string) */
   deferredUntil?: string;
+
+  /** Runtime settings to restore after daemon restart */
+  runtimeSettings?: RuntimeSettings;
 }
 
 /** Runtime update state (in-memory) */


### PR DESCRIPTION
## Summary
- Preserves runtime settings (debug, permissions, chrome, keep-alive) across daemon auto-restarts
- Settings toggled via UI are stored in `update-state.json`
- On daemon restart (when `justUpdated=true`), settings are restored
- Settings are cleared after restore so manual starts use config defaults

## Test plan
- [ ] Toggle settings via UI (d/p/c/k keys)
- [ ] Trigger an auto-update or simulate by setting `justUpdated: true` in `update-state.json`
- [ ] Restart the bot
- [ ] Verify settings are restored
- [ ] Stop and restart manually
- [ ] Verify settings reset to config.yaml defaults

🤖 Generated with [Claude Code](https://claude.ai/code)