### PR TITLE
follow-up review nits from #328 (multi-account)

### DIFF
--- a/src/claude/account-pool.test.ts
+++ b/src/claude/account-pool.test.ts
@@ -30,6 +30,22 @@ describe('AccountPool', () => {
       expect(pool.get('valid')).toBeDefined();
       expect(pool.get('api')).toBeDefined();
     });
+
+    it('drops accounts that have BOTH home and apiKey (mutually exclusive)', () => {
+      // home/apiKey are documented as mutually exclusive: `home` routes via
+      // OAuth, `apiKey` via API billing. Silently preferring one (as the old
+      // behavior did) hides misconfiguration; the pool should reject the
+      // account outright so the operator notices.
+      const pool = new AccountPool([
+        { id: 'oauth', home: '/tmp/a' },
+        { id: 'dual', home: '/tmp/b', apiKey: 'sk-ant-xxx' }, // invalid
+        { id: 'api', apiKey: 'sk-ant-yyy' },
+      ]);
+      expect(pool.size).toBe(2);
+      expect(pool.get('dual')).toBeUndefined();
+      expect(pool.get('oauth')).toBeDefined();
+      expect(pool.get('api')).toBeDefined();
+    });
   });
 
   describe('acquire / round-robin', () => {

--- a/src/claude/account-pool.ts
+++ b/src/claude/account-pool.ts
@@ -37,8 +37,18 @@ export class AccountPool {
       const hasAuth = !!acc.home || !!acc.apiKey;
       if (!hasAuth) {
         log.warn(`Claude account ${acc.id} has neither home nor apiKey — ignoring`);
+        return false;
       }
-      return hasAuth;
+      // home and apiKey are documented as mutually exclusive. Dropping here
+      // is the natural chokepoint so the later spawn path in cli.ts doesn't
+      // silently pick one over the other.
+      if (acc.home && acc.apiKey) {
+        log.warn(
+          `Claude account ${acc.id} has both home and apiKey set — must choose one; ignoring`
+        );
+        return false;
+      }
+      return true;
     });
     this.byId = new Map(this.accounts.map((acc) => [acc.id, acc]));
     for (const acc of this.accounts) {

--- a/src/claude/cli.test.ts
+++ b/src/claude/cli.test.ts
@@ -138,6 +138,68 @@ describe('ClaudeCli', () => {
       cli.stopStatusWatch();
     });
   });
+
+  describe('rate-limit emit guard', () => {
+    /**
+     * The ClaudeCli class exposes `'rate-limit'` events through a private
+     * `maybeEmitRateLimit` guard. The guard must dedupe repeat hits at the
+     * same severity (avoiding spam from stderr chunks) but still forward a
+     * new hit whose cooldown deadline moves FORWARD — otherwise
+     * `AccountPool.markCooling` (extend-only) would never see the wider
+     * window and the account would stay cool for only the shorter of the
+     * two deadlines.
+     *
+     * Using `(cli as any)` to reach the private method keeps the test tiny
+     * and hits exactly the code path that parseOutput / stderr handler use.
+     */
+    const callGuard = (cli: ClaudeCli, text: string) =>
+      (cli as unknown as { maybeEmitRateLimit: (t: string) => void }).maybeEmitRateLimit(text);
+
+    test('emits on first hit, dedupes identical repeats', () => {
+      const cli = new ClaudeCli({ workingDir: '/test' });
+      const hits: unknown[] = [];
+      cli.on('rate-limit', (h) => hits.push(h));
+
+      callGuard(cli, 'Usage limit reached. Resets in 10 minutes.');
+      callGuard(cli, 'Usage limit reached. Resets in 10 minutes.');  // same
+      callGuard(cli, 'Usage limit reached. Resets in 10 minutes.');  // same
+
+      expect(hits).toHaveLength(1);
+    });
+
+    test('re-emits when a later hit extends the cooldown deadline', () => {
+      const cli = new ClaudeCli({ workingDir: '/test' });
+      const hits: unknown[] = [];
+      cli.on('rate-limit', (h) => hits.push(h));
+
+      callGuard(cli, 'Usage limit reached. Resets in 10 minutes.');
+      callGuard(cli, 'Usage limit reached. Resets in 2 hours.');  // longer
+
+      expect(hits).toHaveLength(2);
+    });
+
+    test('does not re-emit when a later hit would not advance the deadline', () => {
+      const cli = new ClaudeCli({ workingDir: '/test' });
+      const hits: unknown[] = [];
+      cli.on('rate-limit', (h) => hits.push(h));
+
+      callGuard(cli, 'Usage limit reached. Resets in 2 hours.');
+      callGuard(cli, 'Usage limit reached. Resets in 10 minutes.');  // earlier
+
+      expect(hits).toHaveLength(1);
+    });
+
+    test('ignores non-rate-limit text', () => {
+      const cli = new ClaudeCli({ workingDir: '/test' });
+      const hits: unknown[] = [];
+      cli.on('rate-limit', (h) => hits.push(h));
+
+      callGuard(cli, 'some unrelated stderr line');
+      callGuard(cli, 'context limit approaching');
+
+      expect(hits).toHaveLength(0);
+    });
+  });
 });
 
 describe('StatusLineData interface', () => {

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { createLogger } from '../utils/logger.js';
 import { getClaudePath } from './version-check.js';
-import { detectRateLimit } from './rate-limit-detector.js';
+import { detectRateLimit, cooldownDeadline } from './rate-limit-detector.js';
 
 const log = createLogger('claude');
 
@@ -168,7 +168,10 @@ export class ClaudeCli extends EventEmitter {
   private statusFilePath: string | null = null;
   private lastStatusData: StatusLineData | null = null;
   private stderrBuffer = '';  // Capture stderr for error detection
-  private rateLimitEmitted = false;  // Fire 'rate-limit' only once per process
+  // Deadline of the last rate-limit hit we emitted. Zero means we haven't
+  // emitted one yet. Used to dedupe repeated hits at the same severity while
+  // still letting a LATER deadline through — see maybeEmitRateLimit().
+  private lastEmittedRateLimitDeadline = 0;
   private log: ReturnType<typeof createLogger>;  // Session-scoped logger
 
   constructor(options: ClaudeCliOptions) {
@@ -252,7 +255,7 @@ export class ClaudeCli extends EventEmitter {
 
     // Clear stderr buffer and rate-limit dedupe flag from any previous run
     this.stderrBuffer = '';
-    this.rateLimitEmitted = false;
+    this.lastEmittedRateLimitDeadline = 0;
 
     // Clean up stale browser bridge sockets (workaround for Claude CLI bug)
     cleanupBrowserBridgeSockets();
@@ -452,18 +455,29 @@ export class ClaudeCli extends EventEmitter {
 
   /**
    * Scan a stderr chunk or result-event body for rate-limit signals and, on a
-   * hit, emit a single `'rate-limit'` event with the parsed hit.
+   * hit, emit a `'rate-limit'` event with the parsed hit.
    *
-   * We guard against re-emitting on every subsequent stderr tick by keeping
-   * a small cursor: callers (SessionManager) will typically already have put
-   * the account into cooldown, so duplicate emits are harmless — but cheap to
-   * avoid.
+   * Dedupe semantics: we track the cooldown deadline of the last emit and
+   * re-emit only when a new hit would move the deadline FORWARD by more than
+   * a minute. This means:
+   *  - Identical hits from successive stderr chunks emit once (no spam):
+   *    relative hints like "Resets in 10 minutes" recompute against
+   *    `Date.now()` each call so deadlines drift by milliseconds — the
+   *    epsilon keeps that from counting as "new".
+   *  - A second rate-limit with a meaningfully longer reset (e.g. first hit
+   *    said 10 min, second says 1 hour) does re-emit, so
+   *    `AccountPool.markCooling` — which only extends cooldown — can widen
+   *    the deadline.
+   *  - A second hit with the same or earlier deadline is skipped: the pool
+   *    would have dropped it anyway.
    */
   private maybeEmitRateLimit(text: string): void {
     const hit = detectRateLimit(text);
     if (!hit.detected) return;
-    if (this.rateLimitEmitted) return;
-    this.rateLimitEmitted = true;
+    const newDeadline = cooldownDeadline(hit);
+    const MIN_ADVANCE_MS = 60_000;  // 1 minute: coarser than clock drift, finer than any real rate-limit reset step
+    if (newDeadline - this.lastEmittedRateLimitDeadline < MIN_ADVANCE_MS) return;
+    this.lastEmittedRateLimitDeadline = newDeadline;
     this.log.warn(`Rate limit detected: ${hit.matched ?? '(no match text)'}`);
     this.emit('rate-limit', hit);
   }

--- a/src/claude/rate-limit-detector.test.ts
+++ b/src/claude/rate-limit-detector.test.ts
@@ -92,6 +92,30 @@ describe('reset-time extraction', () => {
     expect(hit.detected).toBe(true);
     expect(hit.resetAtEpochMs).toBeUndefined();
   });
+
+  // Regression: the reset-time regex must not match other fields whose names
+  // contain "reset" as a substring. Before word-boundary anchors, both of the
+  // cases below extracted a bogus epoch and silently misrouted the cooldown.
+  it('does not match "preset": N (word-boundary regression)', () => {
+    const hit = detectRateLimit(
+      `rate_limit_error, "preset": 1700003600`,
+      NOW
+    );
+    // Phrase still triggers detection, but no reset extracted from "preset".
+    expect(hit.detected).toBe(true);
+    expect(hit.resetAtEpochMs).toBeUndefined();
+  });
+
+  it('does not match reset_after=N (relative hint, not absolute epoch)', () => {
+    const hit = detectRateLimit(
+      `rate_limit_error reset_after=1700003600`,
+      NOW
+    );
+    expect(hit.detected).toBe(true);
+    // reset_after would be a *relative* retry-after; interpreting it as an
+    // absolute epoch would put cooldown decades into the future.
+    expect(hit.resetAtEpochMs).toBeUndefined();
+  });
 });
 
 describe('false-positive guards (regression for M2)', () => {

--- a/src/claude/rate-limit-detector.ts
+++ b/src/claude/rate-limit-detector.ts
@@ -98,8 +98,11 @@ function extractResetAt(text: string, now: number): number | undefined {
     return now + value * unitMs[unit];
   }
 
-  // JSON-ish: "reset_at": 1234567890  (seconds)
-  const unix = text.match(/["']?reset(?:_at)?["']?\s*[:=]\s*(\d{10,13})/);
+  // JSON-ish: "reset_at": 1234567890  (seconds).
+  // Word-boundary anchors keep this from matching "preset": ... (the `p`
+  // has no \b before `r`) or reset_after=... (a relative retry-after hint,
+  // which would be silently misread here as an absolute epoch).
+  const unix = text.match(/\breset(?:_at)?\b\s*["']?\s*[:=]\s*(\d{10,13})/);
   if (unix) {
     const raw = parseInt(unix[1], 10);
     // 10 digits = seconds, 13 = ms


### PR DESCRIPTION
Follow-up to #328 (merged as `58c845c`). Three inline review nits from @anneschuth didn't make it into the merge — this PR lands them  on top of `main` as a small isolated change.

  All three were flagged as non-blockers on #328; grouping them together since they're all ~dozen-line fixes.

  ### 1. `AccountPool` rejects accounts with both `home` and `apiKey`

  The docs say these are mutually exclusive but the pool silently preferred `home` (via the `start()` branch in `cli.ts`). Moved validation into the `AccountPool` constructor filter — same log + drop pattern as the existing `hasAuth` check, so the spawn path stays branch-clean.

  File: `src/claude/account-pool.ts` · Test: `account-pool.test.ts`

  ### 2. Tighten `reset_at` epoch regex

  Previous pattern `/["']?reset(?:_at)?["']?\s*[:=]\s*(\d{10,13})/` would match `"preset": 1234567890` (no anchor on the `p`) or `reset_after=1234567890`. The second one is the real hazard — `reset_after` is a **relative** retry-after hint; parsing it as an absolute epoch would put cooldown decades into the future.

  Switched to `\breset(?:_at)?\b\s*["']?\s*[:=]\s*(\d{10,13})` and added regression tests for both cases.

  File: `src/claude/rate-limit-detector.ts` · Test: `rate-limit-detector.test.ts`

  ### 3. Rate-limit emit latch allows deadline extensions

  Replaced the boolean `rateLimitEmitted` with numeric `lastEmittedRateLimitDeadline`. A second rate-limit whose cooldown deadline advances by more than a minute now re-emits so `AccountPool.markCooling` (extend-only) can widen the window. Repeat hits at the same severity — including the stderr-chunk spam the boolean latch was designed to prevent — stay deduped. The 1-minute floor keeps `Date.now()`-based drift on relative hints (`"Resets in 10 minutes"`) from counting as a new event.

  File: `src/claude/cli.ts` · Test: `cli.test.ts` (dedupe / extend / earlier-deadline / non-rate-limit-text)

  ## Verified

  - `bun run typecheck` clean
  - `bun test src/` — **1959/1959** (+5 new tests)
  - `bun run build` clean
  - RED-GREEN verified on (2) and (3): both tests fail when the fix is reverted

  Thanks again for the review — you were right on all three.