### PR TITLE
feat: Clean up session header message

### DIFF
--- a/src/operations/sticky-message/handler.ts
+++ b/src/operations/sticky-message/handler.ts
@@ -16,6 +16,7 @@ import { formatBatteryStatus } from '../../utils/battery.js';
 import { formatUptime } from '../../utils/uptime.js';
 import { formatRelativeTimeShort, formatShortId } from '../../utils/format.js';
 import { VERSION } from '../../version.js';
+import { getReleaseNotes, getWhatsNewSummary } from '../../changelog.js';
 import { createLogger } from '../../utils/logger.js';
 import { formatPullRequestLink } from '../../utils/pr-detector.js';
 import { getClaudeCliVersion } from '../../claude/version-check.js';
@@ -549,6 +550,14 @@ export async function buildStickyMessage(
       }
     }
 
+    // Add "What's new" from release notes
+    const releaseNotes = getReleaseNotes(VERSION);
+    const whatsNew = releaseNotes ? getWhatsNewSummary(releaseNotes) : '';
+    if (whatsNew) {
+      lines.push('');
+      lines.push(`✨ ${formatter.formatBold("What's new:")} ${whatsNew}`);
+    }
+
     lines.push('');
     lines.push(`${formatter.formatItalic('Mention me to start a session')} · ${formatter.formatCode('bun install -g claude-threads')} · ${formatter.formatLink('claude-threads.run', 'https://claude-threads.run/')}`);
 
@@ -640,6 +649,14 @@ export async function buildStickyMessage(
     for (const historySession of historySessions) {
       lines.push(...formatHistoryEntry(historySession, formatter, getThreadLink));
     }
+  }
+
+  // Add "What's new" from release notes
+  const releaseNotes = getReleaseNotes(VERSION);
+  const whatsNew = releaseNotes ? getWhatsNewSummary(releaseNotes) : '';
+  if (whatsNew) {
+    lines.push('');
+    lines.push(`✨ ${formatter.formatBold("What's new:")} ${whatsNew}`);
   }
 
   lines.push('');

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -666,6 +666,11 @@ export async function startSession(
   // Update the header with full session info
   await ctx.ops.updateSessionHeader(session);
 
+  // Pin the header message
+  if (session.sessionStartPostId) {
+    await platform.pinPost(session.sessionStartPostId).catch(() => {});
+  }
+
   // Update sticky channel message with new session
   await ctx.ops.updateStickyMessage();
 
@@ -966,6 +971,11 @@ export async function resumeSession(
 
     // Update session header
     await ctx.ops.updateSessionHeader(session);
+
+    // Re-pin the header message (may have been unpinned)
+    if (session.sessionStartPostId) {
+      await session.platform.pinPost(session.sessionStartPostId).catch(() => {});
+    }
 
     // Update sticky channel message with resumed session
     await ctx.ops.updateStickyMessage();


### PR DESCRIPTION
## Summary

- Remove ASCII logo from session header message
- Remove "What's new" section from header (moved to sticky channel message)
- Add version info (claude-threads + CLI) to header message status bar
- Always pin the header message on session start and resume

## Test plan

- [ ] Start a new session - verify header has no logo, versions in status bar, is pinned
- [ ] Resume a session - verify header is re-pinned
- [ ] Check sticky channel message shows "What's new" at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)