### PR TITLE
feat: show typing indicator immediately when thread starts

### DIFF
--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -713,6 +713,10 @@ export async function startSession(
   const actualThreadId = replyToPostId || startPost.id;
   const sessionId = ctx.ops.getSessionId(platformId, actualThreadId);
 
+  // Start typing indicator early so user sees activity during session setup
+  // We'll set up a proper interval-based typing indicator once the session is created
+  platform.sendTyping(actualThreadId);
+
   // Generate a unique session ID for this Claude session
   const claudeSessionId = randomUUID();
 


### PR DESCRIPTION
## Summary

- Show typing indicator immediately after posting the "session starting" message, before session setup completes
- Gives users visual feedback while Claude CLI initializes and branch suggestions are fetched

## Test plan

- [ ] Start a new session in Mattermost/Slack
- [ ] Verify typing indicator appears immediately after "Claude Threads session starting..." message
- [ ] Verify typing indicator continues during branch suggestion fetch (if worktree mode enabled)
- [ ] Verify all existing tests pass (`bun test`)