### PR TITLE
feat: Enhance audit logging and integrate logs with bug reports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.25.1",
+        "@redactpii/node": "^1.0.16",
         "cli-spinners": "^3.3.0",
         "commander": "^14.0.2",
         "diff": "^8.0.2",
@@ -76,6 +77,8 @@
     "@pnpm/network.ca-file": ["@pnpm/network.ca-file@1.0.2", "", { "dependencies": { "graceful-fs": "4.2.10" } }, "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA=="],
 
     "@pnpm/npm-conf": ["@pnpm/npm-conf@2.3.1", "", { "dependencies": { "@pnpm/config.env-replace": "^1.1.0", "@pnpm/network.ca-file": "^1.0.1", "config-chain": "^1.1.11" } }, "sha512-c83qWb22rNRuB0UaVCI0uRPNRr8Z0FWnEIvT47jiHAmOIUHbBOg5XvV7pM5x+rKn9HRpjxquDbXYSXr3fAKFcw=="],
+
+    "@redactpii/node": ["@redactpii/node@1.0.16", "", {}, "sha512-8gVDlnmyAyqMbA3yjiKIFgT6hzMzKJzBLJZQbX6Jv8Qxe3axT3CQQq5ar8kI3vQvSB8VbTisL66Hg4eHJRycqQ=="],
 
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
+    "@redactpii/node": "^1.0.16",
     "cli-spinners": "^3.3.0",
     "commander": "^14.0.2",
     "diff": "^8.0.2",

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -355,7 +355,7 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'please help me with this code', undefined);
+      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'please help me with this code', undefined, 'allowed-user', 'User');
     });
 
     test('requests approval for unauthorized user', async () => {
@@ -994,7 +994,7 @@ describe('handleMessage', () => {
 
       expect(session.handleWorktreeBranchResponse).toHaveBeenCalled();
       // Should fall through to sendFollowUp
-      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'not a valid branch response', undefined);
+      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'not a valid branch response', undefined, 'allowed-user', 'User');
     });
 
     test('does not handle branch response for unauthorized user', async () => {

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -290,7 +290,7 @@ export async function handleMessage(
       // Get any attached files (images)
       const files = post.metadata?.files;
 
-      if (content || files?.length) await session.sendFollowUp(threadRoot, content, files);
+      if (content || files?.length) await session.sendFollowUp(threadRoot, content, files, username, user?.displayName);
       return;
     }
 

--- a/src/session/commands.ts
+++ b/src/session/commands.ts
@@ -41,6 +41,7 @@ import { formatPullRequestLink } from '../utils/pr-detector.js';
 import { getCurrentBranch, isGitRepository } from '../git/worktree.js';
 import { getClaudeCliVersion } from '../claude/version-check.js';
 import { shortenPath } from '../utils/tool-formatter.js';
+import { getLogFilePath } from '../persistence/thread-logger.js';
 
 const log = createLogger('commands');
 
@@ -640,6 +641,11 @@ export async function updateSessionHeader(
   }
 
   items.push(['🆔', 'Session ID', formatter.formatCode(session.claudeSessionId.substring(0, 8))]);
+
+  // Show log file path (sanitized)
+  const logPath = getLogFilePath(session.platform.platformId, session.threadId);
+  const shortLogPath = logPath.replace(process.env.HOME || '', '~');
+  items.push(['📋', 'Log File', formatter.formatCode(shortLogPath)]);
 
   // Check for available updates
   const updateInfo = getUpdateInfo();

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -356,7 +356,7 @@ export async function startSession(
   const existingSession = mutableSessions(ctx).get(existingSessionId);
   if (existingSession && existingSession.claude.isRunning()) {
     // Send as follow-up instead
-    await sendFollowUp(existingSession, options.prompt, options.files, ctx);
+    await sendFollowUp(existingSession, options.prompt, options.files, ctx, username, displayName);
     return;
   }
 
@@ -784,9 +784,19 @@ export async function sendFollowUp(
   session: Session,
   message: string,
   files: PlatformFile[] | undefined,
-  ctx: SessionContext
+  ctx: SessionContext,
+  username?: string,
+  displayName?: string
 ): Promise<void> {
   if (!session.claude.isRunning()) return;
+
+  // Log the user message
+  session.threadLogger?.logUserMessage(
+    username || session.startedBy,
+    message,
+    displayName,
+    files && files.length > 0
+  );
 
   // Flush any pending content before starting new message
   // This ensures code blocks and other structures are properly closed

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1154,10 +1154,10 @@ export class SessionManager extends EventEmitter {
     return undefined;
   }
 
-  async sendFollowUp(threadId: string, message: string, files?: PlatformFile[]): Promise<void> {
+  async sendFollowUp(threadId: string, message: string, files?: PlatformFile[], username?: string, displayName?: string): Promise<void> {
     const session = this.findSessionByThreadId(threadId);
     if (!session || !session.claude.isRunning()) return;
-    await lifecycle.sendFollowUp(session, message, files, this.getContext());
+    await lifecycle.sendFollowUp(session, message, files, this.getContext(), username, displayName);
   }
 
   isSessionActive(): boolean {

--- a/src/session/reactions.ts
+++ b/src/session/reactions.ts
@@ -55,6 +55,9 @@ export async function handleQuestionReaction(
   question.answer = selectedOption.label;
   sessionLog(session).debug(`💬 @${username} answered "${question.header}": ${selectedOption.label}`);
 
+  // Log the reaction
+  session.threadLogger?.logReaction('question_answer', username, emojiName, selectedOption.label);
+
   // Update the post to show answer
   const formatter = session.platform.getFormatter();
   await withErrorHandling(
@@ -113,6 +116,9 @@ export async function handleApprovalReaction(
   const { postId } = session.pendingApproval;
   // Note: toolUseId is no longer used - Claude Code CLI handles ExitPlanMode internally
   sessionLog(session).info(`${isApprove ? '✅' : '❌'} Plan ${isApprove ? 'approved' : 'rejected'} by @${username}`);
+
+  // Log the reaction
+  session.threadLogger?.logReaction(isApprove ? 'plan_approve' : 'plan_reject', username, emojiName);
 
   // Update the post to show the decision
   const formatter = session.platform.getFormatter();
@@ -183,6 +189,7 @@ export async function handleMessageApprovalReaction(
     session.lastActivityAt = new Date();
     ctx.ops.startTyping(session);
     sessionLog(session).info(`✅ Message from @${pending.fromUser} approved by @${approver}`);
+    session.threadLogger?.logReaction('message_approve', approver, emoji);
   } else if (isInvite) {
     // Invite user to session
     session.sessionAllowedUsers.add(pending.fromUser);
@@ -202,6 +209,7 @@ export async function handleMessageApprovalReaction(
       `❌ Message from ${formatter.formatUserMention(pending.fromUser)} denied by ${formatter.formatUserMention(approver)}`
     );
     sessionLog(session).info(`❌ Message from @${pending.fromUser} denied by @${approver}`);
+    session.threadLogger?.logReaction('message_reject', approver, emoji);
   }
 
   session.pendingMessageApproval = null;

--- a/src/types/redactpii.d.ts
+++ b/src/types/redactpii.d.ts
@@ -1,0 +1,50 @@
+/**
+ * Type declarations for @redactpii/node
+ *
+ * @redactpii/node is a zero-dependency PII redaction library.
+ * https://www.npmjs.com/package/@redactpii/node
+ */
+
+declare module '@redactpii/node' {
+  export interface RedactorOptions {
+    /** API key for dashboard integration (optional) */
+    apiKey?: string;
+    /** Custom API URL for dashboard (optional) */
+    apiUrl?: string;
+    /** Whether to fail silently on errors (default: true) */
+    failSilent?: boolean;
+    /** Timeout for dashboard hook in ms (default: 500) */
+    hookTimeout?: number;
+    /** Rule configuration - which rules to enable/disable */
+    rules?: {
+      CREDIT_CARD?: boolean;
+      EMAIL?: boolean;
+      NAME?: boolean;
+      PHONE?: boolean;
+      SSN?: boolean;
+    };
+    /** Custom rules to add */
+    customRules?: Array<{
+      pattern: RegExp;
+      name: string;
+      replaceWith?: string;
+    }>;
+    /** Global replacement string for all rules */
+    globalReplaceWith?: string;
+    /** Enable anonymization mode (use consistent tokens) */
+    anonymize?: boolean;
+    /** Enable aggressive mode for catching obfuscated patterns */
+    aggressive?: boolean;
+  }
+
+  export class Redactor {
+    constructor(options?: RedactorOptions);
+
+    /**
+     * Redact PII from text
+     * @param text - The text to redact
+     * @returns The redacted text with PII replaced by labels
+     */
+    redact(text: string): string;
+  }
+}


### PR DESCRIPTION
## Summary

- Add comprehensive logging for user messages, commands, reactions, and permissions
- Integrate audit logs with `!bug` reports (last 50 entries included in GitHub issues)
- Add username anonymization for GitHub issues (User1, User2, etc.)
- Add PII/secret redaction using `@redactpii/node` library (zero-dependency, actively maintained)
- Show log file path in session header

## Security

Two-layer sanitization approach for maximum protection:
1. **Custom patterns** for technical secrets: API keys, tokens, SSH keys, database URLs, JWT tokens
2. **@redactpii/node library** for general PII: emails, phone numbers, SSNs, credit cards, names

All sensitive data is redacted before appearing in GitHub issues.

## Test plan

- [x] All 1426 tests pass
- [x] New tests added for PII redaction (emails, phone numbers, credit cards, SSNs, obfuscated patterns)
- [x] Lint passes (no errors)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.ai/code)