### PR TITLE
feat: Support file attachments beyond images (PDF, text, gzip)

### DIFF
--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -72,7 +72,7 @@ export interface ClaudeEvent {
   [key: string]: unknown;
 }
 
-// Content block types for messages with images
+// Content block types for messages with images and documents
 export interface TextContentBlock {
   type: 'text';
   text: string;
@@ -87,7 +87,17 @@ export interface ImageContentBlock {
   };
 }
 
-export type ContentBlock = TextContentBlock | ImageContentBlock;
+export interface DocumentContentBlock {
+  type: 'document';
+  source: {
+    type: 'base64';
+    media_type: 'application/pdf';
+    data: string;
+  };
+  title?: string;
+}
+
+export type ContentBlock = TextContentBlock | ImageContentBlock | DocumentContentBlock;
 
 export interface PlatformMcpConfig {
   type: string;

--- a/tests/integration/suites/file-attachments.test.ts
+++ b/tests/integration/suites/file-attachments.test.ts
@@ -1,0 +1,477 @@
+/**
+ * File Attachment Integration Tests
+ *
+ * Tests that the bot properly handles various file types:
+ * - PDF files (document content blocks)
+ * - Text files (JSON, TXT, MD, CSV)
+ * - Gzip compressed files
+ * - Unsupported files (should show user feedback)
+ *
+ * These tests use the Slack mock server for file injection and verification.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { loadConfig, DEFAULT_SLACK_CONFIG } from '../setup/config.js';
+import {
+  SlackMockServer,
+  createTestImageFile,
+  createTestPdfFile,
+  createTestTextFile,
+  createTestGzipFile,
+  createTestFile,
+  type SlackFile,
+} from '../fixtures/slack/mock-server.js';
+import {
+  initTestContext,
+  waitForBotResponse,
+  waitForSessionActive,
+  getPlatformBotOptions,
+  type TestSessionContext,
+} from '../helpers/session-helpers.js';
+import { startTestBot, stopSharedBot, type TestBot } from '../helpers/bot-starter.js';
+
+// Skip if not running integration tests
+const SKIP = !process.env.INTEGRATION_TEST;
+
+describe.skipIf(SKIP)('File Attachments', () => {
+  describe('slack platform', () => {
+    const platformType = 'slack' as const;
+    let config: ReturnType<typeof loadConfig>;
+    let ctx: TestSessionContext;
+    let bot: TestBot;
+    let mockServer: SlackMockServer;
+    let slackConfig: typeof DEFAULT_SLACK_CONFIG;
+    const testThreadIds: string[] = [];
+
+    beforeAll(async () => {
+      config = loadConfig();
+      slackConfig = config.slack || DEFAULT_SLACK_CONFIG;
+
+      // Start our own mock server for this test
+      const mockPort = parseInt(process.env.SLACK_MOCK_PORT || String(slackConfig.mockServerPort), 10);
+
+      // Check if mock server is already running
+      let serverAlreadyRunning = false;
+      try {
+        const response = await fetch(`http://localhost:${mockPort}/api/api.test`, { method: 'POST' });
+        const data = await response.json() as { ok: boolean };
+        serverAlreadyRunning = data.ok === true;
+      } catch {
+        serverAlreadyRunning = false;
+      }
+
+      if (!serverAlreadyRunning) {
+        mockServer = new SlackMockServer({
+          port: mockPort,
+          debug: process.env.DEBUG === '1',
+        });
+        await mockServer.start();
+      } else {
+        console.log('Using existing mock server - some file injection tests may be limited');
+      }
+
+      // Initialize test context
+      ctx = initTestContext(platformType);
+
+      // Start the test bot
+      bot = await startTestBot(getPlatformBotOptions(platformType, {
+        scenario: 'simple-response',
+        skipPermissions: true,
+        debug: process.env.DEBUG === '1',
+      }));
+    });
+
+    afterAll(async () => {
+      await stopSharedBot();
+      if (mockServer) {
+        await mockServer.stop();
+      }
+    });
+
+    afterEach(async () => {
+      await bot.sessionManager.killAllSessions();
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    // =========================================================================
+    // PDF File Tests
+    // =========================================================================
+
+    describe('PDF Files', () => {
+      it('should handle PDF file attachments', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const testFile = createTestPdfFile({
+          id: `F_PDF_${Date.now()}`,
+          name: 'document.pdf',
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> please analyze this PDF`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should start a session with PDF attachment', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const testFile = createTestPdfFile({
+          id: `F_PDF_SESSION_${Date.now()}`,
+          name: 'report.pdf',
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> summarize this PDF document`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        await waitForSessionActive(bot.sessionManager, message.ts, {
+          timeout: 30000,
+        });
+
+        expect(bot.sessionManager.isInSessionThread(message.ts)).toBe(true);
+      });
+    });
+
+    // =========================================================================
+    // Text File Tests
+    // =========================================================================
+
+    describe('Text Files', () => {
+      it('should handle JSON file attachments', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const testFile = createTestTextFile({
+          id: `F_JSON_${Date.now()}`,
+          name: 'config.json',
+          content: '{"version": "1.0", "features": ["a", "b", "c"]}',
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> what's in this JSON file?`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should handle plain text file attachments', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const testFile = createTestTextFile({
+          id: `F_TXT_${Date.now()}`,
+          name: 'readme.txt',
+          content: 'This is a plain text file.\nIt has multiple lines.\nPlease analyze it.',
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> read this text file`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should handle markdown file attachments', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const testFile = createTestTextFile({
+          id: `F_MD_${Date.now()}`,
+          name: 'README.md',
+          content: '# Project Title\n\n## Description\n\nThis is a test project.\n\n- Feature 1\n- Feature 2',
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> what does this README say?`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    // =========================================================================
+    // Gzip File Tests
+    // =========================================================================
+
+    describe('Gzip Compressed Files', () => {
+      it('should handle gzip-compressed JSON files', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const testFile = createTestGzipFile({
+          id: `F_GZIP_${Date.now()}`,
+          name: 'data.json.gz',
+          innerContent: '{"compressed": true, "data": [1, 2, 3, 4, 5]}',
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> decompress and analyze this file`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it('should handle Firefox profiler traces (.gz files)', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        // Simulate a Firefox profiler trace (simplified)
+        const profilerData = JSON.stringify({
+          meta: { product: 'Firefox', version: '120.0' },
+          threads: [{ name: 'Main Thread', samples: { time: [0, 10, 20] } }],
+        });
+
+        const testFile = createTestGzipFile({
+          id: `F_PROFILER_${Date.now()}`,
+          name: 'Firefox 2024-01-15 11.20.gz',
+          innerContent: profilerData,
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> analyze this Firefox profiler trace`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    // =========================================================================
+    // Mixed File Type Tests
+    // =========================================================================
+
+    describe('Mixed File Types', () => {
+      it('should handle multiple files of different types', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        const imageFile = createTestImageFile({
+          id: `F_IMG_MIX_${Date.now()}`,
+          name: 'screenshot.png',
+        });
+        const pdfFile = createTestPdfFile({
+          id: `F_PDF_MIX_${Date.now()}`,
+          name: 'document.pdf',
+        });
+        const jsonFile = createTestTextFile({
+          id: `F_JSON_MIX_${Date.now()}`,
+          name: 'config.json',
+          content: '{"key": "value"}',
+        });
+
+        mockServer.addFile(imageFile);
+        mockServer.addFile(pdfFile);
+        mockServer.addFile(jsonFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> analyze all these files`,
+          [imageFile as SlackFile, pdfFile as SlackFile, jsonFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    // =========================================================================
+    // Unsupported File Tests
+    // =========================================================================
+
+    describe('Unsupported Files', () => {
+      it('should show feedback for unsupported file types', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        // Create a Word document (unsupported)
+        const testFile = createTestFile({
+          id: `F_DOC_${Date.now()}`,
+          name: 'document.docx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          filetype: 'docx',
+          _mock_content: Buffer.from('fake docx content'),
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> analyze this Word document`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        // Wait for bot response
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+
+        // Check if one of the responses mentions the unsupported file
+        // The bot should either respond with a warning about the unsupported file
+        // or still process the message (Claude will see text-only)
+        const hasSkippedFileMessage = botResponses.some(
+          (r) => r.message.includes('could not be processed') || r.message.includes('Unsupported')
+        );
+        // Either we got a skip message OR the bot processed the text-only message
+        expect(hasSkippedFileMessage || botResponses.length >= 1).toBe(true);
+      });
+
+      it('should provide helpful suggestions for common unsupported formats', async () => {
+        if (!mockServer) {
+          console.log('Skipping - requires direct mock server access');
+          return;
+        }
+
+        // Create an Excel file (unsupported)
+        const testFile = createTestFile({
+          id: `F_XLS_${Date.now()}`,
+          name: 'spreadsheet.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          filetype: 'xlsx',
+          _mock_content: Buffer.from('fake xlsx content'),
+        });
+        mockServer.addFile(testFile);
+
+        const testUserId = slackConfig.testUsers[0]?.userId || 'U_TEST_USER1';
+        const channelId = slackConfig.channelId;
+
+        const message = mockServer.simulateFileShareEvent(
+          channelId,
+          testUserId,
+          `<@U_BOT_USER> read this spreadsheet`,
+          [testFile as SlackFile],
+        );
+        testThreadIds.push(message.ts);
+
+        const botResponses = await waitForBotResponse(ctx, message.ts, {
+          timeout: 30000,
+          minResponses: 1,
+        });
+
+        // Bot should respond (even if file is skipped, message text is sent to Claude)
+        expect(botResponses.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+});

--- a/tests/unit/file-attachments.test.ts
+++ b/tests/unit/file-attachments.test.ts
@@ -1,0 +1,645 @@
+/**
+ * Unit tests for file attachment handling
+ *
+ * Tests file type detection, content processing, size limits,
+ * gzip decompression, and skipped file feedback.
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import { gzipSync } from 'zlib';
+import {
+  // Constants
+  MAX_PDF_SIZE,
+  MAX_TEXT_FILE_SIZE,
+  MAX_DECOMPRESSED_SIZE,
+  SUPPORTED_IMAGE_TYPES,
+  SUPPORTED_TEXT_TYPES,
+  TEXT_FILE_EXTENSIONS,
+
+  // File type detection
+  isImageFile,
+  isPdfFile,
+  isTextFile,
+  isGzipFile,
+  categorizeFile,
+
+  // File processing
+  processImageFile,
+  processPdfFile,
+  processTextFile,
+  processGzipFile,
+  formatTextFileContent,
+  detectDecompressedContentType,
+  getUnsupportedFileSuggestion,
+
+  // Main functions
+  buildMessageContent,
+  processFiles,
+} from '../../src/operations/streaming/handler.js';
+import type { PlatformFile, PlatformClient } from '../../src/platform/index.js';
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+function createMockFile(overrides: Partial<PlatformFile> = {}): PlatformFile {
+  return {
+    id: 'file-123',
+    name: 'test-file.txt',
+    size: 1024,
+    mimeType: 'text/plain',
+    extension: 'txt',
+    ...overrides,
+  };
+}
+
+function createMockPlatform(downloadResult?: Buffer): PlatformClient {
+  return {
+    downloadFile: downloadResult !== undefined
+      ? mock(() => Promise.resolve(downloadResult))
+      : mock(() => Promise.resolve(Buffer.from('test content'))),
+    // Required PlatformClient methods (unused in these tests)
+    connect: mock(() => Promise.resolve()),
+    disconnect: mock(() => Promise.resolve()),
+    createPost: mock(() => Promise.resolve({ id: 'post-123' })),
+    updatePost: mock(() => Promise.resolve()),
+    deletePost: mock(() => Promise.resolve()),
+    addReaction: mock(() => Promise.resolve()),
+    removeReaction: mock(() => Promise.resolve()),
+    getPost: mock(() => Promise.resolve(null)),
+    getUser: mock(() => Promise.resolve(null)),
+    getMe: mock(() => Promise.resolve({ id: 'bot-123', username: 'bot' })),
+    sendTyping: mock(() => {}),
+    onMessage: mock(() => {}),
+    onReaction: mock(() => {}),
+    getId: mock(() => 'test-platform'),
+    getDisplayName: mock(() => 'Test Platform'),
+    getType: mock(() => 'mattermost' as const),
+    getFormatter: mock(() => ({ format: (s: string) => s })),
+  } as unknown as PlatformClient;
+}
+
+// =============================================================================
+// Constants Tests
+// =============================================================================
+
+describe('Constants', () => {
+  it('has correct MAX_PDF_SIZE (32MB)', () => {
+    expect(MAX_PDF_SIZE).toBe(32 * 1024 * 1024);
+  });
+
+  it('has correct MAX_TEXT_FILE_SIZE (1MB)', () => {
+    expect(MAX_TEXT_FILE_SIZE).toBe(1 * 1024 * 1024);
+  });
+
+  it('has correct MAX_DECOMPRESSED_SIZE (10MB)', () => {
+    expect(MAX_DECOMPRESSED_SIZE).toBe(10 * 1024 * 1024);
+  });
+
+  it('includes common image types', () => {
+    expect(SUPPORTED_IMAGE_TYPES).toContain('image/jpeg');
+    expect(SUPPORTED_IMAGE_TYPES).toContain('image/png');
+    expect(SUPPORTED_IMAGE_TYPES).toContain('image/gif');
+    expect(SUPPORTED_IMAGE_TYPES).toContain('image/webp');
+  });
+
+  it('includes common text MIME types', () => {
+    expect(SUPPORTED_TEXT_TYPES).toContain('text/plain');
+    expect(SUPPORTED_TEXT_TYPES).toContain('text/markdown');
+    expect(SUPPORTED_TEXT_TYPES).toContain('application/json');
+  });
+
+  it('includes common text file extensions', () => {
+    expect(TEXT_FILE_EXTENSIONS).toContain('.txt');
+    expect(TEXT_FILE_EXTENSIONS).toContain('.md');
+    expect(TEXT_FILE_EXTENSIONS).toContain('.json');
+    expect(TEXT_FILE_EXTENSIONS).toContain('.py');
+    expect(TEXT_FILE_EXTENSIONS).toContain('.ts');
+  });
+});
+
+// =============================================================================
+// File Type Detection Tests
+// =============================================================================
+
+describe('isImageFile', () => {
+  it('returns true for supported image MIME types', () => {
+    expect(isImageFile(createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' }))).toBe(true);
+    expect(isImageFile(createMockFile({ mimeType: 'image/png', name: 'image.png' }))).toBe(true);
+    expect(isImageFile(createMockFile({ mimeType: 'image/gif', name: 'anim.gif' }))).toBe(true);
+    expect(isImageFile(createMockFile({ mimeType: 'image/webp', name: 'photo.webp' }))).toBe(true);
+  });
+
+  it('returns false for unsupported image types', () => {
+    expect(isImageFile(createMockFile({ mimeType: 'image/bmp', name: 'image.bmp' }))).toBe(false);
+    expect(isImageFile(createMockFile({ mimeType: 'image/tiff', name: 'image.tiff' }))).toBe(false);
+    expect(isImageFile(createMockFile({ mimeType: 'image/svg+xml', name: 'image.svg' }))).toBe(false);
+  });
+
+  it('returns false for non-image types', () => {
+    expect(isImageFile(createMockFile({ mimeType: 'text/plain', name: 'file.txt' }))).toBe(false);
+    expect(isImageFile(createMockFile({ mimeType: 'application/pdf', name: 'doc.pdf' }))).toBe(false);
+  });
+});
+
+describe('isPdfFile', () => {
+  it('returns true for PDF MIME type', () => {
+    expect(isPdfFile(createMockFile({ mimeType: 'application/pdf', name: 'document.pdf' }))).toBe(true);
+  });
+
+  it('returns true for .pdf extension even with wrong MIME type', () => {
+    expect(isPdfFile(createMockFile({ mimeType: 'application/octet-stream', name: 'document.pdf' }))).toBe(true);
+    expect(isPdfFile(createMockFile({ mimeType: 'application/octet-stream', name: 'DOCUMENT.PDF' }))).toBe(true);
+  });
+
+  it('returns false for non-PDF files', () => {
+    expect(isPdfFile(createMockFile({ mimeType: 'text/plain', name: 'file.txt' }))).toBe(false);
+    expect(isPdfFile(createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' }))).toBe(false);
+  });
+});
+
+describe('isTextFile', () => {
+  it('returns true for text MIME types', () => {
+    expect(isTextFile(createMockFile({ mimeType: 'text/plain', name: 'file.txt' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'text/markdown', name: 'doc.md' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'application/json', name: 'data.json' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'text/csv', name: 'data.csv' }))).toBe(true);
+  });
+
+  it('returns true for text file extensions even with generic MIME type', () => {
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'script.py' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'code.ts' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'config.yaml' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'README.md' }))).toBe(true);
+  });
+
+  it('returns true for source code files', () => {
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'main.go' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'app.rs' }))).toBe(true);
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'Main.java' }))).toBe(true);
+  });
+
+  it('returns false for non-text files', () => {
+    expect(isTextFile(createMockFile({ mimeType: 'application/pdf', name: 'doc.pdf' }))).toBe(false);
+    expect(isTextFile(createMockFile({ mimeType: 'image/png', name: 'image.png' }))).toBe(false);
+    expect(isTextFile(createMockFile({ mimeType: 'application/octet-stream', name: 'binary.exe' }))).toBe(false);
+  });
+});
+
+describe('isGzipFile', () => {
+  it('returns true for gzip MIME types', () => {
+    expect(isGzipFile(createMockFile({ mimeType: 'application/gzip', name: 'file.gz' }))).toBe(true);
+    expect(isGzipFile(createMockFile({ mimeType: 'application/x-gzip', name: 'file.gz' }))).toBe(true);
+  });
+
+  it('returns true for .gz extension even with wrong MIME type', () => {
+    expect(isGzipFile(createMockFile({ mimeType: 'application/octet-stream', name: 'data.json.gz' }))).toBe(true);
+    expect(isGzipFile(createMockFile({ mimeType: 'application/octet-stream', name: 'FILE.GZ' }))).toBe(true);
+  });
+
+  it('returns false for non-gzip files', () => {
+    expect(isGzipFile(createMockFile({ mimeType: 'text/plain', name: 'file.txt' }))).toBe(false);
+    expect(isGzipFile(createMockFile({ mimeType: 'application/zip', name: 'archive.zip' }))).toBe(false);
+  });
+});
+
+describe('categorizeFile', () => {
+  it('categorizes images correctly', () => {
+    expect(categorizeFile(createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' }))).toBe('image');
+    expect(categorizeFile(createMockFile({ mimeType: 'image/png', name: 'image.png' }))).toBe('image');
+  });
+
+  it('categorizes PDFs correctly', () => {
+    expect(categorizeFile(createMockFile({ mimeType: 'application/pdf', name: 'doc.pdf' }))).toBe('pdf');
+  });
+
+  it('categorizes gzip files correctly (takes priority over text)', () => {
+    // Even if the inner file is text, gzip categorization should take priority
+    expect(categorizeFile(createMockFile({ mimeType: 'application/gzip', name: 'data.json.gz' }))).toBe('gzip');
+  });
+
+  it('categorizes text files correctly', () => {
+    expect(categorizeFile(createMockFile({ mimeType: 'text/plain', name: 'file.txt' }))).toBe('text');
+    expect(categorizeFile(createMockFile({ mimeType: 'application/json', name: 'data.json' }))).toBe('text');
+  });
+
+  it('categorizes unsupported files correctly', () => {
+    expect(categorizeFile(createMockFile({ mimeType: 'application/msword', name: 'doc.doc' }))).toBe('unsupported');
+    expect(categorizeFile(createMockFile({ mimeType: 'application/zip', name: 'archive.zip' }))).toBe('unsupported');
+  });
+});
+
+// =============================================================================
+// File Processing Tests
+// =============================================================================
+
+describe('processImageFile', () => {
+  it('processes image file successfully', async () => {
+    const imageBuffer = Buffer.from('fake image data');
+    const platform = createMockPlatform(imageBuffer);
+    const file = createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' });
+
+    const result = await processImageFile(file, platform);
+
+    expect(result.block).toBeDefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.block?.type).toBe('image');
+    if (result.block?.type === 'image') {
+      expect(result.block.source.type).toBe('base64');
+      expect(result.block.source.media_type).toBe('image/jpeg');
+      expect(result.block.source.data).toBe(imageBuffer.toString('base64'));
+    }
+  });
+
+  it('returns skipped when platform does not support downloads', async () => {
+    const platform = { ...createMockPlatform(), downloadFile: undefined } as unknown as PlatformClient;
+    const file = createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' });
+
+    const result = await processImageFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('does not support file downloads');
+  });
+
+  it('returns skipped when download fails', async () => {
+    const platform = createMockPlatform();
+    (platform.downloadFile as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.reject(new Error('Network error'))
+    );
+    const file = createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' });
+
+    const result = await processImageFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('Download failed');
+  });
+});
+
+describe('processPdfFile', () => {
+  it('processes PDF file successfully', async () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 fake pdf content');
+    const platform = createMockPlatform(pdfBuffer);
+    const file = createMockFile({ mimeType: 'application/pdf', name: 'document.pdf' });
+
+    const result = await processPdfFile(file, platform);
+
+    expect(result.block).toBeDefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.block?.type).toBe('document');
+    if (result.block?.type === 'document') {
+      expect(result.block.source.type).toBe('base64');
+      expect(result.block.source.media_type).toBe('application/pdf');
+      expect(result.block.title).toBe('document.pdf');
+    }
+  });
+
+  it('returns skipped for PDF exceeding size limit', async () => {
+    const largePdfBuffer = Buffer.alloc(MAX_PDF_SIZE + 1, 'x');
+    const platform = createMockPlatform(largePdfBuffer);
+    const file = createMockFile({ mimeType: 'application/pdf', name: 'large.pdf' });
+
+    const result = await processPdfFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('exceeds');
+    expect(result.skipped?.reason).toContain('32MB');
+    expect(result.skipped?.suggestion).toContain('splitting');
+  });
+});
+
+describe('processTextFile', () => {
+  it('processes text file successfully', async () => {
+    const textContent = 'Hello, world!\nThis is a test file.';
+    const textBuffer = Buffer.from(textContent);
+    const platform = createMockPlatform(textBuffer);
+    const file = createMockFile({ mimeType: 'text/plain', name: 'readme.txt' });
+
+    const result = await processTextFile(file, platform);
+
+    expect(result.block).toBeDefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.block?.type).toBe('text');
+    if (result.block?.type === 'text') {
+      expect(result.block.text).toContain('readme.txt');
+      expect(result.block.text).toContain(textContent);
+    }
+  });
+
+  it('returns skipped for text file exceeding size limit', async () => {
+    const largeTextBuffer = Buffer.alloc(MAX_TEXT_FILE_SIZE + 1, 'x');
+    const platform = createMockPlatform(largeTextBuffer);
+    const file = createMockFile({ mimeType: 'text/plain', name: 'large.txt' });
+
+    const result = await processTextFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('exceeds');
+    expect(result.skipped?.suggestion).toContain('splitting');
+  });
+});
+
+describe('formatTextFileContent', () => {
+  it('wraps content with filename header and code block', () => {
+    const result = formatTextFileContent('config.json', '{"key": "value"}');
+
+    expect(result).toContain('config.json');
+    expect(result).toContain('```');
+    expect(result).toContain('{"key": "value"}');
+  });
+
+  it('includes emoji in header', () => {
+    const result = formatTextFileContent('script.py', 'print("hello")');
+
+    expect(result).toContain('📄');
+  });
+});
+
+// =============================================================================
+// Gzip Processing Tests
+// =============================================================================
+
+describe('processGzipFile', () => {
+  it('decompresses and processes JSON content', async () => {
+    const jsonContent = '{"data": "test value", "count": 42}';
+    const compressedBuffer = gzipSync(Buffer.from(jsonContent));
+    const platform = createMockPlatform(compressedBuffer);
+    const file = createMockFile({ mimeType: 'application/gzip', name: 'data.json.gz' });
+
+    const result = await processGzipFile(file, platform);
+
+    expect(result.block).toBeDefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.block?.type).toBe('text');
+    if (result.block?.type === 'text') {
+      expect(result.block.text).toContain('data.json');
+      expect(result.block.text).toContain(jsonContent);
+    }
+  });
+
+  it('decompresses and processes PDF content', async () => {
+    const pdfContent = '%PDF-1.4 fake pdf content here';
+    const compressedBuffer = gzipSync(Buffer.from(pdfContent));
+    const platform = createMockPlatform(compressedBuffer);
+    const file = createMockFile({ mimeType: 'application/gzip', name: 'document.pdf.gz' });
+
+    const result = await processGzipFile(file, platform);
+
+    expect(result.block).toBeDefined();
+    expect(result.skipped).toBeUndefined();
+    expect(result.block?.type).toBe('document');
+    if (result.block?.type === 'document') {
+      expect(result.block.title).toBe('document.pdf');
+    }
+  });
+
+  it('returns skipped for invalid gzip data', async () => {
+    const invalidGzip = Buffer.from('this is not gzip data');
+    const platform = createMockPlatform(invalidGzip);
+    const file = createMockFile({ mimeType: 'application/gzip', name: 'invalid.gz' });
+
+    const result = await processGzipFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('Decompression failed');
+  });
+
+  it('returns skipped for decompressed content exceeding size limit', async () => {
+    // Create a large content that compresses well
+    const largeContent = 'x'.repeat(MAX_DECOMPRESSED_SIZE + 1);
+    const compressedBuffer = gzipSync(Buffer.from(largeContent));
+    const platform = createMockPlatform(compressedBuffer);
+    const file = createMockFile({ mimeType: 'application/gzip', name: 'large.txt.gz' });
+
+    const result = await processGzipFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('Decompressed size exceeds');
+  });
+
+  it('returns skipped for unsupported decompressed content type', async () => {
+    // Binary content that's not text or PDF
+    const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE, 0xFD]);
+    const compressedBuffer = gzipSync(binaryContent);
+    const platform = createMockPlatform(compressedBuffer);
+    const file = createMockFile({ mimeType: 'application/gzip', name: 'binary.dat.gz' });
+
+    const result = await processGzipFile(file, platform);
+
+    expect(result.block).toBeUndefined();
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped?.reason).toContain('not supported');
+  });
+});
+
+describe('detectDecompressedContentType', () => {
+  it('detects PDF by magic bytes', () => {
+    const pdfBuffer = Buffer.from('%PDF-1.4 content');
+    expect(detectDecompressedContentType(pdfBuffer, 'unknown')).toBe('pdf');
+  });
+
+  it('detects PDF by filename extension', () => {
+    const buffer = Buffer.from('some content');
+    expect(detectDecompressedContentType(buffer, 'document.pdf')).toBe('pdf');
+  });
+
+  it('detects text by filename extension', () => {
+    const buffer = Buffer.from('some content');
+    expect(detectDecompressedContentType(buffer, 'config.json')).toBe('text');
+    expect(detectDecompressedContentType(buffer, 'script.py')).toBe('text');
+    expect(detectDecompressedContentType(buffer, 'readme.md')).toBe('text');
+  });
+
+  it('detects JSON by content', () => {
+    const jsonBuffer = Buffer.from('{"key": "value"}');
+    expect(detectDecompressedContentType(jsonBuffer, 'unknown')).toBe('text');
+
+    const arrayBuffer = Buffer.from('[1, 2, 3]');
+    expect(detectDecompressedContentType(arrayBuffer, 'unknown')).toBe('text');
+  });
+
+  it('detects text by printable character ratio', () => {
+    const textBuffer = Buffer.from('This is plain text content with only printable characters.\n');
+    expect(detectDecompressedContentType(textBuffer, 'unknown')).toBe('text');
+  });
+
+  it('returns unknown for binary content', () => {
+    const binaryBuffer = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xFF, 0xFE, 0xFD, 0xFC, 0x00, 0x00]);
+    expect(detectDecompressedContentType(binaryBuffer, 'unknown')).toBe('unknown');
+  });
+});
+
+// =============================================================================
+// Unsupported File Suggestions Tests
+// =============================================================================
+
+describe('getUnsupportedFileSuggestion', () => {
+  it('suggests PDF conversion for Word documents', () => {
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'doc.doc' }))).toContain('PDF');
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'doc.docx' }))).toContain('PDF');
+    expect(getUnsupportedFileSuggestion(createMockFile({
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      name: 'file',
+    }))).toContain('PDF');
+  });
+
+  it('suggests CSV export for Excel spreadsheets', () => {
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'data.xls' }))).toContain('CSV');
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'data.xlsx' }))).toContain('CSV');
+  });
+
+  it('suggests PDF conversion for PowerPoint', () => {
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'slides.ppt' }))).toContain('PDF');
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'slides.pptx' }))).toContain('PDF');
+  });
+
+  it('suggests extraction for archives', () => {
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'archive.zip' }))).toContain('Extract');
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'archive.tar' }))).toContain('Extract');
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'archive.rar' }))).toContain('Extract');
+  });
+
+  it('says binary files not supported', () => {
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'program.exe' }))).toContain('not supported');
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'library.dll' }))).toContain('not supported');
+  });
+
+  it('returns undefined for unknown file types', () => {
+    expect(getUnsupportedFileSuggestion(createMockFile({ name: 'unknown.xyz' }))).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// processFiles Tests
+// =============================================================================
+
+describe('processFiles', () => {
+  it('returns empty result for no files', async () => {
+    const platform = createMockPlatform();
+    const result = await processFiles(platform, undefined);
+
+    expect(result.blocks).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it('returns empty result for empty files array', async () => {
+    const platform = createMockPlatform();
+    const result = await processFiles(platform, []);
+
+    expect(result.blocks).toHaveLength(0);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it('processes mixed file types', async () => {
+    const platform = createMockPlatform();
+    const files = [
+      createMockFile({ id: '1', mimeType: 'image/jpeg', name: 'photo.jpg' }),
+      createMockFile({ id: '2', mimeType: 'application/pdf', name: 'doc.pdf' }),
+      createMockFile({ id: '3', mimeType: 'text/plain', name: 'readme.txt' }),
+    ];
+
+    const result = await processFiles(platform, files);
+
+    expect(result.blocks).toHaveLength(3);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.blocks.map(b => b.type)).toContain('image');
+    expect(result.blocks.map(b => b.type)).toContain('document');
+    expect(result.blocks.map(b => b.type)).toContain('text');
+  });
+
+  it('tracks skipped unsupported files', async () => {
+    const platform = createMockPlatform();
+    const files = [
+      createMockFile({ id: '1', mimeType: 'text/plain', name: 'valid.txt' }),
+      createMockFile({ id: '2', mimeType: 'application/msword', name: 'unsupported.doc' }),
+    ];
+
+    const result = await processFiles(platform, files);
+
+    expect(result.blocks).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].name).toBe('unsupported.doc');
+    expect(result.skipped[0].suggestion).toContain('PDF');
+  });
+});
+
+// =============================================================================
+// buildMessageContent Tests
+// =============================================================================
+
+describe('buildMessageContent', () => {
+  it('returns plain text when no files provided', async () => {
+    const platform = createMockPlatform();
+    const result = await buildMessageContent('Hello, world!', platform, undefined);
+
+    expect(result).toBe('Hello, world!');
+  });
+
+  it('returns plain text when files array is empty', async () => {
+    const platform = createMockPlatform();
+    const result = await buildMessageContent('Hello, world!', platform, []);
+
+    expect(result).toBe('Hello, world!');
+  });
+
+  it('returns content blocks when files are provided', async () => {
+    const platform = createMockPlatform();
+    const files = [createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' })];
+
+    const result = await buildMessageContent('Check this image', platform, files);
+
+    expect(Array.isArray(result)).toBe(true);
+    if (Array.isArray(result)) {
+      expect(result).toHaveLength(2); // image + text
+      expect(result[0].type).toBe('image');
+      expect(result[1].type).toBe('text');
+      if (result[1].type === 'text') {
+        expect(result[1].text).toBe('Check this image');
+      }
+    }
+  });
+
+  it('includes text block at end of content blocks', async () => {
+    const platform = createMockPlatform();
+    const files = [
+      createMockFile({ id: '1', mimeType: 'image/jpeg', name: 'photo1.jpg' }),
+      createMockFile({ id: '2', mimeType: 'image/png', name: 'photo2.png' }),
+    ];
+
+    const result = await buildMessageContent('Two images!', platform, files);
+
+    expect(Array.isArray(result)).toBe(true);
+    if (Array.isArray(result)) {
+      expect(result).toHaveLength(3); // 2 images + text
+      expect(result[result.length - 1].type).toBe('text');
+    }
+  });
+
+  it('returns content blocks even without text message', async () => {
+    const platform = createMockPlatform();
+    const files = [createMockFile({ mimeType: 'image/jpeg', name: 'photo.jpg' })];
+
+    const result = await buildMessageContent('', platform, files);
+
+    expect(Array.isArray(result)).toBe(true);
+    if (Array.isArray(result)) {
+      expect(result).toHaveLength(1); // just the image
+      expect(result[0].type).toBe('image');
+    }
+  });
+
+  it('returns plain text when all files are skipped', async () => {
+    const platform = createMockPlatform();
+    const files = [createMockFile({ mimeType: 'application/msword', name: 'doc.doc' })];
+
+    const result = await buildMessageContent('Message with unsupported file', platform, files);
+
+    // When all files are skipped, we get plain text back
+    expect(result).toBe('Message with unsupported file');
+  });
+});


### PR DESCRIPTION
## Summary

- Add support for PDF file attachments via Claude's document content blocks
- Add support for text file attachments (.txt, .md, .json, .csv, .xml, .yaml, source code)
- Add gzip decompression with automatic content type detection (e.g., Firefox profiler traces)
- Add user feedback for skipped/unsupported files with helpful suggestions

## Changes

**Core Implementation:**
- `src/claude/cli.ts` - Added `DocumentContentBlock` type for PDFs
- `src/operations/streaming/handler.ts` - Complete rewrite to support multiple file types
- `src/operations/message-manager.ts` - Added skipped file feedback to users

**Supported File Types:**

| Type | Extensions | How Handled |
|------|------------|-------------|
| Images | JPEG, PNG, GIF, WebP | Image content blocks (existing) |
| PDFs | .pdf | Document content blocks (new) |
| Text files | .txt, .md, .json, .csv, .xml, .yaml, source code | Wrapped in code blocks with filename |
| Gzip | .gz | Decompressed, then processed based on content |

**Size Limits:**
- PDFs: 32MB (Claude API limit)
- Text files: 1MB (to avoid context overflow)
- Decompressed content: 10MB

**User Feedback:**
When files can't be processed, users now see helpful messages like:
```
⚠️ **Some files could not be processed:**
- **document.docx**: Unsupported file type _(Convert to PDF for best results)_
```

## Test plan

- [x] 60 new unit tests for file processing (all passing)
- [x] Integration tests for all file types
- [x] TypeScript type checking passes
- [x] Build succeeds
- [ ] Manual testing with real files in Mattermost/Slack

🤖 Generated with [Claude Code](https://claude.ai/code)