### PR TITLE
fix: Skip worktree prompt when branch specified in initial message

### DIFF
--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -16,6 +16,8 @@ import { createMockFormatter } from '../test-utils/mock-formatter.js';
 function createMockPlatform(overrides?: Partial<PlatformClient>): PlatformClient {
   return {
     platformId: 'test-platform',
+    platformType: 'mattermost',
+    displayName: 'Test Platform',
     createPost: mock(() => Promise.resolve({ id: 'post-1', message: '', userId: 'bot' })),
     updatePost: mock(() => Promise.resolve({ id: 'post-1', message: '', userId: 'bot' })),
     deletePost: mock(() => Promise.resolve()),
@@ -681,3 +683,10 @@ describe('handleExit', () => {
 // NOTE: Task list bump on resume is tested in src/operations/message-manager.test.ts
 // under the "restoreTaskListFromPersistence" describe block. The tests there properly
 // verify the RED-GREEN behavior by testing the actual MessageManager method.
+
+// NOTE: startSession worktree prompt skip tests are not included here because testing
+// startSession directly requires mocking the Claude CLI spawn, which is complex.
+// The fix is verified by:
+// 1. manager.ts startSessionWithWorktree passes { ...options, skipWorktreePrompt: true }
+// 2. lifecycle.ts startSession checks options.skipWorktreePrompt before shouldPromptForWorktree
+// See src/session/manager.ts:1280 and src/session/lifecycle.ts:692

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -534,7 +534,7 @@ export function maybeInjectMetadataReminder(
  * Create a new session for a thread.
  */
 export async function startSession(
-  options: { prompt: string; files?: PlatformFile[] },
+  options: { prompt: string; files?: PlatformFile[]; skipWorktreePrompt?: boolean },
   username: string,
   displayName: string | undefined,
   replyToPostId: string | undefined,
@@ -688,7 +688,8 @@ export async function startSession(
   }
 
   // Check if we should prompt for worktree
-  const shouldPrompt = await ctx.ops.shouldPromptForWorktree(session);
+  // Skip if explicitly disabled (e.g., when branch was specified in initial message via !worktree)
+  const shouldPrompt = options.skipWorktreePrompt ? null : await ctx.ops.shouldPromptForWorktree(session);
   if (shouldPrompt) {
     session.queuedPrompt = options.prompt;
     session.queuedFiles = options.files;

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -955,7 +955,7 @@ export class SessionManager extends EventEmitter {
   }
 
   async startSession(
-    options: { prompt: string; files?: PlatformFile[] },
+    options: { prompt: string; files?: PlatformFile[]; skipWorktreePrompt?: boolean },
     username: string,
     replyToPostId?: string,
     platformId: string = 'default',
@@ -1276,8 +1276,8 @@ export class SessionManager extends EventEmitter {
     platformId: string = 'default',
     displayName?: string
   ): Promise<void> {
-    // Start normal session first
-    await this.startSession(options, username, replyToPostId, platformId, displayName);
+    // Start normal session first, but skip worktree prompt since branch is already specified
+    await this.startSession({ ...options, skipWorktreePrompt: true }, username, replyToPostId, platformId, displayName);
 
     // Then switch to worktree
     const threadId = replyToPostId || '';


### PR DESCRIPTION
## Summary
- Skip worktree branch suggestions when user specifies branch in initial message
- Affects both `!worktree branch-name` and `on branch X` syntax

## Test plan
- [x] Build passes
- [x] All 1761 tests pass
- [ ] Manual test: Start session with `@bot !worktree my-branch do something` - should NOT show branch suggestions

🤖 Generated with [Claude Code](https://claude.ai/code)