### PR TITLE
fix: Resolve ESLint no-non-null-assertion warnings

### DIFF
--- a/src/claude/version-check.ts
+++ b/src/claude/version-check.ts
@@ -247,7 +247,21 @@ export function validateClaudeCli(): ClaudeValidationResult {
   }
 
   // Case 3: Got a version, check compatibility
-  const compatible = isVersionCompatible(result.version!);
+  // At this point, result.version must be defined:
+  // - Case 1 returned if result.error was truthy
+  // - Case 2 returned if result.version was falsy (with rawOutput)
+  // So if we reach here, result.version is defined
+  if (!result.version) {
+    // This should never happen, but satisfies TypeScript
+    return {
+      installed: true,
+      version: null,
+      compatible: true,
+      message: 'Claude CLI found (version unknown)',
+      rawOutput: result.rawOutput ?? undefined,
+    };
+  }
+  const compatible = isVersionCompatible(result.version);
 
   if (!compatible) {
     return {

--- a/src/operations/bug-report/handler.ts
+++ b/src/operations/bug-report/handler.ts
@@ -444,11 +444,14 @@ class UsernameAnonymizer {
   anonymize(username: string | undefined): string {
     if (!username) return '[unknown]';
 
-    if (!this.usernameMap.has(username)) {
-      this.counter++;
-      this.usernameMap.set(username, `User${this.counter}`);
+    const existing = this.usernameMap.get(username);
+    if (existing) {
+      return existing;
     }
-    return this.usernameMap.get(username)!;
+    this.counter++;
+    const anonymized = `User${this.counter}`;
+    this.usernameMap.set(username, anonymized);
+    return anonymized;
   }
 }
 

--- a/src/operations/executors/task-list.ts
+++ b/src/operations/executors/task-list.ts
@@ -276,7 +276,9 @@ export class TaskListExecutor extends BaseExecutor<TaskListState> {
 
     // IMMEDIATELY create our lock and set it as the new queue
     // This ensures any concurrent call will wait for us
-    let releaseLock: () => void;
+    // Initialize with no-op to satisfy TypeScript - the Promise executor runs synchronously
+    // so releaseLock is always assigned before use
+    let releaseLock: () => void = () => {};
     this.bumpQueue = new Promise(resolve => {
       releaseLock = resolve;
     });
@@ -289,7 +291,7 @@ export class TaskListExecutor extends BaseExecutor<TaskListState> {
       return await fn();
     } finally {
       // Release our lock so next operation can proceed
-      releaseLock!();
+      releaseLock();
     }
   }
 

--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -122,15 +122,16 @@ export class MattermostClient extends BasePlatformClient {
   private async processAndEmitPost(post: MattermostPost): Promise<void> {
     // Check if we need to fetch file metadata
     // WebSocket events include file_ids but may not include metadata.files
-    const hasFileIds = post.file_ids && post.file_ids.length > 0;
+    const fileIds = post.file_ids;
+    const hasFileIds = fileIds && fileIds.length > 0;
     const hasFileMetadata = post.metadata?.files && post.metadata.files.length > 0;
 
     if (hasFileIds && !hasFileMetadata) {
-      log.debug(`Post ${formatShortId(post.id)} has ${post.file_ids!.length} file(s), fetching metadata`);
+      log.debug(`Post ${formatShortId(post.id)} has ${fileIds.length} file(s), fetching metadata`);
       try {
         // Fetch file info for each file_id
         const files: MattermostFile[] = [];
-        for (const fileId of post.file_ids!) {
+        for (const fileId of fileIds) {
           try {
             const file = await this.api<MattermostFile>('GET', `/files/${fileId}/info`);
             files.push(file);


### PR DESCRIPTION
## Summary
- Remove 5 ESLint `@typescript-eslint/no-non-null-assertion` warnings by using proper type guards
- Fixes warnings in `version-check.ts`, `bug-report/handler.ts`, `task-list.ts`, and `mattermost/client.ts`

## Changes
- **version-check.ts**: Add explicit null check before using `result.version`
- **bug-report/handler.ts**: Refactor `anonymize()` to return value directly instead of using `Map.get()!`
- **task-list.ts**: Initialize `releaseLock` with no-op before Promise executor assignment
- **mattermost/client.ts**: Extract `file_ids` to local variable for proper type narrowing

## Test plan
- [x] `bun run lint` passes with no warnings
- [x] `bun run build` compiles successfully