### PR TITLE
fix: improve todo checkbox alignment in task list

### DIFF
--- a/src/operations/executors/task-list.test.ts
+++ b/src/operations/executors/task-list.test.ts
@@ -441,7 +441,7 @@ describe('TaskListExecutor', () => {
       expect(content).toContain('33%'); // 1 of 3 = 33%
       expect(content).toContain('✅'); // completed task
       expect(content).toContain('🔄'); // in-progress task
-      expect(content).toContain('⬜'); // pending task
+      expect(content).toContain('🔲'); // pending task
     });
 
     it('uses activeForm for in-progress tasks', async () => {

--- a/src/operations/executors/task-list.ts
+++ b/src/operations/executors/task-list.ts
@@ -617,7 +617,7 @@ export class TaskListExecutor extends BaseExecutor<TaskListState> {
           }
           break;
         default:
-          icon = '⬜';
+          icon = '🔲';
           taskText = task.content;
       }
 


### PR DESCRIPTION
## Summary
- Replace `⬜` (large white square) with `🔲` (checkbox emoji) for pending tasks
- The new icon aligns better with `✅` and `🔄`, fixing irregular spacing when multiple pending tasks are stacked

## Test plan
- [x] Unit tests pass
- [ ] Verify visually in Mattermost that task list items are evenly spaced