### PR TITLE
fix: worktree switch with prompt in root message now starts session

### DIFF
--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -44,6 +44,8 @@ export interface InitialSessionOptions {
   workingDir?: string;
   /** Force interactive permissions mode */
   forceInteractivePermissions?: boolean;
+  /** Switch to existing worktree instead of creating new (from !worktree switch) */
+  switchToExisting?: boolean;
 }
 
 /** Result of command execution */

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -29,6 +29,8 @@ export interface InitialSessionOptions {
   workingDir?: string;
   /** Force interactive permissions (from !permissions interactive) */
   forceInteractivePermissions?: boolean;
+  /** Switch to existing worktree instead of creating new (from !worktree switch) */
+  switchToExisting?: boolean;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Bug fix: `@bot !worktree switch bla hi! waar ben je nu?` was not working - it returned "Mention me to start a session" instead of switching to the worktree and starting a session with the prompt.

## Changes

- Parse `!worktree switch` args: first word is branch, rest is prompt  
- Add `switchToWorktreeWithoutSession()` for switch-only (no prompt)
- Add `switchToExisting` option to `InitialSessionOptions`
- Update `startSessionWithWorktree` to use existing worktree when flag set

## Test plan

- [x] RED-GREEN verified: tests fail without fix, pass with fix
- [x] All 2006 tests pass
- [ ] Manual test: `@bot !worktree switch bla hi!` should switch to "bla" and start session with "hi!"

🤖 Generated with [Claude Code](https://claude.ai/code)