### PR TITLE
feat: Improve session title stability with structured context

### DIFF
--- a/src/session/index.ts
+++ b/src/session/index.ts
@@ -21,6 +21,6 @@ export { getPendingPrompts, formatPendingPrompts } from './sticky-message.js';
 
 // Session metadata suggestion utilities (quickQuery-based)
 export { suggestSessionMetadata } from './title-suggest.js';
-export type { SessionMetadata } from './title-suggest.js';
+export type { SessionMetadata, TitleContext } from './title-suggest.js';
 export { suggestSessionTags, VALID_TAGS, isValidTag } from './tag-suggest.js';
 export type { SessionTag } from './tag-suggest.js';


### PR DESCRIPTION
## Summary

- **Introduce TitleContext interface** for title generation that uses the original task as the primary anchor for stability, with recent context as secondary input
- **Update periodic reclassification** to use structured context - titles now stay stable unless there's a fundamental focus shift
- **Remove dead code** - the old marker-based metadata extraction from events.ts is no longer needed since title/description generation moved out-of-band via quickQuery

## Problem

Session titles were constantly changing because the title generation only used the last few messages as context. This made titles unstable and confusing as the conversation evolved.

## Solution

The new approach uses a structured context with:
- `originalTask`: The first message that started the session (1000 char limit) - PRIMARY anchor
- `recentContext`: Latest user message (500 char limit) - SECONDARY, only matters if focus fundamentally changed
- `currentTitle`: The existing title, which the LLM is instructed to preserve unless there's a fundamental change

This prevents title thrashing when the conversation evolves but the main goal remains the same.

## Test plan

- [x] All 1438 unit tests pass
- [x] Added 8 new tests for TitleContext functionality
- [x] Updated truncation tests from 500 to 1000 chars for original task

🤖 Generated with [Claude Code](https://claude.com/claude-code)