### PR TITLE
chore: clarify version display in status bars (CT/CC prefixes)

### DIFF
--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -13,7 +13,6 @@ import { randomUUID } from 'crypto';
 import { resolve } from 'path';
 import { existsSync, statSync } from 'fs';
 import { getUpdateInfo } from '../../update-notifier.js';
-import { VERSION } from '../../version.js';
 import {
   APPROVAL_EMOJIS,
   DENIAL_EMOJIS,
@@ -48,7 +47,7 @@ import { createLogger } from '../../utils/logger.js';
 import { createSessionLog } from '../../utils/session-log.js';
 import { formatPullRequestLink } from '../../utils/pr-detector.js';
 import { getCurrentBranch, isGitRepository } from '../../git/worktree.js';
-import { getClaudeCliVersion } from '../../claude/version-check.js';
+import { formatVersionString } from '../../utils/format.js';
 import { shortenPath } from '../index.js';
 import { getLogFilePath } from '../../persistence/thread-logger.js';
 import { quickQuery } from '../../claude/quick-query.js';
@@ -622,8 +621,7 @@ export async function updateSessionHeader(
   const statusItems: string[] = [];
 
   // Version info at the start (like sticky message)
-  const claudeVersion = getClaudeCliVersion().version;
-  const versionStr = claudeVersion ? `v${VERSION} · CLI ${claudeVersion}` : `v${VERSION}`;
+  const versionStr = formatVersionString();
   statusItems.push(formatter.formatCode(versionStr));
 
   // Model and context usage (if available)

--- a/src/operations/sticky-message/handler.test.ts
+++ b/src/operations/sticky-message/handler.test.ts
@@ -159,8 +159,8 @@ describe('buildStickyMessage', () => {
     const sessions = new Map<string, Session>();
     const result = await buildStickyMessage(sessions, 'test-platform', testConfig, mockFormatter, (threadId) => `/_redirect/pl/${threadId}`);
 
-    // Should contain version (with optional CLI version appended)
-    expect(result).toMatch(/`v\d+\.\d+\.\d+( · CLI \d+\.\d+\.\d+)?`/);
+    // Should contain version (CT = claude-threads, CC = Claude Code)
+    expect(result).toMatch(/`CT v\d+\.\d+\.\d+( · CC v\d+\.\d+\.\d+)?`/);
     // Should contain session count
     expect(result).toContain('`0/5 sessions`');
     // Should contain uptime

--- a/src/operations/sticky-message/handler.ts
+++ b/src/operations/sticky-message/handler.ts
@@ -14,12 +14,11 @@ import type { SessionStore, PersistedSession } from '../../persistence/session-s
 import type { WorktreeMode } from '../../config.js';
 import { formatBatteryStatus } from '../../utils/battery.js';
 import { formatUptime } from '../../utils/uptime.js';
-import { formatRelativeTimeShort, formatShortId } from '../../utils/format.js';
+import { formatRelativeTimeShort, formatShortId, formatVersionString } from '../../utils/format.js';
 import { VERSION } from '../../version.js';
 import { getReleaseNotes, getWhatsNewSummary } from '../../changelog.js';
 import { createLogger } from '../../utils/logger.js';
 import { formatPullRequestLink } from '../../utils/pr-detector.js';
-import { getClaudeCliVersion } from '../../claude/version-check.js';
 import { keepAlive } from '../../utils/keep-alive.js';
 
 const log = createLogger('sticky');
@@ -403,10 +402,8 @@ async function buildStatusBar(
     }
   }
 
-  // Version (claude-threads + Claude CLI)
-  const claudeVersion = getClaudeCliVersion().version;
-  const versionStr = claudeVersion ? `v${VERSION} · CLI ${claudeVersion}` : `v${VERSION}`;
-  items.push(formatter.formatCode(versionStr));
+  // Version (CT = claude-threads, CC = Claude Code)
+  items.push(formatter.formatCode(formatVersionString()));
 
   // Session count
   items.push(formatter.formatCode(`${sessionCount}/${config.maxSessions} sessions`));

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -10,6 +10,9 @@
  * - Maintainability: Easy to change formats globally
  */
 
+import { VERSION } from '../version.js';
+import { getClaudeCliVersion } from '../claude/version-check.js';
+
 // =============================================================================
 // ID Formatting
 // =============================================================================
@@ -90,6 +93,21 @@ export function formatRelativeTimeShort(date: Date): string {
   if (hours > 0) return `${hours}h ago`;
   if (minutes > 0) return `${minutes}m ago`;
   return '<1m ago';
+}
+
+// =============================================================================
+// Version Formatting
+// =============================================================================
+
+/**
+ * Format version string for status bar display.
+ * CT = claude-threads, CC = Claude Code (the CLI).
+ *
+ * @returns Formatted string like "CT v1.3.1 · CC v2.1.12" or "CT v1.3.1" if no CLI version
+ */
+export function formatVersionString(): string {
+  const claudeVersion = getClaudeCliVersion().version;
+  return claudeVersion ? `CT v${VERSION} · CC v${claudeVersion}` : `CT v${VERSION}`;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Change status bar version display from `v1.3.1 · CLI 2.1.12` to `CT v1.3.1 · CC v2.1.12` for better clarity
- CT = claude-threads (this bot)
- CC = Claude Code (the CLI)
- Extract `formatVersionString()` utility to DRY up duplicated logic

## Test plan

- [x] All unit tests pass (1942 tests)
- [x] Lint passes
- [x] Build succeeds