### PR TITLE
fix: plain reply resumes paused session after bot restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Plain reply could no longer resume a paused session after bot restart** — when the bot restarted more than 2× `sessionTimeoutMinutes` after a session's last activity, `cleanStale()` soft-deleted the paused record. The reply-resume path used `load()` (which hides soft-deleted sessions), so a user reply in the thread promised by the timeout message (`send a new message to continue`) fell through to the `Mention me with your request` branch and a subsequent @mention started a fresh session, losing thread context. The 🔄 reaction path never had this problem because it reads raw data via `findByPostId`. The two resume paths now share the same visibility into the 3-day history window.
+
 ## [1.8.1] - 2026-04-21
 
 ### Fixed

--- a/src/persistence/session-store.test.ts
+++ b/src/persistence/session-store.test.ts
@@ -167,6 +167,55 @@ describe('SessionStore', () => {
     });
   });
 
+  describe('findByThreadIdAnyState', () => {
+    it('finds an active (not soft-deleted) session by threadId', () => {
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-xyz',
+      });
+      store.save('mattermost-main:thread-xyz', session);
+
+      const found = store.findByThreadIdAnyState('thread-xyz');
+      expect(found).toEqual(session);
+    });
+
+    it('still finds a session after softDelete (unlike load())', () => {
+      // Regression: the plain-reply resume path (message-handler.ts:198) must
+      // see soft-deleted paused sessions so the user can continue them when
+      // cleanStale() at bot startup has tagged them stale. Matches the 🔄
+      // reaction resume path (which uses findByPostId on raw data).
+      const session = createTestSession({
+        platformId: 'mattermost-main',
+        threadId: 'thread-xyz',
+        isPaused: true,
+      });
+      const sessionId = 'mattermost-main:thread-xyz';
+      store.save(sessionId, session);
+      store.softDelete(sessionId);
+
+      // load() hides it — that's by design for auto-resume on startup.
+      expect(store.load().size).toBe(0);
+      // But our lookup still resolves it so a user reply can resume.
+      const found = store.findByThreadIdAnyState('thread-xyz');
+      expect(found).toBeDefined();
+      expect(found?.threadId).toBe('thread-xyz');
+      expect(found?.cleanedAt).toBeDefined();
+    });
+
+    it('returns undefined for unknown threadId', () => {
+      const session = createTestSession({ threadId: 'thread-a' });
+      store.save(`${session.platformId}:${session.threadId}`, session);
+      expect(store.findByThreadIdAnyState('thread-b')).toBeUndefined();
+    });
+
+    it('searches across platforms (returns first match)', () => {
+      const mm = createTestSession({ platformId: 'mattermost-main', threadId: 'shared-id' });
+      store.save('mattermost-main:shared-id', mm);
+      const found = store.findByThreadIdAnyState('shared-id');
+      expect(found?.platformId).toBe('mattermost-main');
+    });
+  });
+
   describe('softDelete', () => {
     it('marks a session as cleaned but keeps it', () => {
       const session = createTestSession();

--- a/src/persistence/session-store.ts
+++ b/src/persistence/session-store.ts
@@ -429,6 +429,32 @@ export class SessionStore {
   }
 
   /**
+   * Find a persisted session by thread ID, searching across all platforms
+   * AND across soft-deleted records that `load()` hides.
+   *
+   * Used by the plain-reply resume path in `message-handler.ts`: after the
+   * bot restarts and `cleanStale()` soft-deletes a paused session whose last
+   * activity is older than 2× timeout, the session is still in the file for
+   * the 3-day history window and can legitimately be resumed if the user
+   * replies in the thread. This mirrors `findByPostId()`'s behavior (which
+   * the 🔄 reaction resume path already uses) so both UX paths promised by
+   * the timeout message — "React with 🔄 OR send a new message to continue"
+   * — work equivalently.
+   *
+   * @param threadId - Thread ID within any platform
+   * @returns Session data if found (including soft-deleted), undefined otherwise
+   */
+  findByThreadIdAnyState(threadId: string): PersistedSession | undefined {
+    const data = this.loadRaw();
+    for (const session of Object.values(data.sessions)) {
+      if (session.threadId === threadId) {
+        return session;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Find a persisted session by lifecycle post ID or session start post ID
    * Used for resuming sessions via emoji reaction
    * @param platformId - Platform instance ID

--- a/src/session/registry.test.ts
+++ b/src/session/registry.test.ts
@@ -33,6 +33,7 @@ function createMockSessionStore(overrides?: Partial<SessionStore>): SessionStore
     isPlatformEnabled: mock(() => true),
     setPlatformEnabled: mock(() => {}),
     findByThread: mock(() => undefined),
+    findByThreadIdAnyState: mock(() => undefined),
     findByPostId: mock(() => undefined),
     ...overrides,
   } as unknown as SessionStore;
@@ -523,7 +524,7 @@ describe('SessionRegistry', () => {
   });
 
   describe('getPersistedByThreadId', () => {
-    it('searches all persisted sessions for thread ID', () => {
+    it('delegates to sessionStore.findByThreadIdAnyState', () => {
       const mockSession: PersistedSession = {
         platformId: 'platform-x',
         threadId: 'target-thread',
@@ -541,12 +542,10 @@ describe('SessionRegistry', () => {
         planApproved: false,
       };
 
-      const sessionsMap = new Map<string, PersistedSession>([
-        ['platform-x:target-thread', mockSession],
-      ]);
-
       mockStore = createMockSessionStore({
-        load: mock(() => sessionsMap),
+        findByThreadIdAnyState: mock((id: string) =>
+          id === 'target-thread' ? mockSession : undefined
+        ),
       });
       registry = new SessionRegistry(mockStore);
 
@@ -556,12 +555,47 @@ describe('SessionRegistry', () => {
 
     it('returns undefined when thread not found', () => {
       mockStore = createMockSessionStore({
-        load: mock(() => new Map()),
+        findByThreadIdAnyState: mock(() => undefined),
       });
       registry = new SessionRegistry(mockStore);
 
       const result = registry.getPersistedByThreadId('nonexistent');
       expect(result).toBeUndefined();
+    });
+
+    it('returns soft-deleted sessions too (reply-resume after restart)', () => {
+      // Regression: a paused session that cleanStale() soft-deleted at bot
+      // startup must still be reachable by threadId so a user reply in the
+      // thread can resume it (same guarantee the 🔄 reaction already has).
+      const softDeleted: PersistedSession = {
+        platformId: 'platform-x',
+        threadId: 'target-thread',
+        claudeSessionId: 'claude-1',
+        startedBy: 'user',
+        startedAt: new Date().toISOString(),
+        sessionNumber: 1,
+        workingDir: '/test',
+        sessionAllowedUsers: [],
+        forceInteractivePermissions: false,
+        sessionStartPostId: null,
+        tasksPostId: null,
+        lastTasksContent: null,
+        lastActivityAt: new Date().toISOString(),
+        planApproved: false,
+        isPaused: true,
+        cleanedAt: new Date().toISOString(),
+      };
+
+      mockStore = createMockSessionStore({
+        // Simulates load() hiding it while the raw-scan helper still sees it.
+        load: mock(() => new Map()),
+        findByThreadIdAnyState: mock((id: string) =>
+          id === 'target-thread' ? softDeleted : undefined
+        ),
+      });
+      registry = new SessionRegistry(mockStore);
+
+      expect(registry.getPersistedByThreadId('target-thread')).toBe(softDeleted);
     });
   });
 

--- a/src/session/registry.ts
+++ b/src/session/registry.ts
@@ -204,16 +204,17 @@ export class SessionRegistry {
 
   /**
    * Get persisted session by thread ID alone (searches all platforms).
+   *
+   * Intentionally includes soft-deleted sessions: when a user replies in a
+   * thread whose paused session was soft-deleted by `cleanStale()` on the
+   * most recent bot restart, we still want to be able to resume it — that
+   * matches the 🔄-reaction resume path (which uses `findByPostId`, also
+   * reading raw data) and honors the "send a new message to continue"
+   * promise in the timeout message. Sessions permanently deleted by
+   * `cleanHistory()` are gone from the file and won't be found here.
    */
   getPersistedByThreadId(threadId: string): PersistedSession | undefined {
-    // Search through all persisted sessions for this threadId
-    const all = this.sessionStore.load();
-    for (const session of all.values()) {
-      if (session.threadId === threadId) {
-        return session;
-      }
-    }
-    return undefined;
+    return this.sessionStore.findByThreadIdAnyState(threadId);
   }
 
   /**


### PR DESCRIPTION
## Summary

  When a session times out, the bot posts:

  > ⏱️ Session timed out after 30 minutes of inactivity
  > 💡 React with 🔄 to resume, or send a new message to continue.

  Two UX paths are promised, but the reply path was unreliable: if the bot restarted after the timeout, a plain reply in the thread
  fell into the "new session, requires @mention" branch. The user's @mention then spawned a fresh session with no thread context.

  ## Root cause

  Bot startup runs `sessionStore.cleanStale(sessionTimeoutMs * 2)` in `SessionManager.initialize()` (`src/session/manager.ts:927`),
  which sets `cleanedAt` on every persisted session with `lastActivityAt` older than 2× timeout — including paused ones that were
  intentionally preserved for resume.

  The reply path (`message-handler.ts:198`) went through `registry.getPersistedByThreadId()`, which called `sessionStore.load()` — and
  `load()` filters records with `cleanedAt` set (`src/persistence/session-store.ts:179`). So the lookup returned `undefined`, the
  paused branch was skipped, and the message fell into the new-session branch.

  The 🔄 reaction path was unaffected because its lookup uses `findByPostId()`, which reads `loadRaw()` directly and sees soft-deleted
  sessions within the 3-day retention window (`cleanHistory()` is what finally removes them).

  ## Fix

  - New `SessionStore.findByThreadIdAnyState(threadId)` — iterates `loadRaw()`, mirrors `findByPostId()`'s intentional-raw-read
  semantics. jsdoc points back at the 🔄 path and the 3-day window.
  - `registry.getPersistedByThreadId()` now delegates to it.

  The two resume paths (reaction and reply) now have matching visibility into the history window. Sessions permanently purged by
  `cleanHistory()` (>3 days after soft-delete) are still unreachable — they've been removed from the file entirely. On successful
  resume, `persistSession()` (`src/session/manager.ts:persistSession`) writes a full record without `cleanedAt`, so the 3-day clock is
  reset.

  ## Callers of `getPersistedByThreadId` (all 5 benefit from the new behavior)

  | Caller | Purpose | Impact |
  |---|---|---|
  | `message-handler.ts:198` | Main paused-resume branch | **Fixes the bug** |
  | `manager.ts:1057` `hasPausedSession` | "Is there a resumable record for this thread?" | Correctly returns `true` for
  soft-deleted-but-still-resumable records |
  | `manager.ts:1065` `getPersistedSession` (used at `message-handler.ts:215,232` and `manager.ts:1470` for allowed-user checks) |
  Allowed-user validation before resume | Allows authorized users to resume after restart |
  | `manager.ts:1073` `cancelPausedSession` | `!stop` on a paused thread | Re-stamps `cleanedAt`; harmless no-op if already
  soft-deleted |
  | `manager.ts:1436` `getSessionStartPostId` | Reuse the timeout post instead of creating a new one | Correctly updates the original
  post when the session resumes |

  ## Tests

  - `session-store.test.ts` — new `findByThreadIdAnyState` describe: finds active sessions, finds soft-deleted ones (the key regression
   lock), returns undefined for unknown IDs, cross-platform search. **RED-GREEN verified** — reverting the fix to use `load()` fails
  the soft-deleted test.
  - `registry.test.ts` — updated `getPersistedByThreadId` describe: now stubs `findByThreadIdAnyState` on the mock store and adds a
  dedicated "soft-deleted session is still reachable" case.

  ## Verified

  - `bun run typecheck` — clean
  - `bun test src/` — **1970 / 1970** pass (+4 new tests)
  - `bun run build` — clean

  ## Follow-ups (not in this PR)

  - **UX for expired sessions (>3 days).** After `cleanHistory()` purges the record, a reply still falls into the new-session branch
  with no explanation. Consider a user-visible "that session has expired, starting a new one" hint.
  - **Method naming.** `findByThreadIdAnyState` is a bit wordy next to the sibling `findByPostId` which has the same raw-read semantics
   without a suffix. Open to renaming on request — either a shorter name or `findByThreadIdIncludingSoftDeleted` if explicit is better.