### PR TITLE
fix: Improve WebSocket reconnection after long idle periods

### DIFF
--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -655,23 +655,53 @@ export class MattermostClient extends EventEmitter implements PlatformClient {
     }
   }
 
+  /**
+   * Clean up the WebSocket connection forcefully.
+   * This ensures we start fresh on reconnection instead of relying on stale sockets.
+   */
+  private cleanupWebSocket(): void {
+    this.stopHeartbeat();
+    if (this.ws) {
+      // Remove all listeners to prevent any callbacks from firing
+      this.ws.onopen = null;
+      this.ws.onmessage = null;
+      this.ws.onclose = null;
+      this.ws.onerror = null;
+      // Force close if still open
+      if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
+        try {
+          this.ws.close();
+        } catch {
+          // Ignore errors on close
+        }
+      }
+      this.ws = null;
+    }
+  }
+
   private scheduleReconnect(): void {
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       log.error('Max reconnection attempts reached');
       return;
     }
 
+    // Clean up any existing WebSocket before reconnecting
+    // This is critical for recovery after long idle periods where the socket may be stale
+    this.cleanupWebSocket();
+
     // Mark that we're reconnecting (to trigger message recovery)
     this.isReconnecting = true;
 
     this.reconnectAttempts++;
     const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
-    log.info(`Reconnecting... (attempt ${this.reconnectAttempts})`);
+    wsLogger.info(`Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
     this.emit('reconnecting', this.reconnectAttempts);
 
     setTimeout(() => {
       this.connect().catch((err) => {
-        log.error(`Reconnection failed: ${err}`);
+        wsLogger.error(`Reconnection failed: ${err}`);
+        // Schedule another reconnect attempt
+        this.scheduleReconnect();
       });
     }, delay);
   }

--- a/src/ui/components/Platforms.tsx
+++ b/src/ui/components/Platforms.tsx
@@ -28,11 +28,11 @@ export function Platforms({ platforms }: PlatformsProps) {
           {/* Platform type icon */}
           <Text>{getPlatformIcon(platform.platformType || 'mattermost')}</Text>
 
-          {/* Connection status indicator */}
+          {/* Connection status indicator with optional spinner */}
           {!platform.enabled ? (
             <Text dimColor>○</Text>
           ) : platform.reconnecting ? (
-            <Text color="yellow">◌</Text>
+            <Spinner type="dots" />
           ) : platform.connected ? (
             <Text color="green">●</Text>
           ) : (
@@ -42,17 +42,11 @@ export function Platforms({ platforms }: PlatformsProps) {
           {/* Bot name */}
           <Text color={platform.enabled ? "cyan" : undefined} dimColor={!platform.enabled}>@{platform.botName}</Text>
 
-          {/* Platform display name - show reconnecting status inline if reconnecting */}
-          {platform.reconnecting ? (
-            <>
-              <Spinner type="dots" />
-              <Text color="yellow">reconnecting ({platform.reconnectAttempts})</Text>
-            </>
-          ) : (
-            <>
-              <Text dimColor>on</Text>
-              <Text dimColor={!platform.enabled}>{platform.displayName}</Text>
-            </>
+          {/* Platform display name with optional reconnect count */}
+          <Text dimColor>on</Text>
+          <Text dimColor={!platform.enabled}>{platform.displayName}</Text>
+          {platform.reconnecting && (
+            <Text dimColor>(retry {platform.reconnectAttempts})</Text>
           )}
         </Box>
       ))}


### PR DESCRIPTION
## Summary

- **Improved reconnection reliability** - Added `cleanupWebSocket()` method that forcefully cleans up stale WebSocket connections before reconnecting (removes event listeners, force closes socket, nullifies reference)
- **Auto-retry on failure** - If a reconnection attempt fails, it now automatically schedules another attempt instead of giving up
- **More compact reconnection UI** - Spinner replaces status indicator, shows "(retry N)" at end instead of replacing platform name

## Test plan

- [ ] Build and run locally
- [ ] Simulate network disconnection (e.g., disable Wi-Fi) and verify reconnection works
- [ ] Put machine to sleep for extended period, wake up and verify bot reconnects
- [ ] Verify UI shows compact reconnection status with retry count

🤖 Generated with [Claude Code](https://claude.com/claude-code)