### PR TITLE
fix: clear CLAUDE_THREADS_INTERACTIVE for daemon subprocess (#312)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,10 +189,10 @@ async function main() {
         env: {
           ...process.env,
           CLAUDE_THREADS_BIN: binPath,
-          // Tell the child process we started from an interactive terminal.
-          // The daemon runs the child as a background job (&) which loses TTY,
-          // causing false headless detection without this flag.
-          ...(process.stdout.isTTY ? { CLAUDE_THREADS_INTERACTIVE: '1' } : {}),
+          // Clear CLAUDE_THREADS_INTERACTIVE so the daemon subprocess detects
+          // its own TTY state. The daemon runs with piped stdio (no TTY), so
+          // forwarding the parent's TTY state would cause InkProvider to crash.
+          CLAUDE_THREADS_INTERACTIVE: '',
         },
       });
     } else {
@@ -201,7 +201,7 @@ async function main() {
         env: {
           ...process.env,
           CLAUDE_THREADS_BIN: binPath,
-          ...(process.stdout.isTTY ? { CLAUDE_THREADS_INTERACTIVE: '1' } : {}),
+          CLAUDE_THREADS_INTERACTIVE: '',
         },
       });
     }


### PR DESCRIPTION
## Summary

Fixes #312.

When the bot starts in daemon mode (auto-restart), the parent process was conditionally forwarding `CLAUDE_THREADS_INTERACTIVE=1` based on its own TTY state. The daemon subprocess runs with piped stdio (no TTY), so when the parent had a TTY, the child would incorrectly believe it was interactive too, causing InkProvider to crash with "InkProvider requires an interactive terminal (TTY)".

The fix clears `CLAUDE_THREADS_INTERACTIVE` (sets it to empty string) for the daemon subprocess, so it detects its own terminal capabilities independently. This applies to both the Windows and non-Windows code paths in `src/index.ts`.

## Test plan

- [x] All 2030 unit tests pass
- [ ] Start bot in daemon mode from an interactive terminal, verify no InkProvider crash
- [ ] Start bot in daemon mode from a non-TTY context, verify normal operation