### PR TITLE
fix: handle worktree subcommands in root messages

### DIFF
--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -1,0 +1,458 @@
+/**
+ * Command Executor
+ *
+ * Unified command execution for both root messages and in-session messages.
+ * This is the single place where all commands are handled.
+ */
+
+import { COMMAND_REGISTRY } from './registry.js';
+import type {
+  CommandExecutorContext,
+  CommandHandler,
+  CommandHandlerMap,
+  CommandResult,
+} from './types.js';
+import { generateHelpMessage } from './help-generator.js';
+import { getReleaseNotes, formatReleaseNotes } from '../changelog.js';
+import { VERSION } from '../version.js';
+
+// =============================================================================
+// Command Handler Registry
+// =============================================================================
+
+const handlers: CommandHandlerMap = new Map();
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Get command definition from registry.
+ */
+function getCommandDef(command: string) {
+  return COMMAND_REGISTRY.find((c) => c.command === command);
+}
+
+/**
+ * Get subcommand definition from a command.
+ */
+function getSubcommandDef(command: string, subcommand: string) {
+  const cmdDef = getCommandDef(command);
+  return cmdDef?.subcommands?.find((s) => s.name === subcommand);
+}
+
+// =============================================================================
+// Command Handlers
+// =============================================================================
+
+/**
+ * Handle !help command.
+ */
+const handleHelp: CommandHandler = async (ctx) => {
+  const helpMessage = generateHelpMessage(ctx.formatter);
+  await ctx.client.createPost(helpMessage, ctx.threadId);
+  return { handled: true };
+};
+
+/**
+ * Handle !release-notes command.
+ */
+const handleReleaseNotes: CommandHandler = async (ctx) => {
+  const notes = getReleaseNotes(VERSION);
+  if (notes) {
+    await ctx.client.createPost(formatReleaseNotes(notes, ctx.formatter), ctx.threadId);
+  } else {
+    await ctx.client.createPost(
+      `📋 ${ctx.formatter.formatBold(`claude-threads v${VERSION}`)}\n\nRelease notes not available. See ${ctx.formatter.formatLink('GitHub releases', 'https://github.com/anneschuth/claude-threads/releases')}.`,
+      ctx.threadId
+    );
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !update command.
+ */
+const handleUpdate: CommandHandler = async (ctx, args) => {
+  const subcommand = args?.toLowerCase();
+
+  if (ctx.commandContext === 'first-message') {
+    // First message: just show status without starting session
+    await ctx.sessionManager.showUpdateStatusWithoutSession(
+      ctx.client.platformId,
+      ctx.threadId
+    );
+    return { handled: true };
+  }
+
+  // In-session: handle subcommands
+  if (subcommand === 'now') {
+    await ctx.sessionManager.forceUpdateNow(ctx.threadId, ctx.username);
+  } else if (subcommand === 'defer') {
+    await ctx.sessionManager.deferUpdate(ctx.threadId, ctx.username);
+  } else {
+    await ctx.sessionManager.showUpdateStatus(ctx.threadId, ctx.username);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !stop command.
+ */
+const handleStop: CommandHandler = async (ctx) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !stop doesn't work in first message
+  }
+  if (ctx.isAllowed) {
+    await ctx.sessionManager.cancelSession(ctx.threadId, ctx.username);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !escape command.
+ */
+const handleEscape: CommandHandler = async (ctx) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !escape doesn't work in first message
+  }
+  if (ctx.isAllowed) {
+    await ctx.sessionManager.interruptSession(ctx.threadId, ctx.username);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !approve command.
+ */
+const handleApprove: CommandHandler = async (ctx) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !approve doesn't work in first message
+  }
+  if (ctx.isAllowed) {
+    await ctx.sessionManager.approvePendingPlan(ctx.threadId, ctx.username);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !invite command.
+ */
+const handleInvite: CommandHandler = async (ctx, args) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !invite doesn't work in first message
+  }
+  if (args) {
+    await ctx.sessionManager.inviteUser(ctx.threadId, args, ctx.username);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !kick command.
+ */
+const handleKick: CommandHandler = async (ctx, args) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !kick doesn't work in first message
+  }
+  if (args) {
+    await ctx.sessionManager.kickUser(ctx.threadId, args, ctx.username);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !cd command.
+ */
+const handleCd: CommandHandler = async (ctx, args) => {
+  if (!args) {
+    return { handled: false };
+  }
+
+  if (ctx.commandContext === 'first-message') {
+    // First message: store in session options for later
+    return {
+      sessionOptions: { workingDir: args },
+      continueProcessing: true,
+    };
+  }
+
+  // In-session: change directory immediately
+  await ctx.sessionManager.changeDirectory(ctx.threadId, args, ctx.username);
+  return { handled: true };
+};
+
+/**
+ * Handle !permissions command.
+ */
+const handlePermissions: CommandHandler = async (ctx, args) => {
+  const mode = args?.toLowerCase();
+
+  if (ctx.commandContext === 'first-message') {
+    if (mode === 'interactive') {
+      return {
+        sessionOptions: { forceInteractivePermissions: true },
+        continueProcessing: true,
+      };
+    }
+    return { handled: false };
+  }
+
+  // In-session: toggle permissions
+  if (mode === 'interactive') {
+    await ctx.sessionManager.enableInteractivePermissions(ctx.threadId, ctx.username);
+  } else {
+    await ctx.client.createPost(
+      `⚠️ Cannot upgrade to auto permissions - can only downgrade to interactive`,
+      ctx.threadId
+    );
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !worktree command (unified handling for subcommands and branch creation).
+ */
+const handleWorktree: CommandHandler = async (ctx, args) => {
+  const parts = args?.split(/\s+/) || [];
+  const subcommandOrBranch = parts[0]?.toLowerCase();
+  const subArgs = parts.slice(1).join(' ');
+  const originalFirstArg = parts[0]; // Keep original case for branch names
+
+  // Check if this is a known subcommand
+  const subDef = getSubcommandDef('worktree', subcommandOrBranch);
+
+  if (subDef) {
+    // Check if subcommand works in current context
+    if (ctx.commandContext === 'first-message' && !subDef.worksInFirstMessage) {
+      return { handled: false };
+    }
+
+    // Handle known subcommands
+    switch (subcommandOrBranch) {
+      case 'list':
+        await ctx.sessionManager.listWorktreesCommand(ctx.threadId, ctx.username);
+        return { handled: true };
+
+      case 'switch':
+        if (!subArgs) {
+          await ctx.client.createPost(
+            `❌ Usage: ${ctx.formatter.formatCode('!worktree switch <branch>')}`,
+            ctx.threadId
+          );
+          return { handled: true };
+        }
+        await ctx.sessionManager.switchToWorktree(ctx.threadId, subArgs, ctx.username);
+        return { handled: true };
+
+      case 'remove':
+        if (!subArgs) {
+          await ctx.client.createPost(
+            `❌ Usage: ${ctx.formatter.formatCode('!worktree remove <branch>')}`,
+            ctx.threadId
+          );
+          return { handled: true };
+        }
+        await ctx.sessionManager.removeWorktreeCommand(ctx.threadId, subArgs, ctx.username);
+        return { handled: true };
+
+      case 'cleanup':
+        await ctx.sessionManager.cleanupWorktreeCommand(ctx.threadId, ctx.username);
+        return { handled: true };
+
+      case 'off':
+        await ctx.sessionManager.disableWorktreePrompt(ctx.threadId, ctx.username);
+        return { handled: true };
+    }
+  }
+
+  // Not a subcommand - treat as branch name
+  if (originalFirstArg) {
+    if (ctx.commandContext === 'first-message') {
+      // First message: return branch name for session creation
+      return {
+        worktreeBranch: originalFirstArg,
+        continueProcessing: true,
+        remainingText: subArgs || undefined,
+      };
+    }
+
+    // In-session: create worktree immediately
+    await ctx.sessionManager.createAndSwitchToWorktree(ctx.threadId, originalFirstArg, ctx.username);
+    return { handled: true };
+  }
+
+  return { handled: false };
+};
+
+/**
+ * Handle !bug command.
+ */
+const handleBug: CommandHandler = async (ctx, args) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !bug doesn't work in first message
+  }
+  if (ctx.isAllowed) {
+    await ctx.sessionManager.reportBug(ctx.threadId, args, ctx.username, ctx.files);
+  }
+  return { handled: true };
+};
+
+/**
+ * Handle !plugin command.
+ */
+const handlePlugin: CommandHandler = async (ctx, args) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false }; // !plugin doesn't work in first message
+  }
+  if (!ctx.isAllowed) {
+    return { handled: true };
+  }
+
+  const parts = args?.split(/\s+/) || [];
+  const subcommand = parts[0]?.toLowerCase() || 'list';
+  const pluginName = parts.slice(1).join(' ');
+
+  switch (subcommand) {
+    case 'list':
+      await ctx.sessionManager.pluginList(ctx.threadId);
+      break;
+    case 'install':
+      if (!pluginName) {
+        await ctx.client.createPost(
+          `❌ Usage: ${ctx.formatter.formatCode('!plugin install <plugin-name>')}`,
+          ctx.threadId
+        );
+      } else {
+        await ctx.sessionManager.pluginInstall(ctx.threadId, pluginName, ctx.username);
+      }
+      break;
+    case 'uninstall':
+      if (!pluginName) {
+        await ctx.client.createPost(
+          `❌ Usage: ${ctx.formatter.formatCode('!plugin uninstall <plugin-name>')}`,
+          ctx.threadId
+        );
+      } else {
+        await ctx.sessionManager.pluginUninstall(ctx.threadId, pluginName, ctx.username);
+      }
+      break;
+    default:
+      await ctx.client.createPost(
+        `❌ Unknown subcommand: ${ctx.formatter.formatCode(subcommand)}. Use ${ctx.formatter.formatCode('list')}, ${ctx.formatter.formatCode('install')}, or ${ctx.formatter.formatCode('uninstall')}.`,
+        ctx.threadId
+      );
+  }
+  return { handled: true };
+};
+
+/**
+ * Create a passthrough handler for Claude Code slash commands.
+ */
+function createPassthroughHandler(slashCommand: string): CommandHandler {
+  return async (ctx) => {
+    if (ctx.commandContext === 'first-message') {
+      return { handled: false }; // Passthrough commands don't work in first message
+    }
+    if (ctx.isAllowed) {
+      await ctx.sessionManager.sendFollowUp(ctx.threadId, `/${slashCommand}`);
+    }
+    return { handled: true };
+  };
+}
+
+// =============================================================================
+// Register Handlers
+// =============================================================================
+
+handlers.set('help', handleHelp);
+handlers.set('release-notes', handleReleaseNotes);
+handlers.set('update', handleUpdate);
+handlers.set('stop', handleStop);
+handlers.set('escape', handleEscape);
+handlers.set('approve', handleApprove);
+handlers.set('invite', handleInvite);
+handlers.set('kick', handleKick);
+handlers.set('cd', handleCd);
+handlers.set('permissions', handlePermissions);
+handlers.set('worktree', handleWorktree);
+handlers.set('bug', handleBug);
+handlers.set('plugin', handlePlugin);
+
+// Passthrough commands
+handlers.set('context', createPassthroughHandler('context'));
+handlers.set('cost', createPassthroughHandler('cost'));
+handlers.set('compact', createPassthroughHandler('compact'));
+
+// =============================================================================
+// Main Execution Function
+// =============================================================================
+
+/**
+ * Execute a command in the given context.
+ *
+ * @param command - The command name (without !)
+ * @param args - Command arguments
+ * @param ctx - Execution context
+ * @returns CommandResult indicating what happened
+ */
+export async function executeCommand(
+  command: string,
+  args: string | undefined,
+  ctx: CommandExecutorContext
+): Promise<CommandResult> {
+  const cmdDef = getCommandDef(command);
+
+  // Check if command exists
+  if (!cmdDef) {
+    return { handled: false };
+  }
+
+  // Check if command works in current context
+  if (ctx.commandContext === 'first-message' && !cmdDef.worksInFirstMessage) {
+    return { handled: false };
+  }
+
+  // Get the handler
+  const handler = handlers.get(command);
+  if (!handler) {
+    return { handled: false };
+  }
+
+  // Execute the handler
+  return handler(ctx, args);
+}
+
+/**
+ * Check if a command is a dynamic slash command (passthrough to Claude Code).
+ * These are commands like !review that come from Claude Code's init event.
+ */
+export function isDynamicSlashCommand(
+  command: string,
+  availableSlashCommands?: Set<string>
+): boolean {
+  // Check if it's a known command first
+  if (handlers.has(command)) {
+    return false;
+  }
+  // Check if it's in the available slash commands from Claude Code
+  return availableSlashCommands?.has(command) ?? false;
+}
+
+/**
+ * Handle a dynamic slash command by passing it through to Claude Code.
+ */
+export async function handleDynamicSlashCommand(
+  command: string,
+  args: string | undefined,
+  ctx: CommandExecutorContext
+): Promise<CommandResult> {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false };
+  }
+  if (ctx.isAllowed) {
+    const fullCommand = args ? `/${command} ${args}` : `/${command}`;
+    await ctx.sessionManager.sendFollowUp(ctx.threadId, fullCommand);
+  }
+  return { handled: true };
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,11 +6,30 @@
 export {
   parseCommand,
   parseClaudeCommand,
+  parseCommandWithRemainder,
   isClaudeAllowedCommand,
   removeCommandFromText,
   CLAUDE_ALLOWED_COMMANDS,
   type ParsedCommand,
+  type ParsedCommandWithRemainder,
 } from './parser.js';
+
+// Executor exports
+export {
+  executeCommand,
+  isDynamicSlashCommand,
+  handleDynamicSlashCommand,
+} from './executor.js';
+
+// Types exports
+export type {
+  CommandContext,
+  CommandExecutorContext,
+  CommandHandler,
+  CommandHandlerMap,
+  CommandResult,
+  InitialSessionOptions,
+} from './types.js';
 
 // Registry exports (single source of truth for commands)
 export {

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Command Execution Types
+ *
+ * Types for unified command handling across root messages and in-session messages.
+ */
+
+import type { PlatformClient, PlatformFormatter, PlatformFile } from '../platform/index.js';
+import type { SessionManager } from '../session/index.js';
+
+// =============================================================================
+// Command Context
+// =============================================================================
+
+/** Context in which a command is being executed */
+export type CommandContext = 'first-message' | 'in-session';
+
+/** Context passed to command handlers */
+export interface CommandExecutorContext {
+  /** Whether this is a first-message or in-session command */
+  commandContext: CommandContext;
+  /** Thread ID where the command was issued */
+  threadId: string;
+  /** Username of the person who issued the command */
+  username: string;
+  /** Platform client for posting messages */
+  client: PlatformClient;
+  /** Session manager for session operations */
+  sessionManager: SessionManager;
+  /** Platform formatter for message formatting */
+  formatter: PlatformFormatter;
+  /** Whether the user is allowed to execute commands in this session */
+  isAllowed?: boolean;
+  /** Attached files from the post */
+  files?: PlatformFile[];
+}
+
+// =============================================================================
+// Command Result
+// =============================================================================
+
+/** Options that can be passed when starting a new session */
+export interface InitialSessionOptions {
+  /** Working directory override */
+  workingDir?: string;
+  /** Force interactive permissions mode */
+  forceInteractivePermissions?: boolean;
+}
+
+/** Result of command execution */
+export interface CommandResult {
+  /** Whether the command was fully handled (stop processing) */
+  handled?: boolean;
+  /** Whether to continue processing remaining text (for stackable commands) */
+  continueProcessing?: boolean;
+  /** Options to pass to session start (for first-message commands) */
+  sessionOptions?: Partial<InitialSessionOptions>;
+  /** Branch name for worktree creation (for first-message) */
+  worktreeBranch?: string;
+  /** Remaining text after command extraction */
+  remainingText?: string;
+}
+
+// =============================================================================
+// Command Handler
+// =============================================================================
+
+/** Command handler function signature */
+export type CommandHandler = (
+  ctx: CommandExecutorContext,
+  args?: string
+) => Promise<CommandResult>;
+
+/** Map of command names to handlers */
+export type CommandHandlerMap = Map<string, CommandHandler>;

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -14,6 +14,7 @@ function createMockPlatform(botName = 'claude-bot') {
   let postIdCounter = 1;
 
   return {
+    platformId: 'test-platform',
     createPost: mock(async (message: string, threadId?: string): Promise<PlatformPost> => {
       const id = `post_${postIdCounter++}`;
       posts.set(id, message);


### PR DESCRIPTION
## Summary

- Fixed a bug where `!worktree switch branch-name` in a root message would incorrectly create a worktree named "switch" instead of switching to the specified branch
- **Major refactoring**: Unified command handling with a registry-driven executor

## What Changed

### Bug Fix
Root message parsing now properly detects worktree subcommands (switch, list, remove, cleanup, off) and handles them the same way as in thread replies.

### Refactoring
Instead of just fixing the bug with duplicated code, this PR creates a unified command execution system:

1. **New `src/commands/types.ts`** - Command execution types (CommandResult, CommandHandler, CommandExecutorContext)
2. **New `src/commands/executor.ts`** - Single `executeCommand()` function that handles all commands
3. **Extended registry** - Added `isStackable`, `isImmediate`, and subcommand `worksInFirstMessage` flags
4. **Extended parser** - Added `parseCommandWithRemainder()` for first-message command stacking
5. **Simplified message-handler.ts** - Replaced ~200 lines of duplicated switch statements with calls to `executeCommand()`

### Benefits
- **Single source of truth**: Registry drives all command behavior
- **No duplication**: Worktree subcommands handled in ONE place (previously duplicated)
- **Easier maintenance**: Add new commands by updating registry + adding handler
- **Better testability**: Handlers can be tested in isolation

## Test plan

- [x] Added unit tests for all worktree subcommands in root messages
- [x] Verified all 2004 tests still pass
- [ ] Manual test: `@bot !worktree switch existing-branch` should switch to existing worktree
- [ ] Manual test: `@bot !worktree list` should list worktrees
- [ ] Manual test: `@bot !worktree my-new-branch` should still create a new worktree
- [ ] Manual test: `@bot !cd /tmp !permissions interactive do something` should stack commands

🤖 Generated with [Claude Code](https://claude.ai/code)