### PR TITLE
chore: align runtime versions, badges, and CI policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
     # Run security scan daily at 6 AM UTC
     - cron: "0 6 * * *"
 
+env:
+  # Pin Bun to a known version so a Bun release can't silently break CI.
+  # Bump in lockstep with what's developed against locally.
+  BUN_VERSION: 1.3.3
+
 jobs:
   security:
     runs-on: ubuntu-latest
@@ -19,7 +24,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - run: bun install
 
@@ -45,7 +50,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - run: bun install
 
@@ -63,7 +68,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - run: bun install
 
@@ -78,7 +83,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - run: bun install
 
@@ -130,7 +135,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - run: bun install
 
@@ -143,3 +148,37 @@ jobs:
 
       - name: Smoke test - verify binary starts
         run: bun dist/index.js --help
+
+  # The published binary runs under Node, not Bun. Smoke-test under each
+  # currently-supported Node line so we catch accidental use of an API that
+  # only exists on newer Node, which would silently break users on the floor.
+  # Floor (20) is what publish.yml builds against. 22 and 24 are active LTS
+  # and current LTS as of 2026-04.
+  node-smoke:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22", "24"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: bun install
+      - run: bun run build
+
+      - name: Smoke test under Node ${{ matrix.node-version }}
+        run: |
+          node --version
+          node dist/index.js --help
+          node dist/index.js --version
+          node dist/mcp/permission-server.js --help || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Pin Bun to a known version so a Bun release can't silently break CI.
+  # Bump in lockstep with .github/workflows/ci.yml.
+  BUN_VERSION: 1.3.3
+
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -42,7 +47,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
 
+env:
+  # Pin Bun to a known version so a Bun release can't silently break a publish.
+  # Bump in lockstep with .github/workflows/ci.yml.
+  BUN_VERSION: 1.3.3
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,8 +17,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
+      # Build under the engines.node floor so we catch unsafe API use that
+      # would silently break users on Node 20. CI's node-smoke matrix verifies
+      # the built artifact also runs on 22 and 24. Do not bump this past the
+      # floor without updating engines.node in package.json.
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,6 +350,28 @@ and only if you haven't already set them in the parent env:
 Export either with a non-default value (e.g. `MCP_CONNECTION_NONBLOCKING=false`)
 to disable.
 
+### Runtime Version Policy
+
+**Floor**: Node 20 (in maintenance LTS through April 2026), Bun 1.2.21.
+Both are declared in `package.json#engines`.
+
+**Why Node 20 and not higher**: no production dep requires more, and bumping
+the floor strands users on otherwise-supported LTS lines. Forced to 20 by
+`@hono/node-server@2` in v1.8.2.
+
+**CI strategy**:
+- Bun is pinned (`BUN_VERSION` env in every workflow) so a Bun release can't
+  silently break us. Bump in lockstep when upgrading.
+- `publish.yml` builds under Node 20 (the floor) so any unsafe API call that
+  only exists on newer Node breaks the build before reaching users.
+- `ci.yml` has a `node-smoke` matrix (`[20, 22, 24]`) that runs the built
+  binary under each currently-relevant Node line.
+
+**When to bump the floor**: only when a real dep forces it. Update
+`package.json#engines.node`, `publish.yml` Node version, the `node-smoke`
+matrix floor, the README prereqs line, and call it out as breaking in the
+CHANGELOG.
+
 ### Claude CLI Version Requirements
 
 claude-threads requires a compatible version of the Claude CLI (`@anthropic-ai/claude-code`).

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 [![CI](https://github.com/anneschuth/claude-threads/actions/workflows/ci.yml/badge.svg)](https://github.com/anneschuth/claude-threads/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/anneschuth/4951f9235658e276208942986092e5ab/raw/coverage-badge.json)](https://github.com/anneschuth/claude-threads/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Node](https://img.shields.io/badge/Node-%3E%3D18-green.svg)](https://nodejs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
+[![Node](https://img.shields.io/node/v/claude-threads.svg)](https://nodejs.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/anneschuth/claude-threads/pulls)
 
 **Bring Claude Code to your team.** Run Claude Code on your machine, share it live in Mattermost or Slack. Colleagues can watch, collaborate, and run their own sessions—all from chat.
@@ -60,7 +59,7 @@ The **interactive setup wizard** will guide you through everything:
 
 ### Prerequisites
 
-- **Bun** or **Node 18+** - [Install Bun](https://bun.sh/) or [Install Node](https://nodejs.org/)
+- **Bun 1.2.21+** or **Node 20+** - [Install Bun](https://bun.sh/) or [Install Node](https://nodejs.org/)
 - **Claude Code CLI working** - test with `claude --version` (needs API key or subscription)
 
 ### Use


### PR DESCRIPTION
## Summary

The Node-version story across the repo had drifted. None of this was actively
broken — the install path works — but the gap between what we say, what we
require, and what we test is the kind of thing that produces subtle
\"works for me\" bug reports.

| Surface | Was | Now |
|---|---|---|
| `package.json#engines.node` | `>=20.0.0` (set in v1.8.2 / #335) | unchanged |
| README Node badge | static `>=18` (stale) | dynamic shields.io \`node/v\` badge that reads engines from the published package |
| README TypeScript badge | static \`5.7\` (stale, we're on 6.0) | removed — TS version isn't user-facing |
| README prereqs | \"Bun or Node 18+\" | \"Bun 1.2.21+ or Node 20+\" |
| CI Bun version | \`latest\` (silent breakage risk) | pinned \`BUN_VERSION: 1.3.3\` across ci/integration/publish |
| Node coverage in CI | none — binary only ever ran under Bun | new \`node-smoke\` matrix \`[20, 22, 24]\` builds and runs the binary under each line |
| publish.yml Node | \`'20'\` | unchanged + comment explaining why (build under floor) |
| CLAUDE.md policy | none documented | new \"Runtime Version Policy\" section with bump checklist |

## Why these specific choices

**Floor stays at Node 20.** No production dep requires more, and bumping
strands users on otherwise-supported LTS lines. The floor was forced to 20
yesterday by \`@hono/node-server@2\`. That's the right answer for now.

**Build under the floor, smoke-test across the matrix.** \`publish.yml\`
deliberately uses Node 20 — building under the floor catches accidental
use of newer Node APIs that would silently break users on the minimum
version. CI then proves the same artifact runs under 22 and 24 too.
Inverting this (build on 24, hope it works on 20) is the common mistake.

**Dynamic Node badge.** Static version badges always rot. The shields.io
\`node/v\` endpoint reads \`engines.node\` from the npm registry, so it
auto-updates whenever a future version bumps the floor. One less file to
remember to edit.

**Pin Bun.** \`bun-version: latest\` means Bun's next release decides
whether our CI passes. Pinning to 1.3.3 (current local dev version) makes
runs reproducible. The pin lives in env at the top of each workflow with
a comment to keep them in lockstep.

**Drop the TypeScript badge.** It said 5.7. We've been on TS 6 for a
while. Nobody installing a CLI tool cares which TS version compiled it.

## Out of scope

- Bumping the floor to Node 22 (no concrete reason; loses Node 20 maintenance LTS users)
- Dropping Node support entirely (bigger conversation; the npm-installable path is real value)
- Replacing the bash daemon wrapper with a Node-native one (tangential)

## Test plan

- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — clean
- [x] \`tsc --noEmit\` — clean
- [x] Local smoke under Node 25 (\`node dist/index.js --help && --version\`) — works
- [ ] CI \`node-smoke\` matrix passes on 20, 22, 24
- [ ] All other CI jobs pass with pinned Bun