### PR TITLE
fix: skip auto-restart daemon when stdout is a TTY

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,12 @@ async function main() {
     if (opts.autoRestart === false) return false;
     if (opts.autoRestart === true) return true;
 
+    // The daemon wrapper runs the child with piped stdio (bash `&`), so the
+    // Ink TUI can't render. When the user has an interactive terminal and
+    // hasn't explicitly asked for --headless, skip the daemon so they keep
+    // the UI. They can opt in with --auto-restart or run --headless.
+    if (!isHeadless && process.stdout.isTTY) return false;
+
     // Check config for autoUpdate.enabled (if config exists)
     // Default is enabled=true, so only disable if explicitly set to false
     if (await checkConfigExists()) {


### PR DESCRIPTION
## Summary

Interactive users lost the Ink TUI on any install with `autoUpdate.enabled`
(the default). The daemon wrapper runs the child as a bash background job
(`&`), which strips stdin and leaves stdout piped — Ink cannot render there,
so the child silently drops to headless mode. One-line guard: when the user
has `process.stdout.isTTY` and hasn't asked for `--headless`, skip the
daemon and start the bot directly.

## Background: we fixed this three times without fixing it

This path has been broken since the daemon landed. Each prior patch papered
over the active crash mode inside the daemon instead of asking whether
interactive users should be routed through the daemon at all:

| PR | Date | Symptom | What it did |
|----|------|---------|-------------|
| #287 | 2026-03-09 | Child had stdin `/dev/null`, Ink crashed on raw mode | Redirect stdin from `/dev/tty` in the bash wrapper |
| #300 | 2026-03-27 | Child saw `stdout.isTTY === undefined`, forced headless | Forward `CLAUDE_THREADS_INTERACTIVE=1` from parent |
| #317 | 2026-04-11 | Forwarded env caused Ink raw-mode crash (stdin still piped) | Clear the env var — daemon child is now **always** headless by design |

After #317 the daemon path is healthy but permanently headless. The comment
at `src/index.ts:192-194` documents this as intended. Interactive users on
the autoUpdate-enabled default just lose their UI.

## The fix

```ts
if (!isHeadless && process.stdout.isTTY) return false;
```

One guard in `shouldUseAutoRestart()`, sitting between the explicit CLI
flags (which still win) and the config check. Behavior:

| Context | Before | After |
|---------|--------|-------|
| Interactive terminal, no flags | Daemon on → headless (broken) | Daemon off → UI (fixed) |
| `--auto-restart` | Daemon on | Daemon on (unchanged) |
| `--no-auto-restart` | Daemon off | Daemon off (unchanged) |
| `--headless` from a TTY | Daemon on → headless | Daemon on → headless (unchanged) |
| No TTY (CI, systemd, nohup) | Daemon on | Daemon on (unchanged) |

The daemon still engages anywhere it was useful — unattended deployments,
explicit opt-in, or headless mode. Interactive users get the UI back.

## Test plan

- [x] `bun test` — 2085 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `tsc --noEmit` — clean
- [x] Verified locally in Ghostty: `bun start` renders the Ink TUI, no silent demotion to headless
- [ ] Verified `--auto-restart` still engages the daemon in the same terminal
- [ ] Verified headless mode still works under `nohup ... &` / systemd-style invocations