### PR TITLE
fix: Correct argument order in createPost call for skipped files feedback

### DIFF
--- a/src/operations/message-manager.ts
+++ b/src/operations/message-manager.ts
@@ -1057,7 +1057,7 @@ export class MessageManager {
     // Post feedback for skipped files
     if (skippedFiles.length > 0) {
       const feedback = this.formatSkippedFilesFeedback(skippedFiles);
-      await this.platform.createPost(this.threadId, feedback);
+      await this.platform.createPost(feedback, this.threadId);
     }
 
     // Update activity time


### PR DESCRIPTION
## Summary
- Fixed swapped arguments in `createPost()` call when posting feedback for skipped files
- The threadId was being passed as the message and feedback text as the threadId
- This caused "Invalid RootId parameter" Mattermost API errors when processing files that needed to be skipped (e.g., large gzip files)

## Test plan
- [x] All existing tests pass
- [ ] Upload a large gzip file (>10MB decompressed) and verify the "file skipped" feedback posts correctly

🤖 Generated with [Claude Code](https://claude.ai/code)