### PR TITLE
feat: Add background cleanup scheduler and session monitor

### DIFF
--- a/src/cleanup/index.ts
+++ b/src/cleanup/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Background cleanup module
+ *
+ * Provides a scheduler for running cleanup tasks out of band.
+ */
+
+export { CleanupScheduler } from './scheduler.js';
+export type { CleanupSchedulerOptions, CleanupStats } from './scheduler.js';

--- a/src/cleanup/scheduler.test.ts
+++ b/src/cleanup/scheduler.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import { CleanupScheduler } from './scheduler.js';
+import type { SessionStore } from '../persistence/session-store.js';
+import type { PersistedSession } from '../persistence/session-store.js';
+
+// Mock session store
+function createMockSessionStore(sessions: Map<string, PersistedSession> = new Map()): SessionStore {
+  return {
+    load: () => sessions,
+    save: mock(() => {}),
+    remove: mock(() => {}),
+    cleanStale: mock(() => []),
+    cleanHistory: mock(() => 0),
+    getPath: () => '/tmp/test-sessions.json',
+  } as unknown as SessionStore;
+}
+
+describe('CleanupScheduler', () => {
+  let scheduler: CleanupScheduler;
+
+  afterEach(() => {
+    scheduler?.stop();
+  });
+
+  describe('constructor', () => {
+    it('should create scheduler with default options', () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({ sessionStore: store });
+
+      expect(scheduler).toBeDefined();
+    });
+
+    it('should accept custom options', () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        intervalMs: 5000,
+        logRetentionDays: 7,
+        threadLogsEnabled: false,
+      });
+
+      expect(scheduler).toBeDefined();
+    });
+  });
+
+  describe('start/stop', () => {
+    it('should start and stop without errors', () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        intervalMs: 60000, // Long interval to avoid actual runs
+      });
+
+      scheduler.start();
+      scheduler.stop();
+    });
+
+    it('should handle multiple start calls gracefully', () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        intervalMs: 60000,
+      });
+
+      scheduler.start();
+      scheduler.start(); // Should not throw
+      scheduler.stop();
+    });
+
+    it('should handle multiple stop calls gracefully', () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        intervalMs: 60000,
+      });
+
+      scheduler.start();
+      scheduler.stop();
+      scheduler.stop(); // Should not throw
+    });
+  });
+
+  describe('runCleanup', () => {
+    it('should run cleanup and return stats', async () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        threadLogsEnabled: false, // Disable to avoid file system operations
+      });
+
+      const stats = await scheduler.runCleanup();
+
+      expect(stats).toBeDefined();
+      expect(typeof stats.logsDeleted).toBe('number');
+      expect(typeof stats.worktreesCleaned).toBe('number');
+      expect(typeof stats.metadataCleaned).toBe('number');
+      expect(Array.isArray(stats.errors)).toBe(true);
+    });
+
+    it('should skip log cleanup when threadLogsEnabled is false', async () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        threadLogsEnabled: false,
+      });
+
+      const stats = await scheduler.runCleanup();
+
+      // Logs should be 0 when disabled
+      expect(stats.logsDeleted).toBe(0);
+    });
+
+    it('should handle cleanup errors gracefully', async () => {
+      const store = createMockSessionStore();
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        threadLogsEnabled: true,
+        logRetentionDays: 30,
+      });
+
+      // Even if there are no logs/worktrees, should complete without error
+      const stats = await scheduler.runCleanup();
+
+      expect(stats).toBeDefined();
+    });
+  });
+
+  describe('integration', () => {
+    it('should not clean worktrees in use by sessions', async () => {
+      // Create a session store with an active worktree
+      const sessions = new Map<string, PersistedSession>();
+      sessions.set('test-session', {
+        threadId: 'thread1',
+        platformId: 'test',
+        claudeSessionId: 'claude1',
+        workingDir: '/tmp/test',
+        startedBy: 'user',
+        worktreeInfo: {
+          repoRoot: '/tmp/repo',
+          worktreePath: '/tmp/active-worktree',
+          branch: 'feature',
+        },
+      } as PersistedSession);
+
+      const store = createMockSessionStore(sessions);
+      scheduler = new CleanupScheduler({
+        sessionStore: store,
+        threadLogsEnabled: false,
+      });
+
+      const stats = await scheduler.runCleanup();
+
+      // Should complete without cleaning the active worktree
+      expect(stats.errors.length).toBe(0);
+    });
+  });
+});

--- a/src/cleanup/scheduler.ts
+++ b/src/cleanup/scheduler.ts
@@ -1,0 +1,287 @@
+/**
+ * Background Cleanup Scheduler
+ *
+ * Runs cleanup tasks out of band to avoid blocking the main flow.
+ * Tasks include:
+ * - Log cleanup (thread logs older than retention period)
+ * - Orphan worktree cleanup (worktrees > 24h with no session)
+ * - Stale worktree metadata cleanup
+ */
+
+import { existsSync } from 'fs';
+import { readdir, rm } from 'fs/promises';
+import { join } from 'path';
+import { createLogger } from '../utils/logger.js';
+import { cleanupOldLogs } from '../persistence/thread-logger.js';
+import {
+  getWorktreesDir,
+  readWorktreeMetadata,
+  removeWorktreeMetadata,
+  removeWorktree as removeGitWorktree,
+  isBranchMerged,
+} from '../git/worktree.js';
+import type { SessionStore } from '../persistence/session-store.js';
+
+const log = createLogger('cleanup');
+
+/** Default cleanup interval: 1 hour */
+const DEFAULT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+
+/** Max age for worktrees before cleanup: 24 hours */
+const MAX_WORKTREE_AGE_MS = 24 * 60 * 60 * 1000;
+
+export interface CleanupSchedulerOptions {
+  /** Interval between cleanup runs in ms (default: 1 hour) */
+  intervalMs?: number;
+  /** Log retention in days (default: 30) */
+  logRetentionDays?: number;
+  /** Whether thread logs are enabled */
+  threadLogsEnabled?: boolean;
+  /** Session store for checking active worktrees */
+  sessionStore: SessionStore;
+}
+
+export interface CleanupStats {
+  logsDeleted: number;
+  worktreesCleaned: number;
+  metadataCleaned: number;
+  errors: string[];
+}
+
+/**
+ * CleanupScheduler - Runs background cleanup tasks periodically.
+ *
+ * Start with `start()`, stop with `stop()`.
+ * The scheduler runs cleanup immediately on start (fire-and-forget),
+ * then periodically at the configured interval.
+ */
+export class CleanupScheduler {
+  private readonly intervalMs: number;
+  private readonly logRetentionDays: number;
+  private readonly threadLogsEnabled: boolean;
+  private readonly sessionStore: SessionStore;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private isRunning = false;
+
+  constructor(options: CleanupSchedulerOptions) {
+    this.intervalMs = options.intervalMs ?? DEFAULT_CLEANUP_INTERVAL_MS;
+    this.logRetentionDays = options.logRetentionDays ?? 30;
+    this.threadLogsEnabled = options.threadLogsEnabled ?? true;
+    this.sessionStore = options.sessionStore;
+  }
+
+  /**
+   * Start the cleanup scheduler.
+   * Runs an initial cleanup immediately (fire-and-forget), then schedules periodic cleanup.
+   */
+  start(): void {
+    if (this.isRunning) {
+      log.debug('Cleanup scheduler already running');
+      return;
+    }
+
+    this.isRunning = true;
+    log.info(`Cleanup scheduler started (interval: ${Math.round(this.intervalMs / 60000)}min)`);
+
+    // Fire-and-forget initial cleanup
+    void this.runCleanup().catch(err => {
+      log.warn(`Initial cleanup failed: ${err}`);
+    });
+
+    // Schedule periodic cleanup
+    this.timer = setInterval(() => {
+      void this.runCleanup().catch(err => {
+        log.warn(`Periodic cleanup failed: ${err}`);
+      });
+    }, this.intervalMs);
+  }
+
+  /**
+   * Stop the cleanup scheduler.
+   */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.isRunning = false;
+    log.debug('Cleanup scheduler stopped');
+  }
+
+  /**
+   * Run all cleanup tasks.
+   * Can be called manually for immediate cleanup.
+   */
+  async runCleanup(): Promise<CleanupStats> {
+    const startTime = Date.now();
+    log.debug('Running background cleanup...');
+
+    const stats: CleanupStats = {
+      logsDeleted: 0,
+      worktreesCleaned: 0,
+      metadataCleaned: 0,
+      errors: [],
+    };
+
+    // Run cleanup tasks in parallel where possible
+    const [logStats, worktreeStats] = await Promise.all([
+      this.cleanupLogs().catch(err => {
+        stats.errors.push(`Log cleanup: ${err}`);
+        return 0;
+      }),
+      this.cleanupOrphanedWorktrees().catch(err => {
+        stats.errors.push(`Worktree cleanup: ${err}`);
+        return { cleaned: 0, metadata: 0 };
+      }),
+    ]);
+
+    stats.logsDeleted = logStats;
+    stats.worktreesCleaned = worktreeStats.cleaned;
+    stats.metadataCleaned = worktreeStats.metadata;
+
+    const elapsed = Date.now() - startTime;
+    const totalCleaned = stats.logsDeleted + stats.worktreesCleaned + stats.metadataCleaned;
+
+    if (totalCleaned > 0 || stats.errors.length > 0) {
+      log.info(
+        `Cleanup completed in ${elapsed}ms: ` +
+        `${stats.logsDeleted} logs, ${stats.worktreesCleaned} worktrees, ${stats.metadataCleaned} metadata` +
+        (stats.errors.length > 0 ? ` (${stats.errors.length} errors)` : '')
+      );
+    } else {
+      log.debug(`Cleanup completed in ${elapsed}ms (nothing to clean)`);
+    }
+
+    return stats;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private cleanup methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Clean up old thread logs.
+   */
+  private async cleanupLogs(): Promise<number> {
+    if (!this.threadLogsEnabled) {
+      return 0;
+    }
+
+    // cleanupOldLogs is synchronous, wrap in Promise for consistency
+    return new Promise(resolve => {
+      try {
+        const deleted = cleanupOldLogs(this.logRetentionDays);
+        resolve(deleted);
+      } catch (err) {
+        log.warn(`Log cleanup error: ${err}`);
+        resolve(0);
+      }
+    });
+  }
+
+  /**
+   * Clean up orphaned worktrees.
+   * Orphan = worktree in ~/.claude-threads/worktrees/ with no active session using it,
+   * and either older than 24 hours or its branch was merged.
+   */
+  private async cleanupOrphanedWorktrees(): Promise<{ cleaned: number; metadata: number }> {
+    const worktreesDir = getWorktreesDir();
+    const result = { cleaned: 0, metadata: 0 };
+
+    if (!existsSync(worktreesDir)) {
+      log.debug('No worktrees directory exists, nothing to clean');
+      return result;
+    }
+
+    // Get list of worktrees currently in use by persisted sessions
+    const persisted = this.sessionStore.load();
+    const activeWorktrees = new Set<string>();
+    for (const session of persisted.values()) {
+      if (session.worktreeInfo?.worktreePath) {
+        activeWorktrees.add(session.worktreeInfo.worktreePath);
+      }
+    }
+
+    const now = Date.now();
+
+    try {
+      const entries = await readdir(worktreesDir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+
+        const worktreePath = join(worktreesDir, entry.name);
+
+        // Skip worktrees that are in use by persisted sessions
+        if (activeWorktrees.has(worktreePath)) {
+          log.debug(`Worktree in use by persisted session, skipping: ${entry.name}`);
+          continue;
+        }
+
+        // Check metadata for age-based and merged-branch cleanup
+        const meta = await readWorktreeMetadata(worktreePath);
+        let shouldCleanup = false;
+        let cleanupReason = '';
+
+        if (meta) {
+          const lastActivity = new Date(meta.lastActivityAt).getTime();
+          const age = now - lastActivity;
+
+          // Check if branch was merged
+          const merged = await isBranchMerged(meta.repoRoot, meta.branch).catch(() => false);
+          if (merged) {
+            shouldCleanup = true;
+            cleanupReason = `branch "${meta.branch}" was merged`;
+          } else if (age >= MAX_WORKTREE_AGE_MS) {
+            shouldCleanup = true;
+            cleanupReason = `inactive for ${Math.round(age / 3600000)}h`;
+          } else {
+            log.debug(`Worktree recent (${Math.round(age / 60000)}min old), skipping: ${entry.name}`);
+            continue;
+          }
+        } else {
+          // No metadata = truly orphaned
+          shouldCleanup = true;
+          cleanupReason = 'no metadata';
+        }
+
+        if (!shouldCleanup) continue;
+
+        // Orphaned, old, or merged worktree - clean it up
+        log.info(`Cleaning worktree (${cleanupReason}): ${entry.name}`);
+
+        try {
+          // Try git worktree remove first (proper cleanup)
+          if (meta?.repoRoot) {
+            await removeGitWorktree(meta.repoRoot, worktreePath);
+          } else {
+            // No metadata, just remove the directory
+            await rm(worktreePath, { recursive: true, force: true });
+          }
+          result.cleaned++;
+
+          // Also clean up metadata
+          await removeWorktreeMetadata(worktreePath);
+          result.metadata++;
+        } catch (err) {
+          log.warn(`Failed to clean orphaned worktree ${entry.name}: ${err}`);
+          // Try force remove as fallback
+          try {
+            await rm(worktreePath, { recursive: true, force: true });
+            result.cleaned++;
+            // Clean up metadata even on force remove
+            await removeWorktreeMetadata(worktreePath);
+            result.metadata++;
+          } catch (rmErr) {
+            log.error(`Failed to force remove worktree ${entry.name}: ${rmErr}`);
+          }
+        }
+      }
+    } catch (err) {
+      log.warn(`Failed to scan worktrees directory: ${err}`);
+    }
+
+    return result;
+  }
+}

--- a/src/session/monitor.test.ts
+++ b/src/session/monitor.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach, mock } from 'bun:test';
+import { SessionMonitor } from './monitor.js';
+import type { SessionContext } from './context.js';
+
+// Create a minimal mock context
+function createMockContext(): SessionContext {
+  return {
+    state: {
+      sessions: new Map(),
+      platforms: new Map(),
+      postIndex: new Map(),
+      sessionStore: {} as never,
+      isShuttingDown: false,
+    },
+    config: {
+      workingDir: '/tmp',
+      skipPermissions: true,
+      chromeEnabled: false,
+      debug: false,
+      maxSessions: 5,
+    },
+    ops: {} as never,
+  };
+}
+
+describe('SessionMonitor', () => {
+  let monitor: SessionMonitor;
+
+  afterEach(() => {
+    monitor?.stop();
+  });
+
+  describe('constructor', () => {
+    it('should create monitor with required options', () => {
+      const getContext = mock(() => createMockContext());
+      const getSessionCount = mock(() => 0);
+      const updateStickyMessage = mock(async () => {});
+
+      monitor = new SessionMonitor({
+        sessionTimeoutMs: 1800000,
+        sessionWarningMs: 300000,
+        getContext,
+        getSessionCount,
+        updateStickyMessage,
+      });
+
+      expect(monitor).toBeDefined();
+    });
+
+    it('should accept custom interval', () => {
+      const getContext = mock(() => createMockContext());
+      const getSessionCount = mock(() => 0);
+      const updateStickyMessage = mock(async () => {});
+
+      monitor = new SessionMonitor({
+        intervalMs: 5000,
+        sessionTimeoutMs: 1800000,
+        sessionWarningMs: 300000,
+        getContext,
+        getSessionCount,
+        updateStickyMessage,
+      });
+
+      expect(monitor).toBeDefined();
+    });
+  });
+
+  describe('start/stop', () => {
+    it('should start and stop without errors', () => {
+      const getContext = mock(() => createMockContext());
+      const getSessionCount = mock(() => 0);
+      const updateStickyMessage = mock(async () => {});
+
+      monitor = new SessionMonitor({
+        intervalMs: 60000, // Long interval to avoid actual runs
+        sessionTimeoutMs: 1800000,
+        sessionWarningMs: 300000,
+        getContext,
+        getSessionCount,
+        updateStickyMessage,
+      });
+
+      monitor.start();
+      monitor.stop();
+    });
+
+    it('should handle multiple start calls gracefully', () => {
+      const getContext = mock(() => createMockContext());
+      const getSessionCount = mock(() => 0);
+      const updateStickyMessage = mock(async () => {});
+
+      monitor = new SessionMonitor({
+        intervalMs: 60000,
+        sessionTimeoutMs: 1800000,
+        sessionWarningMs: 300000,
+        getContext,
+        getSessionCount,
+        updateStickyMessage,
+      });
+
+      monitor.start();
+      monitor.start(); // Should not throw
+      monitor.stop();
+    });
+
+    it('should handle multiple stop calls gracefully', () => {
+      const getContext = mock(() => createMockContext());
+      const getSessionCount = mock(() => 0);
+      const updateStickyMessage = mock(async () => {});
+
+      monitor = new SessionMonitor({
+        intervalMs: 60000,
+        sessionTimeoutMs: 1800000,
+        sessionWarningMs: 300000,
+        getContext,
+        getSessionCount,
+        updateStickyMessage,
+      });
+
+      monitor.start();
+      monitor.stop();
+      monitor.stop(); // Should not throw
+    });
+  });
+});

--- a/src/session/monitor.ts
+++ b/src/session/monitor.ts
@@ -1,0 +1,108 @@
+/**
+ * Session Monitor
+ *
+ * Periodically checks for idle sessions that need to be timed out
+ * and refreshes sticky messages to keep relative times current.
+ */
+
+import { createLogger } from '../utils/logger.js';
+import * as lifecycle from './lifecycle.js';
+import type { SessionContext } from './context.js';
+
+const log = createLogger('monitor');
+
+/** Default interval: 1 minute */
+const DEFAULT_INTERVAL_MS = 60 * 1000;
+
+export interface SessionMonitorOptions {
+  /** Interval between checks in ms (default: 1 minute) */
+  intervalMs?: number;
+  /** Session timeout in ms */
+  sessionTimeoutMs: number;
+  /** Warning before timeout in ms */
+  sessionWarningMs: number;
+  /** Get the session context */
+  getContext: () => SessionContext;
+  /** Get active session count */
+  getSessionCount: () => number;
+  /** Update sticky message */
+  updateStickyMessage: () => Promise<void>;
+}
+
+/**
+ * SessionMonitor - Monitors sessions for idle timeout and refreshes UI.
+ *
+ * Responsibilities:
+ * - Check for idle sessions that should be timed out
+ * - Refresh sticky messages to keep relative times current
+ *
+ * Start with `start()`, stop with `stop()`.
+ */
+export class SessionMonitor {
+  private readonly intervalMs: number;
+  private readonly sessionTimeoutMs: number;
+  private readonly sessionWarningMs: number;
+  private readonly getContext: () => SessionContext;
+  private readonly getSessionCount: () => number;
+  private readonly updateStickyMessage: () => Promise<void>;
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private isRunning = false;
+
+  constructor(options: SessionMonitorOptions) {
+    this.intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.sessionTimeoutMs = options.sessionTimeoutMs;
+    this.sessionWarningMs = options.sessionWarningMs;
+    this.getContext = options.getContext;
+    this.getSessionCount = options.getSessionCount;
+    this.updateStickyMessage = options.updateStickyMessage;
+  }
+
+  /**
+   * Start the session monitor.
+   */
+  start(): void {
+    if (this.isRunning) {
+      log.debug('Session monitor already running');
+      return;
+    }
+
+    this.isRunning = true;
+    log.debug(`Session monitor started (interval: ${this.intervalMs / 1000}s)`);
+
+    this.timer = setInterval(() => {
+      this.runCheck().catch(err => {
+        log.error(`Error during session monitoring: ${err}`);
+      });
+    }, this.intervalMs);
+  }
+
+  /**
+   * Stop the session monitor.
+   */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.isRunning = false;
+    log.debug('Session monitor stopped');
+  }
+
+  /**
+   * Run a single check cycle.
+   */
+  private async runCheck(): Promise<void> {
+    // Check for idle sessions that need to be timed out
+    await lifecycle.cleanupIdleSessions(
+      this.sessionTimeoutMs,
+      this.sessionWarningMs,
+      this.getContext()
+    );
+
+    // Refresh sticky message to keep relative times current (only if there are active sessions)
+    if (this.getSessionCount() > 0) {
+      await this.updateStickyMessage();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **SessionMonitor**: Checks for idle sessions + refreshes sticky messages (every 1 min)
- **CleanupScheduler**: Cleans old logs + orphan worktrees (every 1 hour)

Both have a consistent `start()`/`stop()` interface and run out of band to avoid blocking startup.

## Changes

- New `src/cleanup/scheduler.ts` - CleanupScheduler class
- New `src/session/monitor.ts` - SessionMonitor class  
- Moved orphan worktree cleanup from SessionManager to CleanupScheduler
- Replaced raw `setInterval` with SessionMonitor class
- Added tests for both

## Test plan

- [x] Unit tests pass (1509 tests)
- [x] Build passes
- [ ] Integration tests

🤖 Generated with [Claude Code](https://claude.ai/code)