### PR TITLE
fix: Shorten logger component names for aligned log output

### DIFF
--- a/src/auto-update/manager.ts
+++ b/src/auto-update/manager.ts
@@ -26,7 +26,7 @@ import type { PlatformFormatter } from '../platform/formatter.js';
 /** Message builder function that takes a formatter and returns the formatted message */
 export type MessageBuilder = (formatter: PlatformFormatter) => string;
 
-const log = createLogger('auto-update');
+const log = createLogger('updater');
 
 /** Callbacks for integrating with the session manager and chat platforms */
 export interface AutoUpdateCallbacks {

--- a/src/claude/quick-query.ts
+++ b/src/claude/quick-query.ts
@@ -14,7 +14,7 @@
 import { spawn } from 'child_process';
 import { createLogger } from '../utils/logger.js';
 
-const log = createLogger('quick-query');
+const log = createLogger('query');
 
 export interface QuickQueryOptions {
   /** The prompt to send to Claude */

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs/promises';
 import { homedir } from 'os';
 import { createLogger } from '../utils/logger.js';
 
-const log = createLogger('git-worktree');
+const log = createLogger('git-wt');
 
 /** Centralized worktree location for easy cleanup */
 const WORKTREES_DIR = path.join(homedir(), '.claude-threads', 'worktrees');

--- a/src/session/branch-suggest.ts
+++ b/src/session/branch-suggest.ts
@@ -12,7 +12,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 
 const execAsync = promisify(exec);
-const log = createLogger('branch-suggest');
+const log = createLogger('branch');
 
 /** Default timeout for branch suggestions (ms) */
 const SUGGESTION_TIMEOUT = 15000;

--- a/src/session/post-helpers.ts
+++ b/src/session/post-helpers.ts
@@ -18,7 +18,7 @@ import { createLogger } from '../utils/logger.js';
 import { withErrorHandling } from './error-handler.js';
 import { BUG_REPORT_EMOJI } from '../utils/emoji.js';
 
-const log = createLogger('post-helpers');
+const log = createLogger('helpers');
 
 /** Get session-scoped logger for routing to correct UI panel */
 function sessionLog(session: Session) {

--- a/src/session/tag-suggest.ts
+++ b/src/session/tag-suggest.ts
@@ -9,7 +9,7 @@
 import { quickQuery } from '../claude/quick-query.js';
 import { createLogger } from '../utils/logger.js';
 
-const log = createLogger('tag-suggest');
+const log = createLogger('tags');
 
 /** Default timeout for tag suggestions (ms) */
 const SUGGESTION_TIMEOUT = 15000;

--- a/src/session/title-suggest.ts
+++ b/src/session/title-suggest.ts
@@ -10,7 +10,7 @@ import { quickQuery } from '../claude/quick-query.js';
 import { createLogger } from '../utils/logger.js';
 import { truncateAtWord } from '../utils/format.js';
 
-const log = createLogger('title-suggest');
+const log = createLogger('title');
 
 /** Default timeout for title suggestions (ms) */
 const SUGGESTION_TIMEOUT = 15000;


### PR DESCRIPTION
## Summary

- Shortens logger component names to fit within the 10-character `COMPONENT_WIDTH` in LogPanel.tsx
- Ensures properly aligned log output in the terminal UI

**Before:**
```
[checker    ] 🔄 Update checker started (every 60 minutes)
[auto-update] 🔄 Auto-update manager started (mode: idle)
```

**After:**
```
[checker  ] 🔄 Update checker started (every 60 minutes)
[updater  ] 🔄 Auto-update manager started (mode: idle)
```

## Changes

| Old Name | New Name | Length |
|----------|----------|--------|
| `auto-update` | `updater` | 11→7 |
| `git-worktree` | `git-wt` | 12→6 |
| `branch-suggest` | `branch` | 14→6 |
| `title-suggest` | `title` | 13→5 |
| `post-helpers` | `helpers` | 12→7 |
| `tag-suggest` | `tags` | 11→4 |
| `quick-query` | `query` | 11→5 |

## Test plan

- [x] Build passes
- [ ] Verify log alignment in terminal UI

🤖 Generated with [Claude Code](https://claude.ai/code)