### PR TITLE
fix: Truncate long titles/descriptions instead of rejecting them

### DIFF
--- a/src/session/events.ts
+++ b/src/session/events.ts
@@ -15,7 +15,7 @@ import {
   DENIAL_EMOJIS,
   MINIMIZE_TOGGLE_EMOJIS,
 } from '../utils/emoji.js';
-import { formatDuration } from '../utils/format.js';
+import { formatDuration, truncateAtWord } from '../utils/format.js';
 import {
   shouldFlushEarly,
   MIN_BREAK_THRESHOLD,
@@ -406,14 +406,7 @@ function formatEvent(
         } else if (block.type === 'thinking' && block.thinking) {
           // Extended thinking - show abbreviated version in blockquote
           const thinking = block.thinking as string;
-          const maxLength = 200;
-          let preview = thinking;
-          if (thinking.length > maxLength) {
-            // Cut at word boundary
-            const truncated = thinking.substring(0, maxLength);
-            const lastSpace = truncated.lastIndexOf(' ');
-            preview = (lastSpace > maxLength * 0.7 ? truncated.substring(0, lastSpace) : truncated) + '...';
-          }
+          const preview = truncateAtWord(thinking, 200);
           // Use blockquote for better formatting
           const formatter = session.platform.getFormatter();
           parts.push(formatter.formatBlockquote(`💭 ${formatter.formatItalic(preview)}`));

--- a/src/session/title-suggest.test.ts
+++ b/src/session/title-suggest.test.ts
@@ -198,12 +198,27 @@ describe('parseMetadata', () => {
     expect(metadata?.title).toBe('Fix');
   });
 
-  test('returns null when title is too long (more than 50 chars)', () => {
-    const longTitle = 'a'.repeat(51);
+  test('truncates title at word boundary when too long (more than 50 chars)', () => {
+    // Title with words that exceeds 50 chars
+    const longTitle = 'Fix the authentication bug in the login system now please';
     const response = `TITLE: ${longTitle}\nDESC: Valid description here.`;
     const metadata = parseMetadata(response);
 
-    expect(metadata).toBeNull();
+    expect(metadata).not.toBeNull();
+    expect(metadata?.title.length).toBeLessThanOrEqual(50);
+    expect(metadata?.title).toContain('…');
+    // Should break at word boundary, not mid-word
+    expect(metadata?.title).toBe('Fix the authentication bug in the login system…');
+  });
+
+  test('hard truncates title when no good word boundary', () => {
+    const longTitle = 'a'.repeat(60);
+    const response = `TITLE: ${longTitle}\nDESC: Valid description here.`;
+    const metadata = parseMetadata(response);
+
+    expect(metadata).not.toBeNull();
+    expect(metadata?.title.length).toBe(50);
+    expect(metadata?.title).toContain('…');
   });
 
   test('accepts title at maximum length (50 chars)', () => {
@@ -215,7 +230,7 @@ describe('parseMetadata', () => {
     expect(metadata?.title).toBe(maxTitle);
   });
 
-  // Description length validation tests (MIN_DESC_LENGTH = 5, MAX_DESC_LENGTH = 100)
+  // Description length validation tests (MIN_DESC_LENGTH = 5, MAX_DESC_LENGTH = 200)
   test('returns null when description is too short (less than 5 chars)', () => {
     const response = 'TITLE: Valid title\nDESC: Test';
     const metadata = parseMetadata(response);
@@ -231,16 +246,29 @@ describe('parseMetadata', () => {
     expect(metadata?.description).toBe('Tests');
   });
 
-  test('returns null when description is too long (more than 100 chars)', () => {
-    const longDesc = 'a'.repeat(101);
+  test('truncates description at word boundary when too long (more than 200 chars)', () => {
+    // Description with words that exceeds 200 chars
+    const longDesc = 'This is a very long description that explains what will be accomplished in great detail including all the steps and actions that need to be taken to complete the task successfully with all requirements met and all tests passing';
     const response = `TITLE: Valid title\nDESC: ${longDesc}`;
     const metadata = parseMetadata(response);
 
-    expect(metadata).toBeNull();
+    expect(metadata).not.toBeNull();
+    expect(metadata?.description.length).toBeLessThanOrEqual(200);
+    expect(metadata?.description).toContain('…');
   });
 
-  test('accepts description at maximum length (100 chars)', () => {
-    const maxDesc = 'a'.repeat(100);
+  test('hard truncates description when no good word boundary', () => {
+    const longDesc = 'a'.repeat(250);
+    const response = `TITLE: Valid title\nDESC: ${longDesc}`;
+    const metadata = parseMetadata(response);
+
+    expect(metadata).not.toBeNull();
+    expect(metadata?.description.length).toBe(200);
+    expect(metadata?.description).toContain('…');
+  });
+
+  test('accepts description at maximum length (200 chars)', () => {
+    const maxDesc = 'a'.repeat(200);
     const response = `TITLE: Valid title\nDESC: ${maxDesc}`;
     const metadata = parseMetadata(response);
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -357,6 +357,30 @@ export function truncate(str: string, maxLength: number): string {
 }
 
 /**
+ * Truncate a string at a word boundary with ellipsis.
+ * Tries to break at the last space, but falls back to hard truncation
+ * if the last space is too early (< 70% of maxLength).
+ *
+ * @param str - The string to truncate
+ * @param maxLength - Maximum length including ellipsis
+ * @returns Truncated string with ellipsis if truncated
+ */
+export function truncateAtWord(str: string, maxLength: number): string {
+  if (str.length <= maxLength) return str;
+
+  const truncated = str.substring(0, maxLength - 1); // Leave room for ellipsis
+  const lastSpace = truncated.lastIndexOf(' ');
+
+  // Break at word boundary if the last space is reasonably far into the string (>70%)
+  if (lastSpace > maxLength * 0.7) {
+    return truncated.substring(0, lastSpace) + '…';
+  }
+
+  // Fall back to hard truncation
+  return truncated + '…';
+}
+
+/**
  * Pluralize a word based on count.
  *
  * @param count - The count


### PR DESCRIPTION
## Summary

- Title suggestions were silently failing when Claude produced descriptions over 100 characters
- Now truncates at word boundaries instead of rejecting
- Added `truncateAtWord()` utility for word-boundary-aware truncation with ellipsis indicator

## Changes

- **Lenient validation**: Prompt asks for "under 100 chars" but we accept up to 200 (then truncate)
- **Word-boundary truncation**: Breaks at last space when possible (>70% of max length)
- **Ellipsis indicator**: Shows `…` when content was truncated
- **Refactored**: `events.ts` thinking preview now uses same utility

## Test plan

- [x] Unit tests pass for `truncateAtWord()` 
- [x] Unit tests updated for title/description truncation behavior
- [x] Manual test: complex prompts now produce titles instead of silently failing