### PR TITLE
feat: Add source tracking for approved guest messages

### DIFF
--- a/src/operations/executors/message-approval.test.ts
+++ b/src/operations/executors/message-approval.test.ts
@@ -90,15 +90,15 @@ function createTestContext(platform?: PlatformClient): ExecutorContext {
 describe('MessageApprovalExecutor', () => {
   let executor: MessageApprovalExecutor;
   let ctx: ExecutorContext;
-  let messageApprovalCompleted: { decision: string; fromUser: string; originalMessage: string } | null;
+  let messageApprovalCompleted: { decision: string; fromUser: string; originalMessage: string; approvedBy: string } | null;
 
   beforeEach(() => {
     messageApprovalCompleted = null;
 
     // Create event emitter and subscribe to events
     const events = createMessageManagerEvents();
-    events.on('message-approval:complete', ({ decision, fromUser, originalMessage }) => {
-      messageApprovalCompleted = { decision, fromUser, originalMessage };
+    events.on('message-approval:complete', ({ decision, fromUser, originalMessage, approvedBy }) => {
+      messageApprovalCompleted = { decision, fromUser, originalMessage, approvedBy };
     });
 
     executor = new MessageApprovalExecutor({
@@ -146,6 +146,7 @@ describe('MessageApprovalExecutor', () => {
       expect(messageApprovalCompleted!.decision).toBe('allow');
       expect(messageApprovalCompleted!.fromUser).toBe('unauthorized-user');
       expect(messageApprovalCompleted!.originalMessage).toBe('Hello world');
+      expect(messageApprovalCompleted!.approvedBy).toBe('approver-user');
     });
 
     it('handles invite decision', async () => {
@@ -166,6 +167,7 @@ describe('MessageApprovalExecutor', () => {
 
       expect(handled).toBe(true);
       expect(messageApprovalCompleted!.decision).toBe('invite');
+      expect(messageApprovalCompleted!.approvedBy).toBe('approver-user');
     });
 
     it('handles deny decision', async () => {
@@ -186,6 +188,7 @@ describe('MessageApprovalExecutor', () => {
 
       expect(handled).toBe(true);
       expect(messageApprovalCompleted!.decision).toBe('deny');
+      expect(messageApprovalCompleted!.approvedBy).toBe('approver-user');
     });
 
     it('ignores response for wrong post', async () => {

--- a/src/operations/executors/message-approval.ts
+++ b/src/operations/executors/message-approval.ts
@@ -139,7 +139,7 @@ export class MessageApprovalExecutor extends BaseExecutor<MessageApprovalState> 
 
     // Emit message approval complete event
     if (this.events) {
-      this.events.emit('message-approval:complete', { decision, fromUser, originalMessage });
+      this.events.emit('message-approval:complete', { decision, fromUser, originalMessage, approvedBy: approver });
     }
 
     return true;

--- a/src/operations/message-manager-events.test.ts
+++ b/src/operations/message-manager-events.test.ts
@@ -61,6 +61,7 @@ describe('TypedEventEmitter', () => {
         decision: 'allow',
         fromUser: 'testuser',
         originalMessage: 'Hello',
+        approvedBy: 'approver',
       };
 
       emitter.on('message-approval:complete', handler);
@@ -445,6 +446,7 @@ describe('Event Payload Types', () => {
       decision: 'deny',
       fromUser: 'unauthorized',
       originalMessage: 'blocked message',
+      approvedBy: 'moderator',
     };
 
     emitter.on('message-approval:complete', handler);
@@ -459,6 +461,7 @@ describe('Event Payload Types', () => {
       decision: 'invite',
       fromUser: 'newuser',
       originalMessage: 'request to join',
+      approvedBy: 'admin',
     };
 
     emitter.on('message-approval:complete', handler);

--- a/src/operations/message-manager-events.ts
+++ b/src/operations/message-manager-events.ts
@@ -55,6 +55,7 @@ export interface MessageManagerEventMap {
     decision: 'allow' | 'invite' | 'deny';
     fromUser: string;
     originalMessage: string;
+    approvedBy: string;
   };
 
   /**


### PR DESCRIPTION
## Summary

- When a guest user's message is approved by a session member, the message sent to Claude now includes source attribution
- Format: `[Message from @guest_user, approved by @session_owner]` followed by the original message
- This follows the same pattern as context messages, helping Claude understand message provenance

## Changes

- Add `approvedBy` field to `message-approval:complete` event payload
- Add `formatApprovedMessage()` helper function in lifecycle.ts
- Update event handler to format messages with source attribution
- Update tests to verify `approvedBy` field is correctly passed through

## Test plan

- [x] All existing unit tests pass (1899 tests)
- [x] TypeScript compiles without errors
- [x] Pre-commit hooks pass (lint, test, tsc)
- [ ] Manual test: Have an unauthorized user send a message, approve it, verify Claude receives the formatted message with attribution

🤖 Generated with [Claude Code](https://claude.ai/code)