### PR TITLE
fix: handle MCP server path resolution for bun build bundles

### DIFF
--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -511,18 +511,24 @@ export class ClaudeCli extends EventEmitter {
   }
 
   private getMcpServerPath(): string {
-    // Get the path to the MCP permission server
-    // When running from source: src/mcp/permission-server.ts -> dist/mcp/permission-server.js
-    // When installed globally: the bin entry points to dist/mcp/permission-server.js
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
+    // When bundled with bun build, __dirname is dist/ (not dist/claude/)
+    // Try the bundled path first, then fall back to source layout
+    const bundledPath = resolve(__dirname, 'mcp', 'permission-server.js');
+    if (existsSync(bundledPath)) {
+      return bundledPath;
+    }
     return resolve(__dirname, '..', 'mcp', 'permission-server.js');
   }
 
   private getStatusLineWriterPath(): string {
-    // Get the path to the status line writer script
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
+    const bundledPath = resolve(__dirname, 'statusline', 'writer.js');
+    if (existsSync(bundledPath)) {
+      return bundledPath;
+    }
     return resolve(__dirname, '..', 'statusline', 'writer.js');
   }
 }


### PR DESCRIPTION
## Summary

- Fix MCP server and status line writer path resolution when the project is bundled with `bun build` into a single `dist/index.js`
- When bundled, `__dirname` resolves to `dist/` instead of `dist/claude/`, so the `resolve(__dirname, '..', 'mcp', ...)` path points to a nonexistent location at the project root
- The fix tries the bundled layout path (sibling directory) first via `existsSync`, falling back to the standard source/installed layout

## Test plan

- [x] All existing unit tests pass (2030 pass, 0 fail)
- [ ] Verify MCP permission server starts correctly when running from `bun build` bundle
- [ ] Verify status line writer works correctly when running from `bun build` bundle
- [ ] Verify standard `bun run build` + `bun start` flow still works (source layout fallback)