### PR TITLE
test: bump per-session timeout in MAX_SESSIONS test to fix CI flake

### DIFF
--- a/tests/integration/suites/session-limits.test.ts
+++ b/tests/integration/suites/session-limits.test.ts
@@ -76,6 +76,13 @@ describe.skipIf(SKIP)('Session Limits', () => {
       await new Promise((r) => setTimeout(r, process.env.CI ? 1000 : 200));
     });
 
+    // The Mattermost docker container in CI throws transient 500s on /posts
+    // which trigger the client's 500ms→1s→2s retry backoff. Each session start
+    // burns ~1-2s extra under that load, so a 6-session test on a tight 10s
+    // per-step budget tips over. Bump the per-step budget for CI; localhost
+    // Mattermost / mock-Slack are fast enough not to need it.
+    const startTimeout = process.env.CI ? 20000 : 10000;
+
     describe('MAX_SESSIONS Limit', () => {
       it('should reject new session when at capacity', async () => {
         const botUsername = platformType === 'mattermost'
@@ -88,27 +95,27 @@ describe.skipIf(SKIP)('Session Limits', () => {
         // Start first session
         const rootPost1 = await startSession(ctx, 'Session 1', botUsername);
         testThreadIds.push(rootPost1.id);
-        await waitForSessionActive(bot.sessionManager, rootPost1.id, { timeout: 10000 });
+        await waitForSessionActive(bot.sessionManager, rootPost1.id, { timeout: startTimeout });
 
         // Start second session
         const rootPost2 = await startSession(ctx, 'Session 2', botUsername);
         testThreadIds.push(rootPost2.id);
-        await waitForSessionActive(bot.sessionManager, rootPost2.id, { timeout: 10000 });
+        await waitForSessionActive(bot.sessionManager, rootPost2.id, { timeout: startTimeout });
 
         // Start third session
         const rootPost3 = await startSession(ctx, 'Session 3', botUsername);
         testThreadIds.push(rootPost3.id);
-        await waitForSessionActive(bot.sessionManager, rootPost3.id, { timeout: 10000 });
+        await waitForSessionActive(bot.sessionManager, rootPost3.id, { timeout: startTimeout });
 
         // Start fourth session
         const rootPost4 = await startSession(ctx, 'Session 4', botUsername);
         testThreadIds.push(rootPost4.id);
-        await waitForSessionActive(bot.sessionManager, rootPost4.id, { timeout: 10000 });
+        await waitForSessionActive(bot.sessionManager, rootPost4.id, { timeout: startTimeout });
 
         // Start fifth session (at limit now)
         const rootPost5 = await startSession(ctx, 'Session 5', botUsername);
         testThreadIds.push(rootPost5.id);
-        await waitForSessionActive(bot.sessionManager, rootPost5.id, { timeout: 10000 });
+        await waitForSessionActive(bot.sessionManager, rootPost5.id, { timeout: startTimeout });
 
         // Verify we have 5 active sessions
         expect(bot.sessionManager.getActiveThreadIds().length).toBe(5);
@@ -118,7 +125,7 @@ describe.skipIf(SKIP)('Session Limits', () => {
         testThreadIds.push(rootPost6.id);
 
         // Wait for "Too busy" message
-        const busyPost = await waitForPostMatching(ctx, rootPost6.id, /Too busy/i, { timeout: 10000 });
+        const busyPost = await waitForPostMatching(ctx, rootPost6.id, /Too busy/i, { timeout: startTimeout });
         expect(busyPost).toBeDefined();
         expect(busyPost.message).toContain('5 sessions active');
         expect(busyPost.message).toContain('Please try again later');


### PR DESCRIPTION
## Summary

The integration test \`Session Limits > MAX_SESSIONS Limit > should reject new
session when at capacity\` flakes ~30-50% of CI runs. Bumping the per-step
\`waitForSessionActive\` timeout from 10s to 20s in CI fixes it without
touching production code.

## What's actually happening

Every recent CI run (failing AND passing) shows the same Mattermost docker
container behavior: transient 500s on \`POST /posts\` that trigger the client's
500ms→1s→2s retry backoff. From this morning's PR #334 failure log:

\`\`\`
23:09:18.6  POST /posts failed with 500, retrying in 500ms (attempt 1/3)
23:09:19.4  POST /posts failed with 500, retrying in 500ms (attempt 1/3)
23:09:20.2  POST /posts failed with 500, retrying in 500ms (attempt 1/3)
23:09:21.0  POST /posts failed with 500, retrying in 500ms (attempt 1/3)
23:09:22.3  POST /posts failed with 500, retrying in 500ms (attempt 1/3)
\`\`\`

Five out of six session starts hit a 500. With ~1.5s of retry overhead each,
the test burns ~7s extra on top of the legitimate session-startup latency.
That's enough to push at least one \`waitForSessionActive(... { timeout: 10000 })\`
past its deadline and tip the test over.

The race the test is *meant* to guard (the \`maxSessions\` cap being exceeded
under concurrent starts) was fixed in v1.7.1 / #331 with the
\`pendingStartsCount\` reservation counter. That fix is intact — the assertion
that fails is the timing-sensitive one, not the cap-check one.

## Why bump timeouts and not retry behavior

The other obvious lever is reducing retry backoff under \`INTEGRATION_TEST=1\`,
but tuning production retry logic from tests is the wrong shape — the prod
behavior (1.5s of total backoff before giving up on a 500) is sensible.
The test's tight 10s budget is the wrong dial.

The sibling test in the same describe (\`should allow new session after one
ends\`) already uses 15-20s timeouts for the same reason. This PR just brings
the first test in line.

## Why \`process.env.CI\` and not always 20s

Localhost Mattermost (and the Slack mock) don't throw 500s, so a 10s budget
is fine for local dev. Keeping the 10s default avoids slowing local iteration.

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`tsc --noEmit\` — clean
- [x] \`bun test\` — full unit suite passes
- [ ] CI integration runs reliably across reruns