### PR TITLE
fix: Escape pipe characters in markdown tables

### DIFF
--- a/src/platform/mattermost/formatter.test.ts
+++ b/src/platform/mattermost/formatter.test.ts
@@ -97,6 +97,24 @@ describe('MattermostFormatter', () => {
       expect(result).toContain('| A | B |');
       expect(result).toContain('| --- | --- |');
     });
+
+    it('escapes pipe characters in cells', () => {
+      const headers = ['Command', 'Description'];
+      const rows = [
+        ['`!permissions interactive|skip`', 'Toggle permission prompts'],
+      ];
+      const result = formatter.formatTable(headers, rows);
+      // Pipe inside cell should be escaped to prevent breaking table structure
+      expect(result).toContain('`!permissions interactive\\|skip`');
+      expect(result).toContain('Toggle permission prompts');
+    });
+
+    it('escapes pipe characters in headers', () => {
+      const headers = ['Option A|B', 'Description'];
+      const rows = [['value', 'desc']];
+      const result = formatter.formatTable(headers, rows);
+      expect(result).toContain('Option A\\|B');
+    });
   });
 
   describe('formatKeyValueList', () => {

--- a/src/platform/mattermost/formatter.ts
+++ b/src/platform/mattermost/formatter.ts
@@ -64,9 +64,11 @@ export class MattermostFormatter implements PlatformFormatter {
 
   formatTable(headers: string[], rows: string[][]): string {
     // Standard markdown table
-    const headerRow = `| ${headers.join(' | ')} |`;
+    // Escape pipe characters in cells to prevent breaking table structure
+    const escapeCell = (cell: string) => cell.replace(/\|/g, '\\|');
+    const headerRow = `| ${headers.map(escapeCell).join(' | ')} |`;
     const separatorRow = `| ${headers.map(() => '---').join(' | ')} |`;
-    const dataRows = rows.map(row => `| ${row.join(' | ')} |`);
+    const dataRows = rows.map(row => `| ${row.map(escapeCell).join(' | ')} |`);
     return [headerRow, separatorRow, ...dataRows].join('\n');
   }
 


### PR DESCRIPTION
## Summary
- Fix broken help menu table caused by unescaped `|` character in `!permissions interactive|skip`
- Escape pipe characters in table cells and headers in `MattermostFormatter.formatTable()`

## Test plan
- [x] Existing tests pass
- [x] Added tests for pipe character escaping in cells and headers
- [ ] Verify help menu renders correctly in Mattermost