### PR TITLE
fix: Make !update now check for updates consistently with !update

### DIFF
--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -757,13 +757,17 @@ export async function forceUpdateNow(
     return;
   }
 
-  if (!updateManager.hasUpdate()) {
+  // Check for updates first (same as !update does) to ensure we have fresh data
+  // This fixes the inconsistency where !update finds updates but !update now doesn't
+  const updateInfo = await updateManager.checkNow();
+
+  if (!updateInfo || !updateInfo.available) {
     await postInfo(session, `No update available to install`);
     return;
   }
 
   await postInfo(session,
-    `🔄 ${formatter.formatBold('Forcing update')} - restarting shortly...\n` +
+    `🔄 ${formatter.formatBold('Forcing update')} to v${updateInfo.latestVersion} - restarting shortly...\n` +
     formatter.formatItalic('Sessions will resume automatically')
   );
 


### PR DESCRIPTION
## Summary

- Fixed inconsistency where `!update` found updates but `!update now` said "no updates available"
- Root cause: `!update now` used `hasUpdate()` (cached state) while `!update` used `checkNow()` (fresh npm check)
- Now both commands use `checkNow()` for consistent behavior
- Also improved the status message to show which version will be installed

## Test plan

- [ ] Run `!update` and note if an update is available
- [ ] Run `!update now` and verify it finds the same update (previously it might say "no update")
- [ ] Verify the message now shows the target version: "Forcing update to vX.Y.Z"

🤖 Generated with [Claude Code](https://claude.ai/code)