### PR TITLE
feat: opt-in multi-account Claude support with rate-limit aware round-robin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Multi-account Claude support (opt-in)** — configure a pool of Claude accounts in `config.yaml` so sessions round-robin across multiple subscriptions / API keys and stop sharing one token budget. Each Claude CLI spawn runs with an overridden `HOME` (for OAuth Pro/Max accounts) or `ANTHROPIC_API_KEY`. Persisted sessions remember which account they were started on and resume under the same one. Omitting `claudeAccounts` leaves the bot in single-account mode — zero change for existing installs.
+- **Rate-limit detection & auto-reassignment** — the bot parses Claude's stderr and result events for rate-limit signals (`usage limit reached`, `rate_limit_error`, `429 ... rate limit`, `quota exceeded`) and puts the offending account into cooldown until the extracted reset time (with a 1-hour fallback). A heads-up is posted in the session thread so the user knows which account is cooling.
+- **Session header & sticky-message account indicators** — the per-session header shows `🔑 Claude account` when multi-account mode is active, and the channel sticky summarizes the pool: `🔑 N accounts` or `🔑 A/N accounts (K cooling)`.
+
 ## [1.6.3] - 2026-04-21
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,56 @@ platforms:
 
 Configuration is stored in YAML only - no `.env` file support.
 
+## Multi-Account Claude Support (opt-in)
+
+By default every session spawns `claude` with the bot's own `process.env`, so
+they all share one subscription's token budget. When you expect heavy concurrent
+use, configure a pool of accounts in `config.yaml` — sessions will round-robin
+across them and new ones automatically skip accounts that are in rate-limit
+cooldown.
+
+```yaml
+# Omit this block entirely → single-account mode (unchanged behavior).
+claudeAccounts:
+  # OAuth Pro/Max — prepare the HOME with `HOME=<path> claude login` first
+  - id: primary
+    home: /home/bot/.claude-accounts/primary
+  - id: backup
+    displayName: Backup (Pro)
+    home: /home/bot/.claude-accounts/backup
+
+  # API-key billed
+  - id: shared-api
+    apiKey: sk-ant-api03-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+How it works:
+
+1. **Spawn env override.** For `home` we set `HOME` (and `USERPROFILE` on Windows)
+   so Claude reads `.credentials.json`, `.claude/projects/*`, and MCP config from
+   that directory. For `apiKey` we set `ANTHROPIC_API_KEY` (leaving HOME as-is).
+2. **Session → account binding is persisted.** `PersistedSession.claudeAccountId`
+   stores which account a session started on, so resume after a bot restart uses
+   the same credentials — critical for OAuth accounts since the conversation
+   history in `~/.claude/projects/*` lives under that HOME.
+3. **Rate-limit handling.** Claude's stderr and result events are scanned for
+   phrases like `usage limit reached`, `rate_limit_error`, `429 ... rate limit`,
+   `quota exceeded`. On a hit the offending account is cooled down until the
+   extracted reset time (fallback: 1 hour). Future `acquireClaudeAccount()` calls
+   skip cooling accounts; resumed sessions bypass cooldown because their history
+   can't move.
+
+Files involved:
+
+| File | Role |
+|------|------|
+| `src/claude/account-pool.ts` | `AccountPool` — round-robin, cooldown tracking, usage accounting. |
+| `src/claude/rate-limit-detector.ts` | Pure parser that turns stderr/JSON into `{ detected, resetAtEpochMs }`. |
+| `src/claude/cli.ts` | `ClaudeCliOptions.account` → overrides `HOME` / `ANTHROPIC_API_KEY` on spawn. Emits `rate-limit` events. |
+| `src/session/lifecycle.ts` | Acquires the account on `startSession`/`resumeSession`, releases on `removeFromRegistry`, handles `rate-limit` events. |
+| `src/operations/commands/handler.ts` | Preserves the account when `!cd` / `!permissions interactive` respawn Claude; adds the 🔑 row to the session header. |
+| `src/operations/sticky-message/handler.ts` | Pool summary in the channel sticky. |
+
 ## Source Files
 
 ### Core

--- a/src/claude/account-pool.test.ts
+++ b/src/claude/account-pool.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for AccountPool.
+ */
+import { describe, it, expect } from 'bun:test';
+import { AccountPool } from './account-pool.js';
+
+describe('AccountPool', () => {
+  describe('empty / single-account mode', () => {
+    it('is empty when constructed with no accounts', () => {
+      const pool = new AccountPool();
+      expect(pool.isEmpty).toBe(true);
+      expect(pool.size).toBe(0);
+      expect(pool.acquire()).toBeNull();
+    });
+
+    it('is empty when constructed with empty array', () => {
+      const pool = new AccountPool([]);
+      expect(pool.isEmpty).toBe(true);
+      expect(pool.acquire()).toBeNull();
+    });
+
+    it('drops accounts that have neither home nor apiKey', () => {
+      const pool = new AccountPool([
+        { id: 'valid', home: '/tmp/a' },
+        { id: 'empty' }, // invalid
+        { id: 'api', apiKey: 'sk-xxx' },
+      ]);
+      expect(pool.size).toBe(2);
+      expect(pool.get('empty')).toBeUndefined();
+      expect(pool.get('valid')).toBeDefined();
+      expect(pool.get('api')).toBeDefined();
+    });
+  });
+
+  describe('acquire / round-robin', () => {
+    it('returns accounts in round-robin order', () => {
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+        { id: 'c', home: '/tmp/c' },
+      ]);
+      expect(pool.acquire()?.id).toBe('a');
+      expect(pool.acquire()?.id).toBe('b');
+      expect(pool.acquire()?.id).toBe('c');
+      expect(pool.acquire()?.id).toBe('a'); // wraps
+    });
+
+    it('returns preferred account when supplied and known', () => {
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+      ]);
+      expect(pool.acquire('b')?.id).toBe('b');
+      expect(pool.acquire('b')?.id).toBe('b');
+    });
+
+    it('falls back to round-robin when preferred id is unknown', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      expect(pool.acquire('ghost')?.id).toBe('a');
+    });
+
+    it('skips cooling accounts in round-robin', () => {
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+        { id: 'c', home: '/tmp/c' },
+      ]);
+      pool.markCooling('b', Date.now() + 60_000);
+
+      expect(pool.acquire()?.id).toBe('a');
+      expect(pool.acquire()?.id).toBe('c'); // b skipped
+      expect(pool.acquire()?.id).toBe('a');
+    });
+
+    it('returns null when every account is cooling', () => {
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+      ]);
+      const future = Date.now() + 60_000;
+      pool.markCooling('a', future);
+      pool.markCooling('b', future);
+      expect(pool.acquire()).toBeNull();
+    });
+
+    it('returns preferred account even if it is cooling (resume path)', () => {
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+      ]);
+      pool.markCooling('a', Date.now() + 60_000);
+      // Resuming a session that was started on 'a' must still get 'a' —
+      // its history lives under a's HOME and can't move.
+      expect(pool.acquire('a')?.id).toBe('a');
+    });
+
+    it('allows reacquisition after cooldown passes', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.markCooling('a', Date.now() - 1); // already expired
+      expect(pool.acquire()?.id).toBe('a');
+    });
+  });
+
+  describe('usage accounting', () => {
+    it('tracks active sessions via acquire/release', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.acquire(); // 1
+      pool.acquire(); // 2
+      pool.release('a'); // 1
+      const status = pool.status();
+      expect(status[0].activeSessions).toBe(1);
+    });
+
+    it('clamps release at zero', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.release('a'); // no-op effectively
+      pool.release('a');
+      expect(pool.status()[0].activeSessions).toBe(0);
+    });
+
+    it('ignores release for unknown accounts', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.release('ghost'); // does not throw
+      expect(pool.status()[0].activeSessions).toBe(0);
+    });
+  });
+
+  describe('markCooling', () => {
+    it('reports cooling in status()', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      const until = Date.now() + 60_000;
+      pool.markCooling('a', until);
+      expect(pool.status()[0].coolingUntil).toBe(until);
+    });
+
+    it('never shortens an existing cooldown', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      const far = Date.now() + 120_000;
+      const near = Date.now() + 60_000;
+      pool.markCooling('a', far);
+      pool.markCooling('a', near);
+      expect(pool.status()[0].coolingUntil).toBe(far);
+    });
+
+    it('treats expired cooldowns as available in status()', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.markCooling('a', Date.now() - 1);
+      expect(pool.status()[0].coolingUntil).toBeNull();
+    });
+
+    it('ignores markCooling for unknown accounts', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.markCooling('ghost', Date.now() + 60_000);
+      // shouldn't throw and shouldn't appear in status
+      expect(pool.status()).toHaveLength(1);
+    });
+  });
+});

--- a/src/claude/account-pool.ts
+++ b/src/claude/account-pool.ts
@@ -1,0 +1,148 @@
+/**
+ * AccountPool — round-robin selector over a pool of Claude accounts.
+ *
+ * Responsibilities:
+ * - Hand out an account for a new session (round-robin, skipping cooling accounts).
+ * - Track which accounts are currently in rate-limit cooldown so future sessions
+ *   route around them. Resume of existing sessions bypasses cooldown because the
+ *   conversation history lives under that account's HOME and can't be moved.
+ * - Track usage counts for UI display (sticky message).
+ *
+ * Single-account mode: pass an empty array (or `undefined`) to the constructor
+ * and every method returns `null` — the bot then falls back to `process.env` as
+ * it does today.
+ */
+import type { ClaudeAccount } from '../config/types.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('account-pool');
+
+/** Snapshot of pool state for UI/debug. */
+export interface AccountPoolStatus {
+  id: string;
+  displayName: string;
+  activeSessions: number;
+  coolingUntil: number | null; // epoch ms, null = available
+}
+
+export class AccountPool {
+  private readonly accounts: ClaudeAccount[];
+  private readonly byId: Map<string, ClaudeAccount>;
+  private readonly activeCounts: Map<string, number> = new Map();
+  private readonly coolingUntil: Map<string, number> = new Map();
+  private roundRobinIndex = 0;
+
+  constructor(accounts?: ClaudeAccount[]) {
+    this.accounts = (accounts ?? []).filter((acc) => {
+      const hasAuth = !!acc.home || !!acc.apiKey;
+      if (!hasAuth) {
+        log.warn(`Claude account ${acc.id} has neither home nor apiKey — ignoring`);
+      }
+      return hasAuth;
+    });
+    this.byId = new Map(this.accounts.map((acc) => [acc.id, acc]));
+    for (const acc of this.accounts) {
+      this.activeCounts.set(acc.id, 0);
+    }
+  }
+
+  /** True when no accounts are configured — caller should use default env. */
+  get isEmpty(): boolean {
+    return this.accounts.length === 0;
+  }
+
+  /** Number of configured accounts. */
+  get size(): number {
+    return this.accounts.length;
+  }
+
+  /**
+   * Acquire the next available account via round-robin, skipping cooling ones.
+   *
+   * If `preferredId` is given and that account exists, it is returned as-is —
+   * even if it's currently cooling. This path is used when resuming an existing
+   * session whose conversation history lives under that account's HOME.
+   *
+   * Returns `null` when the pool is empty, or when every account is cooling
+   * and no `preferredId` was supplied.
+   */
+  acquire(preferredId?: string): ClaudeAccount | null {
+    if (this.isEmpty) return null;
+
+    if (preferredId) {
+      const preferred = this.byId.get(preferredId);
+      if (preferred) {
+        this.incrementActive(preferred.id);
+        return preferred;
+      }
+      log.warn(`Preferred account "${preferredId}" not in pool — falling back to round-robin`);
+    }
+
+    const now = Date.now();
+    const n = this.accounts.length;
+    for (let i = 0; i < n; i++) {
+      const idx = (this.roundRobinIndex + i) % n;
+      const candidate = this.accounts[idx];
+      const cooling = this.coolingUntil.get(candidate.id) ?? 0;
+      if (cooling <= now) {
+        this.roundRobinIndex = (idx + 1) % n;
+        this.incrementActive(candidate.id);
+        return candidate;
+      }
+    }
+
+    log.warn(`All ${n} accounts are in rate-limit cooldown`);
+    return null;
+  }
+
+  /**
+   * Release an account — caller invokes this when a session ends so usage
+   * accounting stays accurate. No-op if the id isn't in the pool.
+   */
+  release(accountId: string): void {
+    const current = this.activeCounts.get(accountId);
+    if (current === undefined) return;
+    this.activeCounts.set(accountId, Math.max(0, current - 1));
+  }
+
+  /**
+   * Mark an account as rate-limited until `untilEpochMs`. Subsequent `acquire()`
+   * calls without `preferredId` will skip this account until the timestamp passes.
+   */
+  markCooling(accountId: string, untilEpochMs: number): void {
+    if (!this.byId.has(accountId)) {
+      log.warn(`markCooling called for unknown account "${accountId}"`);
+      return;
+    }
+    const existing = this.coolingUntil.get(accountId) ?? 0;
+    // Only extend cooldown, never shorten it.
+    if (untilEpochMs > existing) {
+      this.coolingUntil.set(accountId, untilEpochMs);
+      const minutes = Math.ceil((untilEpochMs - Date.now()) / 60000);
+      log.info(`Account "${accountId}" cooling for ~${minutes}min`);
+    }
+  }
+
+  /** Look up an account by id. Returns undefined for unknown ids. */
+  get(accountId: string): ClaudeAccount | undefined {
+    return this.byId.get(accountId);
+  }
+
+  /** Snapshot of pool state — for UI / sticky message / debug logs. */
+  status(): AccountPoolStatus[] {
+    const now = Date.now();
+    return this.accounts.map((acc) => {
+      const cooling = this.coolingUntil.get(acc.id) ?? 0;
+      return {
+        id: acc.id,
+        displayName: acc.displayName ?? acc.id,
+        activeSessions: this.activeCounts.get(acc.id) ?? 0,
+        coolingUntil: cooling > now ? cooling : null,
+      };
+    });
+  }
+
+  private incrementActive(accountId: string): void {
+    this.activeCounts.set(accountId, (this.activeCounts.get(accountId) ?? 0) + 1);
+  }
+}

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -8,8 +8,13 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { createLogger } from '../utils/logger.js';
 import { getClaudePath } from './version-check.js';
+import { detectRateLimit } from './rate-limit-detector.js';
 
 const log = createLogger('claude');
+
+// Re-export so consumers (SessionManager) can import without digging into
+// the detector module directly.
+export type { RateLimitHit } from './rate-limit-detector.js';
 
 /**
  * Clean up stale Claude browser bridge socket files.
@@ -122,6 +127,37 @@ export interface ClaudeCliOptions {
   appendSystemPrompt?: string;  // Additional system prompt to append
   logSessionId?: string;  // Session ID for log routing (platformId:threadId)
   permissionTimeoutMs?: number;  // Timeout for permission approval (default: 120000)
+  /**
+   * Optional Claude account to spawn under. When set, `HOME` (for OAuth) or
+   * `ANTHROPIC_API_KEY` (for API-billed) in the child env is overridden so
+   * Claude uses that account's credentials. When omitted, the child inherits
+   * `process.env` — single-account mode, identical to prior behavior.
+   */
+  account?: ClaudeCliAccount;
+}
+
+/** Minimal subset of ClaudeAccount that `ClaudeCli` needs. */
+export interface ClaudeCliAccount {
+  id: string;
+  home?: string;
+  apiKey?: string;
+}
+
+/**
+ * True when a Claude `result` event carries an error payload. Gates the
+ * rate-limit scanner so assistant text in successful turns (which can legally
+ * contain phrases like "rate_limit_error" when the user asks about them) can't
+ * poison the account cooldown logic.
+ *
+ * Error subtypes from Claude CLI include `error_during_execution`,
+ * `error_max_turns`, and other `error_*` values. Payloads that set
+ * `is_error: true` are also treated as errors.
+ */
+function isErrorResultEvent(event: ClaudeEvent): boolean {
+  const ev = event as { subtype?: unknown; is_error?: unknown };
+  if (typeof ev.subtype === 'string' && ev.subtype.startsWith('error')) return true;
+  if (ev.is_error === true) return true;
+  return false;
 }
 
 export class ClaudeCli extends EventEmitter {
@@ -132,6 +168,7 @@ export class ClaudeCli extends EventEmitter {
   private statusFilePath: string | null = null;
   private lastStatusData: StatusLineData | null = null;
   private stderrBuffer = '';  // Capture stderr for error detection
+  private rateLimitEmitted = false;  // Fire 'rate-limit' only once per process
   private log: ReturnType<typeof createLogger>;  // Session-scoped logger
 
   constructor(options: ClaudeCliOptions) {
@@ -213,8 +250,9 @@ export class ClaudeCli extends EventEmitter {
   start(): void {
     if (this.process) throw new Error('Already running');
 
-    // Clear stderr buffer from any previous run
+    // Clear stderr buffer and rate-limit dedupe flag from any previous run
     this.stderrBuffer = '';
+    this.rateLimitEmitted = false;
 
     // Clean up stale browser bridge sockets (workaround for Claude CLI bug)
     cleanupBrowserBridgeSockets();
@@ -305,9 +343,17 @@ export class ClaudeCli extends EventEmitter {
 
     this.log.debug(`Starting: ${claudePath} ${args.slice(0, 5).join(' ')}...`);
 
+    // Build child env. When an account is configured, override HOME (OAuth) or
+    // ANTHROPIC_API_KEY (API) so Claude reads different credentials per session.
+    // No account → inherit process.env unchanged (single-account mode).
+    const childEnv = this.buildChildEnv();
+    if (this.options.account) {
+      this.log.debug(`Spawning under Claude account "${this.options.account.id}"`);
+    }
+
     this.process = crossSpawn(claudePath, args, {
       cwd: this.options.workingDir,
-      env: process.env,
+      env: childEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
@@ -325,6 +371,7 @@ export class ClaudeCli extends EventEmitter {
         this.stderrBuffer = this.stderrBuffer.slice(-10240);
       }
       this.log.debug(`stderr: ${text.trim()}`);
+      this.maybeEmitRateLimit(text);
     });
 
     this.process.on('error', (err) => {
@@ -388,10 +435,37 @@ export class ClaudeCli extends EventEmitter {
         const event = JSON.parse(trimmed) as ClaudeEvent;
         // Note: Event details are logged in events.ts handleEvent with session context
         this.emit('event', event);
+        // Scan for rate-limit only on error-flavored result events. `success`
+        // results contain the assistant's final answer text, which could easily
+        // include phrases like "rate_limit_error" if the user asked about them
+        // — scanning those would cool the account down on a normal reply.
+        // Error subtypes (e.g. "error_during_execution", "error_max_turns") and
+        // any event carrying `is_error: true` are the narrow set we trust.
+        if (event.type === 'result' && isErrorResultEvent(event)) {
+          this.maybeEmitRateLimit(trimmed);
+        }
       } catch {
         // Ignore unparseable lines (usually partial JSON from streaming)
       }
     }
+  }
+
+  /**
+   * Scan a stderr chunk or result-event body for rate-limit signals and, on a
+   * hit, emit a single `'rate-limit'` event with the parsed hit.
+   *
+   * We guard against re-emitting on every subsequent stderr tick by keeping
+   * a small cursor: callers (SessionManager) will typically already have put
+   * the account into cooldown, so duplicate emits are harmless — but cheap to
+   * avoid.
+   */
+  private maybeEmitRateLimit(text: string): void {
+    const hit = detectRateLimit(text);
+    if (!hit.detected) return;
+    if (this.rateLimitEmitted) return;
+    this.rateLimitEmitted = true;
+    this.log.warn(`Rate limit detected: ${hit.matched ?? '(no match text)'}`);
+    this.emit('rate-limit', hit);
   }
 
   isRunning(): boolean {
@@ -508,6 +582,48 @@ export class ClaudeCli extends EventEmitter {
     this.log.debug(`Interrupting Claude process (pid=${this.process.pid})`);
     this.process.kill('SIGINT');
     return true;
+  }
+
+  /**
+   * Build the env object for the spawned Claude process.
+   *
+   * Without `options.account` we pass `process.env` through unchanged so
+   * existing single-account users see no difference. With an account:
+   * - `home` set → override `HOME` (and `USERPROFILE` on Windows). Claude
+   *   reads `.credentials.json`, `.claude/projects/*`, and MCP config from
+   *   this directory, so the child session runs fully under that account's
+   *   OAuth state.
+   * - `apiKey` set → override `ANTHROPIC_API_KEY`. Claude keeps using the
+   *   outer HOME for history and MCP, but billing goes to this key. We also
+   *   clear the outer OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) so the API key
+   *   wins even if both are present.
+   *
+   * Exposed as a separate method to keep `start()` readable and to make the
+   * env-assembly logic straightforward to audit.
+   */
+  private buildChildEnv(): NodeJS.ProcessEnv {
+    const account = this.options.account;
+    if (!account) return process.env;
+
+    const env: NodeJS.ProcessEnv = { ...process.env };
+
+    if (account.home) {
+      env.HOME = account.home;
+      env.USERPROFILE = account.home;
+      // OAuth lives under HOME, so clear env vars that would otherwise beat
+      // the file-based credentials we're pointing at: an inherited API key
+      // (ANTHROPIC_API_KEY) or an inherited OAuth token
+      // (CLAUDE_CODE_OAUTH_TOKEN) from the bot's own parent env would both
+      // silently swap the account we thought we were using.
+      delete env.ANTHROPIC_API_KEY;
+      delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    } else if (account.apiKey) {
+      env.ANTHROPIC_API_KEY = account.apiKey;
+      // Clear an inherited OAuth token so API key billing wins.
+      delete env.CLAUDE_CODE_OAUTH_TOKEN;
+    }
+
+    return env;
   }
 
   private getMcpServerPath(): string {

--- a/src/claude/rate-limit-detector.test.ts
+++ b/src/claude/rate-limit-detector.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for rate-limit detection.
+ */
+import { describe, it, expect } from 'bun:test';
+import { detectRateLimit, cooldownDeadline } from './rate-limit-detector.js';
+
+const NOW = 1_700_000_000_000; // fixed reference timestamp
+
+describe('detectRateLimit', () => {
+  it('returns detected: false for empty input', () => {
+    expect(detectRateLimit('', NOW).detected).toBe(false);
+    expect(detectRateLimit(' ', NOW).detected).toBe(false);
+  });
+
+  it('returns detected: false for unrelated errors', () => {
+    expect(detectRateLimit('file not found', NOW).detected).toBe(false);
+    expect(detectRateLimit('Claude Code v2.1.2', NOW).detected).toBe(false);
+  });
+
+  it('matches "Usage limit reached"', () => {
+    const hit = detectRateLimit('ERROR: Usage limit reached. Try again later.', NOW);
+    expect(hit.detected).toBe(true);
+    expect(hit.matched?.toLowerCase()).toContain('usage limit reached');
+  });
+
+  it('matches rate_limit_error from API error body', () => {
+    const hit = detectRateLimit('{"error":{"type":"rate_limit_error"}}', NOW);
+    expect(hit.detected).toBe(true);
+  });
+
+  it('matches 429 in context', () => {
+    const hit = detectRateLimit('HTTP 429 rate limit exceeded', NOW);
+    expect(hit.detected).toBe(true);
+  });
+
+  it('does not match bare 429', () => {
+    // Bare status code without context shouldn't cool an account down
+    const hit = detectRateLimit('got 429 status', NOW);
+    expect(hit.detected).toBe(false);
+  });
+
+  it('matches "quota exceeded"', () => {
+    const hit = detectRateLimit('your quota has been exceeded', NOW);
+    expect(hit.detected).toBe(true);
+  });
+});
+
+describe('reset-time extraction', () => {
+  it('parses "retry after N seconds"', () => {
+    const hit = detectRateLimit('rate_limit_error: retry after 120 seconds', NOW);
+    expect(hit.resetAtEpochMs).toBe(NOW + 120_000);
+  });
+
+  it('parses "Resets in N hours"', () => {
+    const hit = detectRateLimit('Usage limit reached. Resets in 2 hours.', NOW);
+    expect(hit.resetAtEpochMs).toBe(NOW + 2 * 3_600_000);
+  });
+
+  it('parses "Resets in N minutes"', () => {
+    const hit = detectRateLimit('usage limit reached. Resets in 45 minutes', NOW);
+    expect(hit.resetAtEpochMs).toBe(NOW + 45 * 60_000);
+  });
+
+  it('parses unix seconds in JSON', () => {
+    const resetSec = 1_700_003_600;
+    const hit = detectRateLimit(
+      `{"error":{"type":"rate_limit_error","reset_at":${resetSec}}}`,
+      NOW
+    );
+    expect(hit.resetAtEpochMs).toBe(resetSec * 1000);
+  });
+
+  it('parses unix milliseconds in JSON', () => {
+    const resetMs = 1_700_003_600_000;
+    const hit = detectRateLimit(
+      `{"error":{"type":"rate_limit_error","reset":${resetMs}}}`,
+      NOW
+    );
+    expect(hit.resetAtEpochMs).toBe(resetMs);
+  });
+
+  it('parses clock time "resets at HH:MM" and rolls to tomorrow when in past', () => {
+    // NOW is 2023-11-14 ~22:13:20 UTC; "05:00 UTC" is earlier today → tomorrow
+    const hit = detectRateLimit('Usage limit reached. Resets at 05:00 UTC.', NOW);
+    expect(hit.resetAtEpochMs).toBeGreaterThan(NOW);
+    // Should be within the next 24 hours
+    expect(hit.resetAtEpochMs! - NOW).toBeLessThan(24 * 3_600_000);
+  });
+
+  it('returns undefined reset when no hint present', () => {
+    const hit = detectRateLimit('rate_limit_error occurred', NOW);
+    expect(hit.detected).toBe(true);
+    expect(hit.resetAtEpochMs).toBeUndefined();
+  });
+});
+
+describe('false-positive guards (regression for M2)', () => {
+  // The rate-limit detector is now only invoked from error-flavored result
+  // events and from stderr (see cli.ts:parseOutput). These tests document that
+  // the phrase matchers themselves are intentionally permissive — the
+  // tightening lives in the caller. A test in cli-level code would pair this
+  // with the caller's gating logic.
+  it('still matches when asked, so the caller gating matters', () => {
+    // This is assistant-generated text answering a question about rate limits.
+    // The detector intentionally still matches — the caller must filter out
+    // successful result events so this text never reaches detectRateLimit.
+    const assistantText = 'A rate_limit_error is returned when Anthropic\'s API is...';
+    expect(detectRateLimit(assistantText, NOW).detected).toBe(true);
+  });
+
+  it('does not match benign mentions of "limit" or "quota"', () => {
+    expect(detectRateLimit('context limit approaching', NOW).detected).toBe(false);
+    expect(detectRateLimit('your disk quota is 100GB', NOW).detected).toBe(false);
+    expect(detectRateLimit('429 is the HTTP status for Too Many Requests', NOW).detected).toBe(false);
+  });
+});
+
+describe('cooldownDeadline', () => {
+  it('uses extracted reset when available', () => {
+    const hit = { detected: true, resetAtEpochMs: NOW + 5_000 };
+    expect(cooldownDeadline(hit, NOW)).toBe(NOW + 5_000);
+  });
+
+  it('falls back to default 1-hour cooldown when no reset hint', () => {
+    const hit = { detected: true };
+    expect(cooldownDeadline(hit, NOW)).toBe(NOW + 3_600_000);
+  });
+
+  it('returns now when not detected', () => {
+    expect(cooldownDeadline({ detected: false }, NOW)).toBe(NOW);
+  });
+});

--- a/src/claude/rate-limit-detector.ts
+++ b/src/claude/rate-limit-detector.ts
@@ -1,0 +1,124 @@
+/**
+ * Rate-limit detection from Claude CLI output.
+ *
+ * Claude CLI surfaces rate-limit errors in two places:
+ * 1. stderr — plaintext messages like "Usage limit reached. Resets at 14:00 UTC."
+ * 2. stream-json `result` events with `subtype: "error"` and an error body that
+ *    mirrors the Anthropic API shape, including `error.type === "rate_limit_error"`
+ *    and sometimes a retry-after header.
+ *
+ * This module parses either form and returns a normalized result. It is pure
+ * and synchronous so it can be unit-tested without touching the CLI process.
+ */
+
+export interface RateLimitHit {
+  /** True if the input contained a rate-limit signal. */
+  detected: boolean;
+  /** Epoch ms when the limit resets. Undefined when we can't extract one. */
+  resetAtEpochMs?: number;
+  /** Original matched phrase, useful for logging / debugging. */
+  matched?: string;
+}
+
+/**
+ * Phrases that reliably indicate a rate-limit condition. Matching is case-
+ * insensitive. We keep the list short and high-confidence — anything fuzzy
+ * goes in a follow-up so a single noisy log line doesn't put the account into
+ * cooldown.
+ */
+const RATE_LIMIT_PHRASES = [
+  /usage limit reached/i,
+  /rate[_\s-]?limit[_\s-]?error/i,
+  /you have hit the rate limit/i,
+  /quota (has been )?exceeded/i,
+  /\b429\b.*(rate|limit|quota)/i,
+];
+
+/**
+ * Duration fallbacks if no explicit reset is given. Keep conservative — the
+ * worst case is we re-probe the account once in a while.
+ */
+const DEFAULT_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Parse arbitrary CLI output (stderr line, JSON error body, etc.) and decide
+ * whether it signals a rate limit. Never throws; on ambiguity returns
+ * `detected: true` with no `resetAtEpochMs` so the caller can fall back to
+ * the default cooldown.
+ */
+export function detectRateLimit(text: string, now: number = Date.now()): RateLimitHit {
+  if (!text) return { detected: false };
+
+  let matched: string | undefined;
+  for (const phrase of RATE_LIMIT_PHRASES) {
+    const m = text.match(phrase);
+    if (m) {
+      matched = m[0];
+      break;
+    }
+  }
+  if (!matched) return { detected: false };
+
+  const resetAtEpochMs = extractResetAt(text, now);
+  return { detected: true, matched, resetAtEpochMs };
+}
+
+/**
+ * Derive the cooldown deadline from the parsed hit. Callers feed this straight
+ * into `AccountPool.markCooling(id, deadline)`.
+ */
+export function cooldownDeadline(hit: RateLimitHit, now: number = Date.now()): number {
+  if (!hit.detected) return now;
+  return hit.resetAtEpochMs ?? now + DEFAULT_COOLDOWN_MS;
+}
+
+/**
+ * Try hard to find when the limit resets. Accepts a handful of common shapes:
+ * - `"Resets in 2 hours"` / `"retry after 600 seconds"` — relative offsets
+ * - `"resets at 14:00 UTC"` — absolute UTC clock time (today or tomorrow)
+ * - `"reset_at": 1761234567` — unix seconds inside a JSON blob
+ *
+ * Returns undefined when no hint is present — the caller will use the default
+ * cooldown.
+ */
+function extractResetAt(text: string, now: number): number | undefined {
+  // "retry after N seconds" / "Resets in N minutes|hours|seconds"
+  const relative = text.match(
+    /(?:retry[_\s-]?after|resets?\s+in)\s+(\d+)\s*(second|minute|hour|day)s?/i
+  );
+  if (relative) {
+    const value = parseInt(relative[1], 10);
+    const unit = relative[2].toLowerCase();
+    const unitMs: Record<string, number> = {
+      second: 1000,
+      minute: 60_000,
+      hour: 3_600_000,
+      day: 86_400_000,
+    };
+    return now + value * unitMs[unit];
+  }
+
+  // JSON-ish: "reset_at": 1234567890  (seconds)
+  const unix = text.match(/["']?reset(?:_at)?["']?\s*[:=]\s*(\d{10,13})/);
+  if (unix) {
+    const raw = parseInt(unix[1], 10);
+    // 10 digits = seconds, 13 = ms
+    return unix[1].length === 13 ? raw : raw * 1000;
+  }
+
+  // "resets at 14:00 [UTC]" — pick next occurrence (today or tomorrow)
+  const clock = text.match(/resets?\s+at\s+(\d{1,2}):(\d{2})\s*(utc|gmt)?/i);
+  if (clock) {
+    const hh = parseInt(clock[1], 10);
+    const mm = parseInt(clock[2], 10);
+    if (hh < 24 && mm < 60) {
+      const reference = new Date(now);
+      const target = new Date(
+        Date.UTC(reference.getUTCFullYear(), reference.getUTCMonth(), reference.getUTCDate(), hh, mm)
+      ).getTime();
+      return target > now ? target : target + 86_400_000;
+    }
+  }
+
+  return undefined;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export type {
   WorktreeMode,
   LimitsConfig,
   StickyMessageCustomization,
+  ClaudeAccount,
 } from './config/migration.js';
 
 export { resolveLimits, LIMITS_DEFAULTS } from './config/migration.js';

--- a/src/config/migration.ts
+++ b/src/config/migration.ts
@@ -9,6 +9,7 @@ export type {
   ThreadLogsConfig,
   LimitsConfig,
   StickyMessageCustomization,
+  ClaudeAccount,
   Config,
   PlatformInstanceConfig,
   MattermostPlatformConfig,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -86,6 +86,32 @@ export interface StickyMessageCustomization {
   footer?: string;
 }
 
+/**
+ * One Claude subscription/account the bot can spawn sessions under.
+ *
+ * Exactly one of `home` or `apiKey` should be set:
+ * - `home`: path to an alternate $HOME that contains `.claude/.credentials.json`
+ *   from a prior `HOME=<path> claude login`. Used for OAuth Pro/Max subscriptions.
+ *   Claude's history (`~/.claude/projects/...`) also lives here, so a resumed
+ *   session MUST pick the same account.
+ * - `apiKey`: direct Anthropic API key. Billed against that key's account.
+ *   History still persists under the bot's default HOME because Claude only
+ *   uses `apiKey` for billing, not for state storage.
+ *
+ * Leaving `claudeAccounts` unset in config keeps the bot in single-account mode:
+ * every session inherits `process.env` exactly as before.
+ */
+export interface ClaudeAccount {
+  /** Stable identifier used in logs, UI, and persisted session state. */
+  id: string;
+  /** Alternate $HOME for OAuth-based accounts. Mutually exclusive with apiKey. */
+  home?: string;
+  /** Anthropic API key for API-billed accounts. Mutually exclusive with home. */
+  apiKey?: string;
+  /** Optional human-readable label shown in UI (defaults to `id`). */
+  displayName?: string;
+}
+
 export interface Config {
   version: number;
   workingDir: string;
@@ -96,6 +122,8 @@ export interface Config {
   threadLogs?: ThreadLogsConfig; // Optional thread logging configuration
   limits?: LimitsConfig; // Optional resource limits and timeouts
   stickyMessage?: StickyMessageCustomization; // Optional sticky message customization
+  /** Optional Claude account pool. When omitted, bot runs in single-account mode. */
+  claudeAccounts?: ClaudeAccount[];
   platforms: PlatformInstanceConfig[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,7 +465,8 @@ async function startWithoutDaemon() {
     undefined,  // sessionsPath - use default
     threadLogsEnabled,
     threadLogsRetentionDays,
-    config.limits  // Resource limits (optional, has sensible defaults)
+    config.limits,  // Resource limits (optional, has sensible defaults)
+    config.claudeAccounts  // Claude account pool (undefined = single-account mode)
   );
 
   // Set sticky message customization from config

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -166,6 +166,11 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
       forceUpdate: mock(async () => {}),
       deferUpdate: mock(() => {}),
       handleBugReportApproval: mock(async () => {}),
+      acquireClaudeAccount: mock(() => null),
+      getClaudeAccount: mock(() => undefined),
+      releaseClaudeAccount: mock(() => {}),
+      markClaudeAccountCooling: mock(() => {}),
+      getClaudeAccountPoolStatus: mock(() => []),
     },
   };
 }

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -7,7 +7,8 @@
 import type { Session } from '../../session/types.js';
 import { transitionTo } from '../../session/types.js';
 import type { SessionContext } from '../session-context/index.js';
-import type { ClaudeCliOptions, ClaudeEvent } from '../../claude/cli.js';
+import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../../claude/cli.js';
+import { handleRateLimit } from '../../session/lifecycle.js';
 import { ClaudeCli } from '../../claude/cli.js';
 import { randomUUID } from 'crypto';
 import { resolve } from 'path';
@@ -62,6 +63,23 @@ const sessionLog = createSessionLog(log);
 // ---------------------------------------------------------------------------
 
 /**
+ * Build the `account` option for a Claude CLI restart.
+ *
+ * Sessions that already run under a pooled Claude account must keep using the
+ * same credentials when Claude is respawned (e.g. !cd, !permissions interactive).
+ * Returns undefined for sessions started in single-account mode.
+ */
+function sessionAccountOption(
+  session: Session,
+  ctx: SessionContext
+): ClaudeCliOptions['account'] {
+  if (!session.claudeAccountId) return undefined;
+  const account = ctx.ops.getClaudeAccount(session.claudeAccountId);
+  if (!account) return undefined;
+  return { id: account.id, home: account.home, apiKey: account.apiKey };
+}
+
+/**
  * Restart Claude CLI with new options.
  * Handles the common pattern of kill -> flush -> create new CLI -> rebind -> start.
  * Returns true on success, false if start failed.
@@ -83,9 +101,13 @@ export async function restartClaudeSession(
   // Create new Claude CLI
   session.claude = new ClaudeCli(cliOptions);
 
-  // Rebind event handlers (use sessionId which is the composite key)
+  // Rebind event handlers (use sessionId which is the composite key).
+  // The rate-limit listener MUST be rebound here too — without it, a !cd or
+  // !permissions interactive restart would silently drop rate-limit signals
+  // from the new Claude process and the account would never enter cooldown.
   session.claude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(session.sessionId, e));
   session.claude.on('exit', (code: number) => ctx.ops.handleExit(session.sessionId, code));
+  session.claude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
 
   // Start the new Claude CLI
   try {
@@ -365,6 +387,7 @@ export async function changeDirectory(
     appendSystemPrompt,  // Include platform context and commands
     logSessionId: session.sessionId,  // Route logs to session panel
     permissionTimeoutMs: ctx.config.permissionTimeoutMs,
+    account: sessionAccountOption(session, ctx),
   };
 
   // Restart Claude with new options
@@ -527,6 +550,7 @@ export async function enableInteractivePermissions(
     platformConfig: session.platform.getMcpConfig(),
     logSessionId: session.sessionId,  // Route logs to session panel
     permissionTimeoutMs: ctx.config.permissionTimeoutMs,
+    account: sessionAccountOption(session, ctx),
   };
 
   // Restart Claude with new options
@@ -707,6 +731,13 @@ export async function updateSessionHeader(
 
   if (otherParticipants) {
     items.push(['👥', 'Participants', otherParticipants]);
+  }
+
+  // Claude account (only when the bot is running in multi-account mode)
+  if (session.claudeAccountId) {
+    const account = ctx.ops.getClaudeAccount(session.claudeAccountId);
+    const label = account?.displayName ?? session.claudeAccountId;
+    items.push(['🔑', 'Claude account', formatter.formatCode(label)]);
   }
 
   items.push(['🆔', 'Session ID', formatter.formatCode(session.claudeSessionId.substring(0, 8))]);

--- a/src/operations/commands/restart-rebind.test.ts
+++ b/src/operations/commands/restart-rebind.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression test for reviewer M1: `restartClaudeSession` must rebind the
+ * `'rate-limit'` listener in addition to `'event'` and `'exit'`.
+ *
+ * Without the rebind, a !cd or !permissions interactive run would spawn a
+ * fresh Claude process whose rate-limit signals go nowhere — the account
+ * never enters cooldown until the next cold start. The bug slipped past
+ * typecheck + existing tests because the binding was missing, not malformed.
+ *
+ * The assertion here is deliberately structural: after the restart, the new
+ * ClaudeCli instance must have listeners registered for all three events.
+ * Anything more "behavioral" (emit + check side effect) would need wiring
+ * through the full SessionContext, which is covered by the handleRateLimit
+ * tests in lifecycle.test.ts.
+ */
+import { describe, it, expect, mock } from 'bun:test';
+import { EventEmitter } from 'events';
+
+// Mock ClaudeCli with a minimal EventEmitter so .on() counts are observable.
+// Must be declared before importing handler so the module cache picks it up.
+//
+// NOTE: we deliberately do NOT mock `session/lifecycle.js`. `mock.module` in
+// bun is process-global — stubbing `handleRateLimit` here would leak into
+// lifecycle.test.ts and break its own tests of the real handler. Since this
+// test only checks listener counts (never fires the event), the real import
+// is harmless.
+mock.module('../../claude/cli.js', () => ({
+  ClaudeCli: class MockClaudeCli extends EventEmitter {
+    isRunning() { return true; }
+    kill() { return Promise.resolve(); }
+    start() {}
+    sendMessage() {}
+    interrupt() {}
+  },
+}));
+
+import { restartClaudeSession } from './handler.js';
+import type { ClaudeCliOptions } from '../../claude/cli.js';
+import type { Session } from '../../session/types.js';
+import type { SessionContext } from '../session-context/index.js';
+import { createSessionTimers, createSessionLifecycle } from '../../session/types.js';
+
+function makeSession(): Session {
+  return {
+    sessionId: 'test:thread-1',
+    platformId: 'test',
+    threadId: 'thread-1',
+    claudeSessionId: 'uuid-1',
+    startedBy: 'tester',
+    startedAt: new Date(),
+    lastActivityAt: new Date(),
+    sessionNumber: 1,
+    workingDir: '/tmp',
+    // stub — restartClaudeSession calls .kill() on this, then replaces it
+    claude: new (class extends EventEmitter {
+      isRunning() { return true; }
+      kill() { return Promise.resolve(); }
+    })() as unknown as Session['claude'],
+    planApproved: false,
+    sessionAllowedUsers: new Set(['tester']),
+    forceInteractivePermissions: false,
+    sessionStartPostId: null,
+    timers: createSessionTimers(),
+    lifecycle: createSessionLifecycle(),
+    timeoutWarningPosted: false,
+    messageCount: 0,
+    isProcessing: false,
+    platform: { getFormatter: () => ({}) } as Session['platform'],
+  } as unknown as Session;
+}
+
+function makeCtx(): SessionContext {
+  return {
+    config: {} as SessionContext['config'],
+    state: {} as SessionContext['state'],
+    ops: {
+      stopTyping: mock(() => {}),
+      flush: mock(async () => {}),
+      handleEvent: mock(() => {}),
+      handleExit: mock(async () => {}),
+    } as unknown as SessionContext['ops'],
+  };
+}
+
+describe('restartClaudeSession', () => {
+  it('binds listeners for event, exit, AND rate-limit on the new Claude CLI', async () => {
+    const session = makeSession();
+    const ctx = makeCtx();
+    const cliOptions = { workingDir: '/tmp' } as ClaudeCliOptions;
+
+    const ok = await restartClaudeSession(session, cliOptions, ctx, 'test');
+    expect(ok).toBe(true);
+
+    // session.claude was replaced — verify the NEW instance has all three
+    // listeners wired. If anyone removes the rate-limit binding, the final
+    // expect fails.
+    const claudeEmitter = session.claude as unknown as EventEmitter;
+    expect(claudeEmitter.listenerCount('event')).toBe(1);
+    expect(claudeEmitter.listenerCount('exit')).toBe(1);
+    expect(claudeEmitter.listenerCount('rate-limit')).toBe(1);
+  });
+});

--- a/src/operations/events/handler.test.ts
+++ b/src/operations/events/handler.test.ts
@@ -158,6 +158,11 @@ function createSessionContext(): SessionContext {
       forceUpdate: mock(async () => {}),
       deferUpdate: mock(() => {}),
       handleBugReportApproval: mock(async () => {}),
+      acquireClaudeAccount: mock(() => null),
+      getClaudeAccount: mock(() => undefined),
+      releaseClaudeAccount: mock(() => {}),
+      markClaudeAccountCooling: mock(() => {}),
+      getClaudeAccountPoolStatus: mock(() => []),
     },
   };
 }

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -17,6 +17,8 @@ import type { PlatformClient, PlatformFile } from '../../platform/index.js';
 import type { SessionStore } from '../../persistence/session-store.js';
 import type { SessionInfo } from '../../ui/types.js';
 import type { BuiltMessageContent } from '../streaming/handler.js';
+import type { ClaudeAccount } from '../../config.js';
+import type { AccountPoolStatus } from '../../claude/account-pool.js';
 
 // =============================================================================
 // Configuration (read-only state)
@@ -222,6 +224,41 @@ export interface SessionOperations {
 
   /** Emit session:remove event for UI */
   emitSessionRemove(sessionId: string): void;
+
+  // ---------------------------------------------------------------------------
+  // Claude Account Pool
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Reserve a Claude account for a new or resumed session.
+   *
+   * Returns `null` when the bot is in single-account mode (no pool configured)
+   * or when every account is currently in rate-limit cooldown. Callers that
+   * receive `null` should fall back to spawning Claude with `process.env`.
+   *
+   * `preferredId` is honored even if the account is currently cooling — this
+   * is required for resume, because OAuth history lives under a specific HOME.
+   */
+  acquireClaudeAccount(preferredId?: string): ClaudeAccount | null;
+
+  /**
+   * Look up the Claude account metadata for a session that already holds one.
+   * Used by session restart paths (e.g. !cd) that must keep using the same
+   * account without re-acquiring it from the round-robin pool.
+   */
+  getClaudeAccount(accountId: string): ClaudeAccount | undefined;
+
+  /** Return an account to the pool when a session ends. No-op for unknown ids. */
+  releaseClaudeAccount(accountId: string): void;
+
+  /**
+   * Mark an account as rate-limited until the given epoch timestamp. Future
+   * round-robin picks skip the account until the timestamp passes.
+   */
+  markClaudeAccountCooling(accountId: string, untilEpochMs: number): void;
+
+  /** Snapshot of pool state for sticky-message / header rendering. */
+  getClaudeAccountPoolStatus(): AccountPoolStatus[];
 }
 
 // =============================================================================

--- a/src/operations/sticky-message/handler.ts
+++ b/src/operations/sticky-message/handler.ts
@@ -12,6 +12,7 @@ import type { PlatformClient, PlatformFormatter } from '../../platform/index.js'
 import { getPlatformIcon } from '../../platform/utils.js';
 import type { SessionStore, PersistedSession } from '../../persistence/session-store.js';
 import type { WorktreeMode } from '../../config.js';
+import type { AccountPoolStatus } from '../../claude/account-pool.js';
 import { formatBatteryStatus } from '../../utils/battery.js';
 import { formatUptime } from '../../utils/uptime.js';
 import { formatRelativeTimeShort, formatShortId, formatVersionString } from '../../utils/format.js';
@@ -159,6 +160,11 @@ export interface StickyMessageConfig {
   description?: string;
   /** Custom footer content appended before the default footer */
   footer?: string;
+  /**
+   * Claude account pool snapshot. Undefined means single-account mode; the
+   * sticky skips the account summary entirely in that case.
+   */
+  accountPoolStatus?: AccountPoolStatus[];
 }
 
 // Store sticky post IDs per platform (in-memory cache)
@@ -411,6 +417,17 @@ async function buildStatusBar(
 
   // Session count
   items.push(formatter.formatCode(`${sessionCount}/${config.maxSessions} sessions`));
+
+  // Claude account pool summary (only when pool is configured)
+  if (config.accountPoolStatus && config.accountPoolStatus.length > 0) {
+    const total = config.accountPoolStatus.length;
+    const cooling = config.accountPoolStatus.filter((a) => a.coolingUntil !== null).length;
+    const available = total - cooling;
+    const label = cooling > 0
+      ? `🔑 ${available}/${total} accounts (${cooling} cooling)`
+      : `🔑 ${total} account${total === 1 ? '' : 's'}`;
+    items.push(formatter.formatCode(label));
+  }
 
   // Permission mode
   const permMode = config.skipPermissions ? '⚡ Auto' : '🔐 Interactive';

--- a/src/persistence/session-store.ts
+++ b/src/persistence/session-store.ts
@@ -75,6 +75,15 @@ export interface PersistedSession {
   resumeFailCount?: number;                      // Count of consecutive resume failures
   // History retention (soft delete)
   cleanedAt?: string;                            // ISO date when session was soft-deleted (kept for history)
+  // Multi-account support
+  /**
+   * Claude account id the session was started under, if the bot is configured
+   * with a `claudeAccounts` pool. Resume MUST pick the same account — for
+   * OAuth accounts the conversation history lives under that account's HOME
+   * and cannot be read from a different one. Undefined for legacy sessions
+   * and for bots running in single-account mode.
+   */
+  claudeAccountId?: string;
 }
 
 /**

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -209,6 +209,11 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
       forceUpdate: mock(async () => {}),
       deferUpdate: mock(() => {}),
       handleBugReportApproval: mock(async () => {}),
+      acquireClaudeAccount: mock(() => null),
+      getClaudeAccount: mock(() => undefined),
+      releaseClaudeAccount: mock(() => {}),
+      markClaudeAccountCooling: mock(() => {}),
+      getClaudeAccountPoolStatus: mock(() => []),
     },
   };
 }
@@ -336,6 +341,57 @@ describe('Lifecycle Module', () => {
       expect(session.timeoutWarningPosted).toBe(true);
       expect(sessions.has('test-platform:thread-123')).toBe(true);
     });
+  });
+});
+
+describe('handleRateLimit (multi-account cooldown wiring)', () => {
+  /**
+   * Regression test for reviewer S1: without this coverage, the three
+   * wiring bugs it pairs with (M1 restart-rebind, M2 false-positive, M3
+   * account leak) could all regress silently. This test exercises the
+   * actual handler function that bindings call.
+   */
+  it('cools the session account when a rate-limit hit fires', () => {
+    const session = createMockSession({ claudeAccountId: 'alice' });
+    const ctx = createMockSessionContext(new Map([['test-platform:thread-123', session]]));
+
+    lifecycle.handleRateLimit(
+      session,
+      { detected: true, matched: 'usage limit reached', resetAtEpochMs: Date.now() + 60_000 },
+      ctx
+    );
+
+    expect(ctx.ops.markClaudeAccountCooling).toHaveBeenCalledTimes(1);
+    const [acctId, deadlineMs] = (ctx.ops.markClaudeAccountCooling as ReturnType<typeof mock>).mock.calls[0];
+    expect(acctId).toBe('alice');
+    expect(deadlineMs).toBeGreaterThan(Date.now());
+  });
+
+  it('falls back to the default 1-hour cooldown when reset time is unknown', () => {
+    const session = createMockSession({ claudeAccountId: 'bob' });
+    const ctx = createMockSessionContext(new Map([['test-platform:thread-123', session]]));
+
+    const before = Date.now();
+    lifecycle.handleRateLimit(session, { detected: true, matched: 'rate_limit_error' }, ctx);
+    const after = Date.now();
+
+    const [, deadlineMs] = (ctx.ops.markClaudeAccountCooling as ReturnType<typeof mock>).mock.calls[0];
+    // Default is 1h — allow a wide window for clock drift in the test.
+    expect(deadlineMs).toBeGreaterThanOrEqual(before + 59 * 60_000);
+    expect(deadlineMs).toBeLessThanOrEqual(after + 61 * 60_000);
+  });
+
+  it('is a no-op in single-account mode (no account id on session)', () => {
+    const session = createMockSession({ claudeAccountId: undefined });
+    const ctx = createMockSessionContext(new Map([['test-platform:thread-123', session]]));
+
+    lifecycle.handleRateLimit(
+      session,
+      { detected: true, matched: 'usage limit reached' },
+      ctx
+    );
+
+    expect(ctx.ops.markClaudeAccountCooling).not.toHaveBeenCalled();
   });
 });
 

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -15,8 +15,9 @@ import {
 } from './types.js';
 import { clearAllTimers } from './timer-manager.js';
 import type { PlatformClient, PlatformFile } from '../platform/index.js';
-import type { ClaudeCliOptions, ClaudeEvent } from '../claude/cli.js';
+import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../claude/cli.js';
 import { ClaudeCli } from '../claude/cli.js';
+import { cooldownDeadline } from '../claude/rate-limit-detector.js';
 import type { PersistedSession } from '../persistence/session-store.js';
 import { createThreadLogger } from '../persistence/thread-logger.js';
 import { VERSION } from '../version.js';
@@ -159,6 +160,22 @@ async function cleanupSession(
     cleanupPostIndex(ctx, session.threadId);
   }
   keepAlive.sessionEnded();
+  releaseAccountIfHeld(session, ctx);
+}
+
+/**
+ * Release the session's Claude account slot, if one was acquired. Safe to call
+ * on every exit path — no-op in single-account mode or if the session never
+ * held an account. This is the one-place rule that keeps pool accounting
+ * honest across the many early-exit / failure branches.
+ */
+function releaseAccountIfHeld(session: Session, ctx: SessionContext): void {
+  if (session.claudeAccountId) {
+    ctx.ops.releaseClaudeAccount(session.claudeAccountId);
+    // Guard against double-release: once released, stop tracking the id on
+    // the session so a later cleanup path can't decrement again.
+    session.claudeAccountId = undefined;
+  }
 }
 
 /**
@@ -176,6 +193,38 @@ function removeFromRegistry(session: Session, ctx: SessionContext): void {
   mutableSessions(ctx).delete(session.sessionId);
   cleanupPostIndex(ctx, session.threadId);
   keepAlive.sessionEnded();
+  releaseAccountIfHeld(session, ctx);
+}
+
+/**
+ * React to a rate-limit signal from Claude CLI.
+ *
+ * Puts the current account into cooldown so future `acquire()` calls route new
+ * sessions to other accounts. Posts a heads-up in the session thread. The
+ * session itself is not killed here — Claude CLI will surface the error in its
+ * own output and the user can decide (wait, use another session, etc.).
+ *
+ * Exported so that all code paths that rebind Claude listeners (startSession,
+ * resumeSession, and the `restartClaudeSession` helper used by !cd /
+ * !permissions) share the same handler and can't accidentally drop it.
+ */
+export function handleRateLimit(session: Session, hit: RateLimitHit, ctx: SessionContext): void {
+  if (!session.claudeAccountId) {
+    sessionLog(session).warn(`Rate limit hit in single-account mode — cannot reroute`);
+    return;
+  }
+  const deadline = cooldownDeadline(hit);
+  ctx.ops.markClaudeAccountCooling(session.claudeAccountId, deadline);
+  const minutes = Math.max(1, Math.ceil((deadline - Date.now()) / 60_000));
+  sessionLog(session).warn(
+    `Rate limit on account "${session.claudeAccountId}" — cooling for ~${minutes}min`
+  );
+  void post(
+    session,
+    'warning',
+    `⚠️ Claude account \`${session.claudeAccountId}\` hit a rate limit. ` +
+      `New sessions will use another account until it resets (~${minutes}min).`
+  );
 }
 
 /**
@@ -766,6 +815,12 @@ export async function startSession(
   // Create Claude CLI with options
   const platformMcpConfig = platform.getMcpConfig();
 
+  // Reserve a Claude account from the pool (null = single-account mode)
+  const claudeAccount = ctx.ops.acquireClaudeAccount();
+  if (claudeAccount) {
+    log.info(`Session ${sessionId.substring(0, 20)} reserved Claude account "${claudeAccount.id}"`);
+  }
+
   const cliOptions: ClaudeCliOptions = {
     workingDir,
     threadId: actualThreadId,
@@ -777,6 +832,9 @@ export async function startSession(
     appendSystemPrompt: systemPrompt,
     logSessionId: sessionId,  // Route logs to session panel
     permissionTimeoutMs: ctx.config.permissionTimeoutMs,
+    account: claudeAccount
+      ? { id: claudeAccount.id, home: claudeAccount.home, apiKey: claudeAccount.apiKey }
+      : undefined,
   };
   const claude = new ClaudeCli(cliOptions);
 
@@ -787,6 +845,7 @@ export async function startSession(
     sessionId,
     platform,
     claudeSessionId,
+    claudeAccountId: claudeAccount?.id,
     startedBy: username,
     startedByDisplayName: displayName,
     startedAt: new Date(),
@@ -846,6 +905,7 @@ export async function startSession(
   // Bind event handlers (use sessionId which is the composite key)
   claude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(sessionId, e));
   claude.on('exit', (code: number) => ctx.ops.handleExit(sessionId, code));
+  claude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
 
   try {
     claude.start();
@@ -854,6 +914,7 @@ export async function startSession(
     ctx.ops.stopTyping(session);
     ctx.ops.emitSessionRemove(session.sessionId);
     mutableSessions(ctx).delete(session.sessionId);
+    releaseAccountIfHeld(session, ctx);
     await ctx.ops.updateStickyMessage();
     return;
   }
@@ -978,6 +1039,17 @@ export async function resumeSession(
   const sessionContext = buildSessionContext(platform, state.workingDir);
   const appendSystemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
 
+  // Resume MUST re-use the same Claude account the session started on —
+  // for OAuth accounts the conversation history lives under that HOME.
+  // acquireClaudeAccount honors preferredId even if it is currently cooling.
+  const claudeAccount = ctx.ops.acquireClaudeAccount(state.claudeAccountId);
+  if (state.claudeAccountId && !claudeAccount) {
+    log.warn(
+      `Persisted session referenced Claude account "${state.claudeAccountId}" ` +
+      `which is no longer configured — resuming under default env`
+    );
+  }
+
   const cliOptions: ClaudeCliOptions = {
     workingDir: state.workingDir,
     threadId: state.threadId,
@@ -989,6 +1061,9 @@ export async function resumeSession(
     appendSystemPrompt,
     logSessionId: sessionId,  // Route logs to session panel
     permissionTimeoutMs: ctx.config.permissionTimeoutMs,
+    account: claudeAccount
+      ? { id: claudeAccount.id, home: claudeAccount.home, apiKey: claudeAccount.apiKey }
+      : undefined,
   };
   const claude = new ClaudeCli(cliOptions);
 
@@ -999,6 +1074,7 @@ export async function resumeSession(
     sessionId,
     platform,
     claudeSessionId: state.claudeSessionId,
+    claudeAccountId: claudeAccount?.id,
     startedBy: state.startedBy,
     startedByDisplayName: state.startedByDisplayName,
     startedAt: new Date(state.startedAt),
@@ -1118,6 +1194,7 @@ export async function resumeSession(
   // Bind event handlers (use sessionId which is the composite key)
   claude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(sessionId, e));
   claude.on('exit', (code: number) => ctx.ops.handleExit(sessionId, code));
+  claude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
 
   try {
     claude.start();
@@ -1156,6 +1233,7 @@ export async function resumeSession(
     ctx.ops.emitSessionRemove(sessionId);
     mutableSessions(ctx).delete(sessionId);
     ctx.state.sessionStore.remove(sessionId);
+    releaseAccountIfHeld(session, ctx);
 
     // Try to notify user
     const failFormatter = session.platform.getFormatter();

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -16,7 +16,8 @@ import { EventEmitter } from 'events';
 import { ClaudeEvent } from '../claude/cli.js';
 import type { PlatformClient, PlatformUser, PlatformPost, PlatformFile } from '../platform/index.js';
 import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persistence/session-store.js';
-import { WorktreeMode, type LimitsConfig, resolveLimits } from '../config.js';
+import { WorktreeMode, type LimitsConfig, type ClaudeAccount, resolveLimits } from '../config.js';
+import { AccountPool } from '../claude/account-pool.js';
 import type { SessionInfo } from '../ui/types.js';
 import {
   isCancelEmoji,
@@ -106,6 +107,9 @@ export class SessionManager extends EventEmitter {
   // Auto-update manager (set via setAutoUpdateManager)
   private autoUpdateManager: commands.AutoUpdateManagerInterface | null = null;
 
+  // Claude account pool (single-account mode when empty)
+  private readonly accountPool: AccountPool;
+
   constructor(
     workingDir: string,
     skipPermissions = false,
@@ -114,7 +118,8 @@ export class SessionManager extends EventEmitter {
     sessionsPath?: string,
     threadLogsEnabled = true,
     threadLogsRetentionDays = 30,
-    limits?: LimitsConfig
+    limits?: LimitsConfig,
+    claudeAccounts?: ClaudeAccount[]
   ) {
     super();
     this.workingDir = workingDir;
@@ -126,6 +131,7 @@ export class SessionManager extends EventEmitter {
     this.limits = resolveLimits(limits);
     this.sessionStore = new SessionStore(sessionsPath);
     this.registry = new SessionRegistry(this.sessionStore);
+    this.accountPool = new AccountPool(claudeAccounts);
 
     // Create background tasks (started in initialize())
     this.sessionMonitor = new SessionMonitor({
@@ -313,6 +319,13 @@ export class SessionManager extends EventEmitter {
       emitSessionAdd: (s) => this.emitSessionAdd(s),
       emitSessionUpdate: (sid, u) => this.emitSessionUpdate(sid, u),
       emitSessionRemove: (sid) => this.emitSessionRemove(sid),
+
+      // Claude account pool (null when single-account mode)
+      acquireClaudeAccount: (preferredId) => this.accountPool.acquire(preferredId),
+      getClaudeAccount: (id) => this.accountPool.get(id),
+      releaseClaudeAccount: (id) => this.accountPool.release(id),
+      markClaudeAccountCooling: (id, untilMs) => this.accountPool.markCooling(id, untilMs),
+      getClaudeAccountPoolStatus: () => this.accountPool.status(),
     };
 
     return createSessionContext(config, state, ops);
@@ -711,6 +724,7 @@ export class SessionManager extends EventEmitter {
       pullRequestUrl: session.pullRequestUrl,
       messageCount: session.messageCount,
       resumeFailCount: session.lifecycle.resumeFailCount,
+      claudeAccountId: session.claudeAccountId,
     };
     this.sessionStore.save(session.sessionId, state);
   }
@@ -749,6 +763,7 @@ export class SessionManager extends EventEmitter {
       debug: this.debug,
       description: this.customDescription,
       footer: this.customFooter,
+      accountPoolStatus: this.accountPool.isEmpty ? undefined : this.accountPool.status(),
     });
   }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -249,6 +249,10 @@ export interface Session {
   // Claude process
   claude: ClaudeCli;
 
+  // Claude account id the session is running under (when the bot is configured
+  // with a `claudeAccounts` pool). Undefined in single-account mode.
+  claudeAccountId?: string;
+
   // Interactive state (collaboration - not Claude events)
   planApproved: boolean;
 


### PR DESCRIPTION
## Summary

  Adds an **opt-in** pool of Claude accounts so sessions round-robin across
  multiple subscriptions / API keys instead of sharing one token budget. When an
  account hits a rate limit the bot puts it in cooldown and routes new sessions
  to another account; the cooling account resumes automatically when the
  extracted reset time passes.

  Omitting `claudeAccounts` from YAML leaves the bot in single-account mode —
  every session inherits `process.env` exactly as before. Zero impact on
  existing installs.

  ### Config (opt-in)

  ```yaml
  claudeAccounts:
    # OAuth (prepared via `HOME=<path> claude login` against that home)
    - id: primary
      home: /home/bot/.claude-accounts/primary
    - id: backup
      displayName: Backup (Pro)
      home: /home/bot/.claude-accounts/backup

    # API-key billed (no HOME override needed)
    - id: shared-api
      apiKey: sk-ant-api03-xxxxxxxx...

  How it works

  - Spawn-time env override. ClaudeCli accepts an account option and
  sets either HOME/USERPROFILE (OAuth → reads .credentials.json,
  .claude/projects/*, MCP config from that dir) or ANTHROPIC_API_KEY
  (API-billed, HOME untouched). Conflicting env vars from the parent
  (ANTHROPIC_API_KEY under OAuth mode; CLAUDE_CODE_OAUTH_TOKEN in either
  mode) are cleared so the selected account actually wins.
  - Pooling. AccountPool does round-robin acquire(), accepts a
  preferredId (used by resume so OAuth history under a specific HOME is
  recovered), and tracks cooldown per account. Session exits release the slot
  via a one-place helper that covers both the happy path and all failure
  branches.
  - Persistence. PersistedSession.claudeAccountId remembers which account
  a session ran under. Resume passes it as preferredId. Legacy sessions
  without the field fall back to default env — no migration needed.
  - Rate-limit detection. Scans stderr and error-flavored result events
  (gated on subtype.startsWith('error') or is_error: true so assistant
  text that happens to mention "rate_limit_error" can't cool the account) for
  phrases like usage limit reached, rate_limit_error, 429 … rate limit,
  quota exceeded. Extracts the reset time from retry after N seconds,
  Resets in N units, JSON unix timestamps, or HH:MM UTC. Default fallback:
  1 hour. When detected, the pool marks the account cooling and posts a
  warning in the thread.
  - UI. Session header: 🔑 Claude account: <displayName> when
  multi-account mode is active. Channel sticky: 🔑 N accounts or
  🔑 A/N accounts (K cooling).

  Preserving account on session restart

  !cd and !permissions interactive respawn Claude. The restart helper now
  re-embeds the current account into fresh ClaudeCliOptions and rebinds the
  'rate-limit' listener along with 'event' / 'exit' so a mid-session
  rate-limit after a restart still enters cooldown.

  Files touched

  New

  - src/claude/account-pool.ts — round-robin + cooldown (+ 17 unit tests)
  - src/claude/rate-limit-detector.ts — pure parser (+ 19 unit tests)
  - src/operations/commands/restart-rebind.test.ts — regression lock on the three-listener rebind

  Modified

  - src/config/types.ts — ClaudeAccount type + Config.claudeAccounts?
  - src/claude/cli.ts — ClaudeCliOptions.account, buildChildEnv, 'rate-limit' event, isErrorResultEvent gate
  - src/session/{manager,lifecycle,types}.ts — pool wiring, claudeAccountId on Session, handleRateLimit, releaseAccountIfHeld on all
  exit paths
  - src/persistence/session-store.ts — claudeAccountId?: string
  - src/operations/commands/handler.ts — account preserved on restart, 🔑 row in header
  - src/operations/sticky-message/handler.ts — pool summary in status bar
  - src/operations/session-context/types.ts — 5 new pool ops
  - CLAUDE.md, CHANGELOG.md — docs

  Verified

  - bun run typecheck — clean
  - bun test — 1954/0 (prior baseline: 1912)
  - bun run build — clean bundle
  - Manual E2E with three accounts on an isolated Mattermost test channel:
    - Round-robin cycles through all accounts.
    - Each account's session writes its JSONL transcript into its own
  $HOME/.claude/projects/...; nothing lands in the bot operator's main
  ~/.claude.
    - claudeAccountId present on every persisted session; resumes pick the
  same account.
    - API-key account spawns correctly (verified via stderr showing no
  OAuth-related activity).

  Known follow-ups (separate PR)

  - Worktree mid-session respawn in src/operations/worktree/handler.ts:485,634
  rebuilds ClaudeCliOptions inline and currently doesn't thread the
  account or the 'rate-limit' listener — same class of bug as the !cd
  path that this PR fixes. Deliberately left alone here to keep the diff
  focused; will follow up with a small refactor that extracts the listener
  binding into a single helper and re-embeds the account via the existing
  sessionAccountOption pattern.
  - Config validation: reject accounts with both home and apiKey set (today
  the pool takes home wins silently).

  Test plan for reviewer

  - Remove claudeAccounts from config → bot behaves identically to pre-PR.
  - Configure two accounts → start two sessions in different threads → verify round-robin via logs / session header.
  - Restart bot with active sessions → they resume under the same account (check claudeAccountId in sessions.json pre- and
  post-restart).
  - Trigger or simulate a rate limit → verify the offending account is marked cooling, next session is assigned to a different account,
   and a warning posts to the thread.