### PR TITLE
fix: close maxSessions race that over-admits past the cap

### DIFF
--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -57,6 +57,19 @@ function mutableSessions(ctx: SessionContext): Map<string, Session> {
 }
 
 /**
+ * Count of startSession() calls that have passed the maxSessions cap check but
+ * haven't yet committed themselves to the sessions map. Every await between
+ * the check and the commit is a window where a concurrent startSession can
+ * also pass the check, so we count reservations synchronously alongside the
+ * map's size. Every exit path in startSession decrements via releasePendingStart().
+ */
+let pendingStartsCount = 0;
+
+function releasePendingStart(): void {
+  if (pendingStartsCount > 0) pendingStartsCount--;
+}
+
+/**
  * Get postIndex map with correct mutable type.
  * Reduces type casting noise throughout the module.
  */
@@ -735,8 +748,11 @@ export async function startSession(
     throw new Error(`Platform '${platformId}' not found. Call addPlatform() first.`);
   }
 
-  // Check max sessions limit
-  if (ctx.state.sessions.size >= ctx.config.maxSessions) {
+  // Check max sessions limit. Count pending starts alongside committed sessions
+  // — without this, concurrent startSession() calls all see the same stale size
+  // across the awaits below and over-admit above the configured cap.
+  const activeOrPending = ctx.state.sessions.size + pendingStartsCount;
+  if (activeOrPending >= ctx.config.maxSessions) {
     const formatter = platform.getFormatter();
     // Create a temporary pseudo-session just for posting the message
     // (we don't have a real session yet since we're at capacity)
@@ -745,9 +761,14 @@ export async function startSession(
       threadId: replyToPostId || '',
       sessionId: 'temp',
     } as Session;
-    await post(tempSession, 'warning', `${formatter.formatBold('Too busy')} - ${ctx.state.sessions.size} sessions active. Please try again later.`);
+    await post(tempSession, 'warning', `${formatter.formatBold('Too busy')} - ${activeOrPending} sessions active. Please try again later.`);
     return;
   }
+
+  // Reserve a slot synchronously so concurrent starts see the correct count
+  // at their own cap check. Every early-exit below must release; the success
+  // path releases after the session is committed to the sessions map.
+  pendingStartsCount++;
 
   // Post initial session message (kept short to minimize popup notification size)
   // The full session info is shown when updateSessionHeader() is called shortly after
@@ -759,7 +780,10 @@ export async function startSession(
     ),
     { action: 'Create session post' }
   );
-  if (!startPost) return;
+  if (!startPost) {
+    releasePendingStart();
+    return;
+  }
   const actualThreadId = replyToPostId || startPost.id;
   const sessionId = ctx.ops.getSessionId(platformId, actualThreadId);
 
@@ -788,12 +812,14 @@ export async function startSession(
 
     if (!existsSync(resolvedDir)) {
       await platform.updatePost(startPost.id, `❌ Directory does not exist: ${formatter.formatCode(initialOptions.workingDir)}`);
+      releasePendingStart();
       return;
     }
 
     const { statSync } = await import('fs');
     if (!statSync(resolvedDir).isDirectory()) {
       await platform.updatePost(startPost.id, `❌ Not a directory: ${formatter.formatCode(initialOptions.workingDir)}`);
+      releasePendingStart();
       return;
     }
 
@@ -881,8 +907,10 @@ export async function startSession(
     workingDir: ctx.config.workingDir,
   });
 
-  // Register session
+  // Register session — the reservation can now be released since the real
+  // entry is now in the map and counted by .size.
   mutableSessions(ctx).set(sessionId, session);
+  releasePendingStart();
   ctx.ops.registerPost(startPost.id, actualThreadId);
   ctx.ops.emitSessionAdd(session);
   sessionLog(session).info(`▶ Session started by @${username}`);


### PR DESCRIPTION
## Summary

Closes a race condition in \`startSession()\` that over-admits sessions past the \`maxSessions\` cap. The integration test \`Session Limits > should reject new session when at capacity\` has been flaky at ~40% failure rate for weeks — it's a real bug, not a flake.

## The race

After \`startSession()\` passes the cap check at \`lifecycle.ts:752\`, it awaits \`platform.createPost(\"...starting...\")\` and (for \`!cd\` starts) two dynamic \`import()\` calls before committing the session to \`ctx.state.sessions\` at line 911. During those awaits, concurrent \`startSession()\` calls all read the same stale \`.size\` and every one of them admits.

CI evidence:
\`\`\`
Expected to contain: \"5 sessions active\"
Received:            \"⚠️ **Too busy** - 6 sessions active. Please try again later.\"
\`\`\`

Six sessions existed when the cap-check formatted its message, which only happens if at least two starts passed the check concurrently.

## The fix

Track \"check-passed-but-not-yet-committed\" starts in a module-local counter. The cap check becomes \`sessions.size + pendingStartsCount >= maxSessions\`. Every exit path from \`startSession()\` — whether early-return on validation failure or success-commit to the map — decrements via a \`releasePendingStart()\` helper.

Same shape as the \`releaseAccountIfHeld\` helper introduced in #328 for the account pool: one place that owns the decrement, called from every branch.

## Why not something heavier

- **Mutex / queue serializing \`startSession\`**: overkill for what's genuinely a synchronous reservation. Counter is O(1), lock-free, and the single-threaded JS runtime makes the increment atomic by construction.
- **Tracking pendings via a placeholder entry in the sessions map**: would mutate the shape of a map that many call sites iterate, and requires a sentinel type. Invasive.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun test\` — 2072/0 pass (no regression)
- [x] \`bun run build\` — clean bundle
- [ ] CI — integration test should now pass reliably