### PR TITLE
test: PR 1 safety net — coverage floor for upcoming refactor waves

### DIFF
--- a/src/mcp/permission-server.test.ts
+++ b/src/mcp/permission-server.test.ts
@@ -158,6 +158,29 @@ describe('handlePermissionWith', () => {
     expect(api.updatedPosts[0].message).toContain('Allowed all');
   });
 
+  it('allow-all sticks across subsequent calls — second call auto-approves without the reaction loop', async () => {
+    const api = new FakeApi({
+      // Only one queued reaction: used by the FIRST call. If the second call
+      // reached `waitForReaction` it would hit the empty queue and time out,
+      // causing the assertion on behavior='allow' to fail.
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: 'white_check_mark' }],
+    });
+    const cfg = makeCfg(api);
+
+    const first = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(first.behavior).toBe('allow');
+    expect(cfg.getAllowAllState()).toBe(true);
+    expect(api.waitForReactionCalls).toHaveLength(1);
+    expect(api.createdPosts).toHaveLength(1);
+
+    const second = await handlePermissionWith('Write', { path: '/tmp/x' }, cfg);
+    expect(second.behavior).toBe('allow');
+    expect(second.updatedInput).toEqual({ path: '/tmp/x' });
+    // Second call short-circuited: no new post, no new reaction poll.
+    expect(api.waitForReactionCalls).toHaveLength(1);
+    expect(api.createdPosts).toHaveLength(1);
+  });
+
   it('denies when authorized user reacts with -1', async () => {
     const api = new FakeApi({
       reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '-1' }],

--- a/src/mcp/permission-server.test.ts
+++ b/src/mcp/permission-server.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'bun:test';
+import { handlePermissionWith, type PermissionHandlerConfig } from './permission-server.js';
+import type { PermissionApi, ReactionEvent } from '../platform/permission-api.js';
+import type { PlatformFormatter } from '../platform/formatter.js';
+
+// =============================================================================
+// Test fakes
+// =============================================================================
+
+class FakeFormatter implements Partial<PlatformFormatter> {
+  formatBold(text: string): string { return `**${text}**`; }
+  formatItalic(text: string): string { return `*${text}*`; }
+  formatCode(text: string): string { return `\`${text}\``; }
+  formatCodeBlock(text: string, lang?: string): string { return `\`\`\`${lang ?? ''}\n${text}\n\`\`\``; }
+  formatStrikethrough(text: string): string { return `~~${text}~~`; }
+  formatLink(text: string, url: string): string { return `[${text}](${url})`; }
+  formatUserMention(username: string): string { return `@${username}`; }
+  formatChannelMention(name: string): string { return `#${name}`; }
+  formatHeading(text: string): string { return `# ${text}`; }
+  formatListItem(text: string): string { return `- ${text}`; }
+  formatNumberedListItem(n: number, text: string): string { return `${n}. ${text}`; }
+  formatBlockquote(text: string): string { return `> ${text}`; }
+  formatHorizontalRule(): string { return '---'; }
+  formatTable(): string { return ''; }
+  formatEmoji(name: string): string { return `:${name}:`; }
+  escape(text: string): string { return text; }
+  escapeText(text: string): string { return text; }
+  unescape(text: string): string { return text; }
+}
+
+interface FakeApiOptions {
+  allowedUsers?: string[];
+  usernames?: Record<string, string | null>; // userId -> username
+  reactions?: Array<ReactionEvent | null>;   // queue of reactions to return; null = timeout
+  botUserId?: string;
+  postId?: string;
+  createPostShouldThrow?: boolean;
+  getBotUserIdShouldThrow?: boolean;
+}
+
+class FakeApi implements PermissionApi {
+  public createdPosts: Array<{ message: string; reactions: string[]; threadId?: string }> = [];
+  public updatedPosts: Array<{ postId: string; message: string }> = [];
+  public waitForReactionCalls: Array<{ postId: string; botUserId: string; timeoutMs: number }> = [];
+
+  private readonly formatter = new FakeFormatter() as unknown as PlatformFormatter;
+  private readonly allowedUsers: Set<string>;
+  private readonly usernames: Record<string, string | null>;
+  private readonly reactions: Array<ReactionEvent | null>;
+  private readonly botUserId: string;
+  private readonly postId: string;
+  private readonly createPostShouldThrow: boolean;
+  private readonly getBotUserIdShouldThrow: boolean;
+
+  constructor(opts: FakeApiOptions = {}) {
+    this.allowedUsers = new Set(opts.allowedUsers ?? ['alice']);
+    this.usernames = opts.usernames ?? { 'u-alice': 'alice' };
+    this.reactions = [...(opts.reactions ?? [])];
+    this.botUserId = opts.botUserId ?? 'bot-1';
+    this.postId = opts.postId ?? 'post-1';
+    this.createPostShouldThrow = opts.createPostShouldThrow ?? false;
+    this.getBotUserIdShouldThrow = opts.getBotUserIdShouldThrow ?? false;
+  }
+
+  getFormatter(): PlatformFormatter { return this.formatter; }
+  async getBotUserId(): Promise<string> {
+    if (this.getBotUserIdShouldThrow) throw new Error('bot-id-boom');
+    return this.botUserId;
+  }
+  async getUsername(userId: string): Promise<string | null> {
+    return userId in this.usernames ? this.usernames[userId] : null;
+  }
+  isUserAllowed(username: string): boolean { return this.allowedUsers.has(username); }
+
+  async createInteractivePost(message: string, reactions: string[], threadId?: string) {
+    if (this.createPostShouldThrow) throw new Error('create-boom');
+    this.createdPosts.push({ message, reactions, threadId });
+    return { id: this.postId };
+  }
+
+  async updatePost(postId: string, message: string): Promise<void> {
+    this.updatedPosts.push({ postId, message });
+  }
+
+  async waitForReaction(postId: string, botUserId: string, timeoutMs: number): Promise<ReactionEvent | null> {
+    this.waitForReactionCalls.push({ postId, botUserId, timeoutMs });
+    if (this.reactions.length === 0) return null;
+    return this.reactions.shift()!;
+  }
+}
+
+interface HarnessOptions extends FakeApiOptions {
+  platformConfigured?: boolean;
+  threadId?: string;
+  timeoutMs?: number;
+  initialAllowAll?: boolean;
+  fakeNow?: () => number;
+}
+
+function makeCfg(api: FakeApi, opts: HarnessOptions = {}): PermissionHandlerConfig & { getAllowAllState: () => boolean } {
+  let allowAll = opts.initialAllowAll ?? false;
+  return {
+    api,
+    threadId: opts.threadId,
+    timeoutMs: opts.timeoutMs ?? 120_000,
+    platformConfigured: opts.platformConfigured ?? true,
+    getAllowAll: () => allowAll,
+    setAllowAll: (v) => { allowAll = v; },
+    getAllowAllState: () => allowAll,
+    now: opts.fakeNow,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('handlePermissionWith', () => {
+  it('denies when platform is not configured', async () => {
+    const api = new FakeApi();
+    const cfg = makeCfg(api, { platformConfigured: false });
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result).toEqual({ behavior: 'deny', message: 'Permission service not configured' });
+    expect(api.createdPosts).toHaveLength(0);
+  });
+
+  it('auto-allows when allow-all session flag is set', async () => {
+    const api = new FakeApi();
+    const cfg = makeCfg(api, { initialAllowAll: true });
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result).toEqual({ behavior: 'allow', updatedInput: { command: 'ls' } });
+    expect(api.createdPosts).toHaveLength(0);
+    expect(api.waitForReactionCalls).toHaveLength(0);
+  });
+
+  it('allows when authorized user reacts with +1', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '+1' }],
+    });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('allow');
+    expect(result.updatedInput).toEqual({ command: 'ls' });
+    expect(cfg.getAllowAllState()).toBe(false);
+    expect(api.createdPosts).toHaveLength(1);
+    expect(api.updatedPosts).toHaveLength(1);
+    expect(api.updatedPosts[0].message).toContain('Allowed');
+  });
+
+  it('allows and sets allow-all when authorized user reacts with white_check_mark', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: 'white_check_mark' }],
+    });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('allow');
+    expect(cfg.getAllowAllState()).toBe(true);
+    expect(api.updatedPosts[0].message).toContain('Allowed all');
+  });
+
+  it('denies when authorized user reacts with -1', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '-1' }],
+    });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result).toEqual({ behavior: 'deny', message: 'User denied permission' });
+    expect(api.updatedPosts[0].message).toContain('Denied');
+  });
+
+  it('ignores unauthorized user reactions and waits for authorized user', async () => {
+    const api = new FakeApi({
+      allowedUsers: ['alice'],
+      usernames: { 'u-mallory': 'mallory', 'u-alice': 'alice' },
+      reactions: [
+        { postId: 'post-1', userId: 'u-mallory', emojiName: '+1' }, // unauthorized
+        { postId: 'post-1', userId: 'u-alice', emojiName: '+1' },   // authorized
+      ],
+    });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('allow');
+    // Two polls: first ignored, second accepted
+    expect(api.waitForReactionCalls).toHaveLength(2);
+  });
+
+  it('ignores reaction when username cannot be resolved', async () => {
+    const api = new FakeApi({
+      allowedUsers: ['alice'],
+      usernames: { 'u-ghost': null, 'u-alice': 'alice' },
+      reactions: [
+        { postId: 'post-1', userId: 'u-ghost', emojiName: '+1' },
+        { postId: 'post-1', userId: 'u-alice', emojiName: '-1' },
+      ],
+    });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('deny');
+    expect(api.waitForReactionCalls).toHaveLength(2);
+  });
+
+  it('times out and denies when waitForReaction returns null', async () => {
+    const api = new FakeApi({ reactions: [null] });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result).toEqual({ behavior: 'deny', message: 'Permission request timed out' });
+    expect(api.updatedPosts[0].message).toContain('Timed out');
+  });
+
+  it('times out when cumulative elapsed time exceeds timeoutMs', async () => {
+    // fake clock: start at 0, then each call advances by 60s; timeout is 100s.
+    let fakeTime = 0;
+    const ticks = [0, 60_000, 120_000]; // third call exceeds timeout
+    const now = () => {
+      const t = ticks.length > 0 ? ticks.shift()! : fakeTime;
+      fakeTime = t;
+      return t;
+    };
+    const api = new FakeApi({
+      allowedUsers: ['alice'],
+      usernames: { 'u-mallory': 'mallory' },
+      reactions: [
+        { postId: 'post-1', userId: 'u-mallory', emojiName: '+1' }, // unauthorized, loop again
+      ],
+    });
+    const cfg = makeCfg(api, { timeoutMs: 100_000, fakeNow: now });
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('deny');
+    expect(result.message).toBe('Permission request timed out');
+  });
+
+  it('denies with error message when API throws during createInteractivePost', async () => {
+    const api = new FakeApi({ createPostShouldThrow: true });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('deny');
+    expect(result.message).toContain('create-boom');
+  });
+
+  it('denies when getBotUserId throws', async () => {
+    const api = new FakeApi({ getBotUserIdShouldThrow: true });
+    const cfg = makeCfg(api);
+    const result = await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(result.behavior).toBe('deny');
+    expect(result.message).toContain('bot-id-boom');
+  });
+
+  it('passes the threadId through to createInteractivePost', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '+1' }],
+    });
+    const cfg = makeCfg(api, { threadId: 'thread-xyz' });
+    await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(api.createdPosts[0].threadId).toBe('thread-xyz');
+  });
+
+  it('posts with the three canonical reaction options', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '+1' }],
+    });
+    const cfg = makeCfg(api);
+    await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(api.createdPosts[0].reactions).toEqual(['+1', 'white_check_mark', '-1']);
+  });
+
+  it('decrements remaining timeout across unauthorized-reaction loop iterations', async () => {
+    let t = 0;
+    const now = () => t;
+    const api = new FakeApi({
+      allowedUsers: ['alice'],
+      usernames: { 'u-mallory': 'mallory', 'u-alice': 'alice' },
+      reactions: [
+        { postId: 'post-1', userId: 'u-mallory', emojiName: '+1' },
+        { postId: 'post-1', userId: 'u-alice', emojiName: '+1' },
+      ],
+    });
+    const cfg = makeCfg(api, { timeoutMs: 100_000, fakeNow: now });
+
+    // Increment the fake clock between the two waitForReaction calls by hooking the mock
+    const origWait = api.waitForReaction.bind(api);
+    api.waitForReaction = async (postId, botId, remaining) => {
+      t += 30_000;
+      return origWait(postId, botId, remaining);
+    };
+
+    await handlePermissionWith('Bash', { command: 'ls' }, cfg);
+    expect(api.waitForReactionCalls).toHaveLength(2);
+    // First call sees full 100s, second call sees 70s remaining.
+    expect(api.waitForReactionCalls[0].timeoutMs).toBe(100_000);
+    expect(api.waitForReactionCalls[1].timeoutMs).toBe(70_000);
+  });
+});

--- a/src/mcp/permission-server.ts
+++ b/src/mcp/permission-server.ts
@@ -90,31 +90,52 @@ let allowAllSession = false;
 // Permission Handler
 // =============================================================================
 
-interface PermissionResult {
+export interface PermissionResult {
   behavior: 'allow' | 'deny';
   updatedInput?: Record<string, unknown>;
   message?: string;
 }
 
-async function handlePermission(
+/**
+ * Runtime configuration for the permission handler. Passed explicitly so the
+ * handler can be tested without module-level env state.
+ */
+export interface PermissionHandlerConfig {
+  api: PermissionApi;
+  threadId?: string;
+  timeoutMs: number;
+  platformConfigured: boolean;
+  getAllowAll: () => boolean;
+  setAllowAll: (value: boolean) => void;
+  now?: () => number;
+}
+
+/**
+ * Pure(-ish) permission handler — exported for testing. Side effects flow
+ * through the injected `api` and `get/setAllowAll` callbacks.
+ */
+export async function handlePermissionWith(
   toolName: string,
-  toolInput: Record<string, unknown>
+  toolInput: Record<string, unknown>,
+  cfg: PermissionHandlerConfig
 ): Promise<PermissionResult> {
   mcpLogger.debug(`handlePermission called for ${toolName}`);
 
   // Auto-approve if "allow all" was selected earlier
-  if (allowAllSession) {
+  if (cfg.getAllowAll()) {
     mcpLogger.debug(`Auto-allowing ${toolName} (allow all active)`);
     return { behavior: 'allow', updatedInput: toolInput };
   }
 
-  if (!PLATFORM_URL || !PLATFORM_TOKEN || !PLATFORM_CHANNEL_ID) {
+  if (!cfg.platformConfigured) {
     mcpLogger.error('Missing platform config');
     return { behavior: 'deny', message: 'Permission service not configured' };
   }
 
+  const now = cfg.now ?? Date.now;
+
   try {
-    const api = getApi();
+    const api = cfg.api;
     const formatter = api.getFormatter();
 
     // Post permission request with reaction options
@@ -126,16 +147,16 @@ async function handlePermission(
     const post = await api.createInteractivePost(
       message,
       [APPROVAL_EMOJIS[0], ALLOW_ALL_EMOJIS[0], DENIAL_EMOJIS[0]],
-      PLATFORM_THREAD_ID || undefined
+      cfg.threadId
     );
 
     // Wait for authorized user's reaction (keep waiting if unauthorized users react)
-    const startTime = Date.now();
+    const startTime = now();
     let reaction: Awaited<ReturnType<typeof api.waitForReaction>>;
     let username: string | null = null;
 
     while (true) {
-      const remainingTime = PERMISSION_TIMEOUT_MS - (Date.now() - startTime);
+      const remainingTime = cfg.timeoutMs - (now() - startTime);
       if (remainingTime <= 0) {
         await api.updatePost(post.id, `⏱️ ${formatter.formatBold('Timed out')} - permission denied\n\n${toolInfo}`);
         mcpLogger.info(`Timeout: ${toolName}`);
@@ -168,7 +189,7 @@ async function handlePermission(
       mcpLogger.info(`Allowed: ${toolName}`);
       return { behavior: 'allow', updatedInput: toolInput };
     } else if (isAllowAllEmoji(emoji)) {
-      allowAllSession = true;
+      cfg.setAllowAll(true);
       await api.updatePost(post.id, `✅ ${formatter.formatBold('Allowed all')} by ${formatter.formatUserMention(username)}\n\n${toolInfo}`);
       mcpLogger.info(`Allowed all: ${toolName}`);
       return { behavior: 'allow', updatedInput: toolInput };
@@ -181,6 +202,20 @@ async function handlePermission(
     mcpLogger.error(`Permission error: ${error}`);
     return { behavior: 'deny', message: String(error) };
   }
+}
+
+async function handlePermission(
+  toolName: string,
+  toolInput: Record<string, unknown>
+): Promise<PermissionResult> {
+  return handlePermissionWith(toolName, toolInput, {
+    api: getApi(),
+    threadId: PLATFORM_THREAD_ID || undefined,
+    timeoutMs: PERMISSION_TIMEOUT_MS,
+    platformConfigured: Boolean(PLATFORM_URL && PLATFORM_TOKEN && PLATFORM_CHANNEL_ID),
+    getAllowAll: () => allowAllSession,
+    setAllowAll: (v) => { allowAllSession = v; },
+  });
 }
 
 // =============================================================================

--- a/src/operations/plugin/handler.test.ts
+++ b/src/operations/plugin/handler.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Smoke tests for plugin command handlers.
+ *
+ * Mocks `crossSpawn` so the handler's exit-code branching and messaging are
+ * exercised without spawning real subprocesses. We deliberately avoid mocking
+ * `../commands/index.js` because that module transitively pulls in
+ * `../../claude/cli.js`, whose module identity matters for
+ * `commands/restart-rebind.test.ts` running in the same process.
+ *
+ * As a result:
+ *   - handlePluginList is tested fully.
+ *   - handlePluginInstall / handlePluginUninstall are tested only for their
+ *     "subprocess failed, posts error, never reaches restart" branch. The
+ *     successful restart path is covered by integration tests.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterAll } from 'bun:test';
+import { EventEmitter } from 'events';
+
+// -----------------------------------------------------------------------------
+// Subprocess mock — shared by all plugin invocations.
+// -----------------------------------------------------------------------------
+
+interface FakeSubprocessOpts {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  emitError?: boolean;
+}
+
+const crossSpawnCfg: { current: FakeSubprocessOpts } = { current: { exitCode: 0 } };
+
+function makeFakeProc(opts: FakeSubprocessOpts) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  setImmediate(() => {
+    if (opts.stdout) proc.stdout.emit('data', Buffer.from(opts.stdout));
+    if (opts.stderr) proc.stderr.emit('data', Buffer.from(opts.stderr));
+    if (opts.emitError) {
+      proc.emit('error', new Error('spawn boom'));
+    }
+    proc.emit('close', opts.exitCode ?? 0);
+  });
+  return proc;
+}
+
+const crossSpawnMock = mock(() => makeFakeProc(crossSpawnCfg.current));
+const realSpawn = await import('../../utils/spawn.js');
+mock.module('../../utils/spawn.js', () => ({
+  ...realSpawn,
+  crossSpawn: crossSpawnMock,
+}));
+
+afterAll(() => {
+  mock.module('../../utils/spawn.js', () => realSpawn);
+});
+
+// Import AFTER mock.module
+const { handlePluginList, handlePluginInstall, handlePluginUninstall } = await import('./handler.js');
+import type { Session } from '../../session/types.js';
+import type { SessionContext } from '../session-context/index.js';
+
+// -----------------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------------
+
+interface SessionSpies {
+  createdMessages: string[];
+}
+
+function makeSession(spies: SessionSpies): Session {
+  return {
+    sessionId: 'mm:thread-1',
+    threadId: 'thread-1',
+    claudeSessionId: 'uuid-1',
+    workingDir: '/tmp/proj',
+    platformId: 'mm',
+    startedBy: 'alice',
+    startedAt: new Date(),
+    lastActivityAt: new Date(),
+    sessionNumber: 1,
+    planApproved: false,
+    sessionAllowedUsers: new Set(['alice']),
+    forceInteractivePermissions: false,
+    sessionStartPostId: null,
+    timers: { timeoutTimer: null, warningTimer: null, cleanupTimer: null } as unknown as Session['timers'],
+    lifecycle: { state: 'active' } as unknown as Session['lifecycle'],
+    timeoutWarningPosted: false,
+    messageCount: 0,
+    platform: {
+      platformId: 'mm',
+      createPost: mock(async (message: string) => {
+        spies.createdMessages.push(message);
+        return { id: `post-${spies.createdMessages.length}`, message, userId: 'bot' };
+      }),
+      addReaction: mock(async () => undefined),
+      getFormatter: () => ({
+        formatBold: (t: string) => `**${t}**`,
+        formatCode: (t: string) => `\`${t}\``,
+        formatCodeBlock: (t: string) => `\`\`\`\n${t}\n\`\`\``,
+      }),
+      getMcpConfig: () => ({ type: 'mattermost', url: 'x', token: 'y', channelId: 'c', allowedUsers: [] }),
+    } as unknown as Session['platform'],
+    claude: {} as unknown as Session['claude'],
+    threadLogger: {
+      logCommand: mock(() => undefined),
+    } as unknown as Session['threadLogger'],
+  } as unknown as Session;
+}
+
+function makeCtx(): SessionContext {
+  return {
+    config: {
+      skipPermissions: false,
+      chromeEnabled: false,
+      permissionTimeoutMs: 120_000,
+    },
+  } as unknown as SessionContext;
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+describe('handlePluginList', () => {
+  let spies: SessionSpies;
+  beforeEach(() => {
+    spies = { createdMessages: [] };
+    crossSpawnCfg.current = { exitCode: 0, stdout: 'my-plugin 1.0.0\n' };
+  });
+
+  it('posts info and plugin list on success', async () => {
+    await handlePluginList(makeSession(spies));
+    const all = spies.createdMessages.join('\n');
+    expect(all).toContain('Installed plugins');
+    expect(all).toContain('my-plugin 1.0.0');
+  });
+
+  it('shows "No plugins installed" when stdout is empty', async () => {
+    crossSpawnCfg.current = { exitCode: 0, stdout: '' };
+    await handlePluginList(makeSession(spies));
+    expect(spies.createdMessages.join('\n')).toContain('No plugins installed');
+  });
+
+  it('posts error when exit code is non-zero', async () => {
+    crossSpawnCfg.current = { exitCode: 2, stderr: 'permission denied' };
+    await handlePluginList(makeSession(spies));
+    const all = spies.createdMessages.join('\n');
+    expect(all).toContain('Failed to list plugins');
+    expect(all).toContain('permission denied');
+  });
+
+  it('invokes claude plugin list via crossSpawn', async () => {
+    crossSpawnMock.mockClear();
+    await handlePluginList(makeSession(spies));
+    expect(crossSpawnMock).toHaveBeenCalled();
+    const call = crossSpawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(call[1]).toEqual(['plugin', 'list']);
+  });
+});
+
+describe('handlePluginInstall (failure branch only)', () => {
+  // The success branch calls restartClaudeSession which pulls in the real
+  // Claude CLI module — covered by integration tests, skipped here.
+  let spies: SessionSpies;
+  beforeEach(() => {
+    spies = { createdMessages: [] };
+  });
+
+  it('posts error when subprocess fails', async () => {
+    crossSpawnCfg.current = { exitCode: 1, stderr: 'no such plugin' };
+    await handlePluginInstall(makeSession(spies), 'ghost-plugin', 'alice', makeCtx());
+    const all = spies.createdMessages.join('\n');
+    expect(all).toContain('Failed to install plugin');
+    expect(all).toContain('no such plugin');
+  });
+
+  it('posts initial "Installing..." message before running subprocess', async () => {
+    crossSpawnCfg.current = { exitCode: 1, stderr: 'fail' };
+    await handlePluginInstall(makeSession(spies), 'x', 'alice', makeCtx());
+    expect(spies.createdMessages[0]).toContain('Installing plugin');
+  });
+
+  it('passes plugin name as subprocess arg', async () => {
+    crossSpawnCfg.current = { exitCode: 1, stderr: 'fail' };
+    crossSpawnMock.mockClear();
+    await handlePluginInstall(makeSession(spies), 'hello-plugin', 'alice', makeCtx());
+    const call = crossSpawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(call[1]).toEqual(['plugin', 'install', 'hello-plugin']);
+  });
+});
+
+describe('handlePluginUninstall (failure branch only)', () => {
+  let spies: SessionSpies;
+  beforeEach(() => {
+    spies = { createdMessages: [] };
+  });
+
+  it('posts error when subprocess fails', async () => {
+    crossSpawnCfg.current = { exitCode: 1, stderr: 'not installed' };
+    await handlePluginUninstall(makeSession(spies), 'ghost-plugin', 'alice', makeCtx());
+    expect(spies.createdMessages.join('\n')).toContain('Failed to uninstall plugin');
+  });
+
+  it('handles subprocess error event gracefully', async () => {
+    crossSpawnCfg.current = { emitError: true, exitCode: 1 };
+    await handlePluginUninstall(makeSession(spies), 'my-plugin', 'alice', makeCtx());
+    expect(spies.createdMessages.join('\n')).toContain('Failed to uninstall plugin');
+  });
+
+  it('passes plugin name as subprocess arg', async () => {
+    crossSpawnCfg.current = { exitCode: 1, stderr: 'fail' };
+    crossSpawnMock.mockClear();
+    await handlePluginUninstall(makeSession(spies), 'bye-plugin', 'alice', makeCtx());
+    const call = crossSpawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(call[1]).toEqual(['plugin', 'uninstall', 'bye-plugin']);
+  });
+});

--- a/src/operations/plugin/handler.test.ts
+++ b/src/operations/plugin/handler.test.ts
@@ -55,6 +55,11 @@ mock.module('../../utils/spawn.js', () => ({
   crossSpawn: crossSpawnMock,
 }));
 
+// bun's `mock.module` is process-global and one-way — there is no native
+// "unmock". The best we can do is overwrite it with a pass-through factory
+// that returns the real module, so later test files loading this path behave
+// as if it were never mocked. This is NOT a true restore; it works only
+// because `realSpawn` is still the real live module object.
 afterAll(() => {
   mock.module('../../utils/spawn.js', () => realSpawn);
 });

--- a/src/platform/mattermost/client.test.ts
+++ b/src/platform/mattermost/client.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Unit tests for MattermostClient. HTTP calls are isolated by stubbing
+ * `global.fetch`; WebSocket paths are exercised via the pure helpers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { MattermostClient } from './client.js';
+import type { MattermostPlatformConfig } from '../../config/migration.js';
+
+// -----------------------------------------------------------------------------
+// Fetch harness
+// -----------------------------------------------------------------------------
+
+type FetchResponder = (url: string, init?: RequestInit) => Promise<Response> | Response;
+
+let fetchResponder: FetchResponder = () =>
+  new Response(JSON.stringify({}), { status: 200, headers: { 'content-type': 'application/json' } });
+let fetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body?: unknown }> = [];
+
+const originalFetch = global.fetch;
+beforeEach(() => {
+  fetchCalls = [];
+  global.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headers[k] = h[k];
+    }
+    let body: unknown;
+    if (typeof init?.body === 'string') {
+      try { body = JSON.parse(init.body); } catch { body = init.body; }
+    }
+    fetchCalls.push({ url: urlStr, method, headers, body });
+    return fetchResponder(urlStr, init);
+  }) as typeof global.fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function errorResponse(status: number, text = 'oops'): Response {
+  return new Response(text, { status });
+}
+
+// -----------------------------------------------------------------------------
+// Fixtures
+// -----------------------------------------------------------------------------
+
+function makeConfig(overrides: Partial<MattermostPlatformConfig> = {}): MattermostPlatformConfig {
+  return {
+    id: 'mm-main',
+    type: 'mattermost',
+    displayName: 'Main',
+    url: 'https://chat.example.test',
+    token: 'secret-token',
+    channelId: 'c-123',
+    botName: 'claude',
+    allowedUsers: ['alice', 'bob'],
+    skipPermissions: false,
+    ...overrides,
+  };
+}
+
+function makeClient(overrides: Partial<MattermostPlatformConfig> = {}): MattermostClient {
+  return new MattermostClient(makeConfig(overrides));
+}
+
+// -----------------------------------------------------------------------------
+// Pure method tests
+// -----------------------------------------------------------------------------
+
+describe('MattermostClient pure helpers', () => {
+  it('getMessageLimits returns Mattermost defaults', () => {
+    expect(makeClient().getMessageLimits()).toEqual({ maxLength: 16000, hardThreshold: 14000 });
+  });
+
+  it('isBotMentioned matches @botname at start and mid-message', () => {
+    const c = makeClient({ botName: 'claude' });
+    expect(c.isBotMentioned('@claude do stuff')).toBe(true);
+    expect(c.isBotMentioned('hey @claude please')).toBe(true);
+    expect(c.isBotMentioned('no mention here')).toBe(false);
+    expect(c.isBotMentioned('email me at claude@example.com')).toBe(false);
+  });
+
+  it('isBotMentioned is case-insensitive', () => {
+    const c = makeClient({ botName: 'Claude' });
+    expect(c.isBotMentioned('@claude hi')).toBe(true);
+    expect(c.isBotMentioned('@CLAUDE hi')).toBe(true);
+  });
+
+  it('isBotMentioned handles bot names with special regex chars', () => {
+    const c = makeClient({ botName: 'bot.v2' });
+    expect(c.isBotMentioned('@bot.v2 hello')).toBe(true);
+    // Literal dot should NOT match arbitrary chars
+    expect(c.isBotMentioned('@botXv2 hello')).toBe(false);
+  });
+
+  it('extractPrompt strips bot mention and trims', () => {
+    const c = makeClient({ botName: 'claude' });
+    expect(c.extractPrompt('@claude write a test')).toBe('write a test');
+    expect(c.extractPrompt('hey @claude fix this')).toBe('hey  fix this'.trim());
+  });
+
+  it('getMcpConfig exposes the platform credentials', () => {
+    const c = makeClient({ url: 'https://x', token: 't', channelId: 'cc', allowedUsers: ['u'] });
+    expect(c.getMcpConfig()).toEqual({
+      type: 'mattermost',
+      url: 'https://x',
+      token: 't',
+      channelId: 'cc',
+      allowedUsers: ['u'],
+    });
+  });
+
+  it('getFormatter returns a stable formatter instance', () => {
+    const c = makeClient();
+    expect(c.getFormatter()).toBe(c.getFormatter());
+  });
+
+  it('getThreadLink uses lastMessageId when provided', () => {
+    const c = makeClient({ url: 'https://x.test' });
+    expect(c.getThreadLink('thread-1')).toBe('https://x.test/_redirect/pl/thread-1');
+    expect(c.getThreadLink('thread-1', 'msg-9')).toBe('https://x.test/_redirect/pl/msg-9');
+  });
+
+  it('platform identity fields reflect config', () => {
+    const c = makeClient({ id: 'mm-x', displayName: 'X' });
+    expect(c.platformId).toBe('mm-x');
+    expect(c.displayName).toBe('X');
+    expect(c.platformType).toBe('mattermost');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// HTTP method tests
+// -----------------------------------------------------------------------------
+
+describe('MattermostClient HTTP methods', () => {
+  it('createPost posts to /posts with channel and body, returns normalized post', async () => {
+    fetchResponder = () =>
+      jsonResponse({
+        id: 'p-1',
+        channel_id: 'c-123',
+        user_id: 'bot',
+        message: 'hi',
+        root_id: '',
+        create_at: 1000,
+      });
+    const c = makeClient();
+    const post = await c.createPost('hi');
+    expect(post.id).toBe('p-1');
+    expect(post.channelId).toBe('c-123');
+    expect(post.userId).toBe('bot');
+    expect(post.platformId).toBe('mm-main');
+
+    expect(fetchCalls).toHaveLength(1);
+    const call = fetchCalls[0];
+    expect(call.url).toBe('https://chat.example.test/api/v4/posts');
+    expect(call.method).toBe('POST');
+    expect(call.headers.Authorization).toBe('Bearer secret-token');
+    expect(call.body).toEqual({ channel_id: 'c-123', message: 'hi', root_id: undefined });
+  });
+
+  it('createPost includes root_id when threadId is given', async () => {
+    fetchResponder = () =>
+      jsonResponse({ id: 'p', channel_id: 'c', user_id: 'u', message: '', root_id: 't', create_at: 1 });
+    await makeClient().createPost('reply', 'thread-abc');
+    expect((fetchCalls[0].body as Record<string, unknown>).root_id).toBe('thread-abc');
+  });
+
+  it('updatePost PUTs to /posts/:id', async () => {
+    fetchResponder = () =>
+      jsonResponse({ id: 'p-1', channel_id: 'c', user_id: 'u', message: 'updated', root_id: '', create_at: 1 });
+    const result = await makeClient().updatePost('p-1', 'updated');
+    expect(result.message).toBe('updated');
+    expect(fetchCalls[0].method).toBe('PUT');
+    expect(fetchCalls[0].url).toContain('/posts/p-1');
+  });
+
+  it('addReaction POSTs to /reactions', async () => {
+    fetchResponder = () => jsonResponse({});
+    await makeClient().addReaction('p-1', '+1');
+    const call = fetchCalls[0];
+    expect(call.method).toBe('POST');
+    expect(call.url).toContain('/reactions');
+    expect((call.body as Record<string, unknown>).emoji_name).toBe('+1');
+    expect((call.body as Record<string, unknown>).post_id).toBe('p-1');
+  });
+
+  it('removeReaction DELETEs to scoped endpoint', async () => {
+    fetchResponder = () => jsonResponse({});
+    await makeClient().removeReaction('p-1', '+1');
+    expect(fetchCalls[0].method).toBe('DELETE');
+    expect(fetchCalls[0].url).toContain('/posts/p-1/reactions/+1');
+  });
+
+  it('getPost returns null on error instead of throwing', async () => {
+    fetchResponder = () => errorResponse(404, 'not found');
+    const post = await makeClient().getPost('missing');
+    expect(post).toBeNull();
+  });
+
+  it('unpinPost swallows 403/404 silently', async () => {
+    fetchResponder = () => errorResponse(404, 'not found');
+    await expect(makeClient().unpinPost('p-1')).resolves.toBeUndefined();
+  });
+
+  it('unpinPost still throws on 500', async () => {
+    fetchResponder = () => errorResponse(500, 'boom');
+    // 500 triggers retry-then-fail — accept either rethrow or eventual error.
+    await expect(makeClient().unpinPost('p-1')).rejects.toThrow();
+  }, 10_000);
+
+  it('pinPost POSTs to /posts/:id/pin', async () => {
+    fetchResponder = () => jsonResponse({});
+    await makeClient().pinPost('p-1');
+    expect(fetchCalls[0].method).toBe('POST');
+    expect(fetchCalls[0].url).toContain('/posts/p-1/pin');
+  });
+
+  it('getPinnedPosts returns the order array', async () => {
+    fetchResponder = () => jsonResponse({ order: ['p-1', 'p-2'], posts: {} });
+    const ids = await makeClient().getPinnedPosts();
+    expect(ids).toEqual(['p-1', 'p-2']);
+  });
+
+  it('getPinnedPosts returns empty array when order is missing', async () => {
+    fetchResponder = () => jsonResponse({ posts: {} });
+    expect(await makeClient().getPinnedPosts()).toEqual([]);
+  });
+
+  it('getThreadHistory sorts messages chronologically and filters bot posts', async () => {
+    // Use a client and prime its bot user id via getBotUser.
+    const c = makeClient();
+    const responders: Record<string, Response> = {
+      '/users/me': jsonResponse({ id: 'bot-id', username: 'claude', email: '', first_name: '' }),
+      '/posts/thread-1/thread': jsonResponse({
+        order: ['p-1', 'p-2', 'p-bot'],
+        posts: {
+          'p-1': { id: 'p-1', channel_id: 'c', user_id: 'u-alice', message: 'first', root_id: '', create_at: 300 },
+          'p-2': { id: 'p-2', channel_id: 'c', user_id: 'u-alice', message: 'second', root_id: '', create_at: 100 },
+          'p-bot': { id: 'p-bot', channel_id: 'c', user_id: 'bot-id', message: 'bot reply', root_id: '', create_at: 200 },
+        },
+      }),
+      '/users/u-alice': jsonResponse({ id: 'u-alice', username: 'alice', email: '', first_name: 'Alice' }),
+    };
+    fetchResponder = (url) => {
+      for (const [suffix, response] of Object.entries(responders)) {
+        if (url.includes(suffix)) return response.clone();
+      }
+      return jsonResponse({});
+    };
+
+    await c.getBotUser();
+    const history = await c.getThreadHistory('thread-1', { excludeBotMessages: true });
+    expect(history.map(m => m.id)).toEqual(['p-2', 'p-1']);
+    expect(history.every(m => m.username === 'alice')).toBe(true);
+  });
+
+  it('getThreadHistory respects limit (returns most recent N)', async () => {
+    const c = makeClient();
+    fetchResponder = (url) => {
+      if (url.includes('/users/me')) return jsonResponse({ id: 'b', username: 'c', email: '', first_name: '' });
+      if (url.includes('/posts/t/thread')) {
+        return jsonResponse({
+          order: ['a', 'b', 'c'],
+          posts: {
+            a: { id: 'a', channel_id: '', user_id: 'u', message: '1', root_id: '', create_at: 1 },
+            b: { id: 'b', channel_id: '', user_id: 'u', message: '2', root_id: '', create_at: 2 },
+            c: { id: 'c', channel_id: '', user_id: 'u', message: '3', root_id: '', create_at: 3 },
+          },
+        });
+      }
+      if (url.includes('/users/u')) return jsonResponse({ id: 'u', username: 'u', email: '', first_name: '' });
+      return jsonResponse({});
+    };
+    await c.getBotUser();
+    const limited = await c.getThreadHistory('t', { limit: 2 });
+    expect(limited.map(m => m.id)).toEqual(['b', 'c']);
+  });
+
+  it('getThreadHistory returns [] on API error', async () => {
+    fetchResponder = () => errorResponse(500);
+    const c = makeClient();
+    const history = await c.getThreadHistory('t');
+    expect(history).toEqual([]);
+  }, 10_000);
+
+  it('getUser caches by user id', async () => {
+    const c = makeClient();
+    let calls = 0;
+    fetchResponder = (url) => {
+      if (url.includes('/users/u-1')) {
+        calls += 1;
+        return jsonResponse({ id: 'u-1', username: 'alice', email: '', first_name: '' });
+      }
+      return jsonResponse({});
+    };
+    const first = await c.getUser('u-1');
+    const second = await c.getUser('u-1');
+    expect(first?.username).toBe('alice');
+    expect(second?.username).toBe('alice');
+    expect(calls).toBe(1);
+  });
+
+  it('getUser returns null on 404', async () => {
+    const c = makeClient();
+    fetchResponder = () => errorResponse(404);
+    expect(await c.getUser('u-missing')).toBeNull();
+  }, 10_000);
+
+  it('downloadFile returns a Buffer', async () => {
+    fetchResponder = () => new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    const buf = await makeClient().downloadFile('f-1');
+    expect(buf).toBeInstanceOf(Buffer);
+    expect(buf.length).toBe(3);
+  });
+
+  it('downloadFile throws on non-200', async () => {
+    fetchResponder = () => errorResponse(403, 'forbidden');
+    await expect(makeClient().downloadFile('f-1')).rejects.toThrow(/403/);
+  });
+
+  it('api retries on 500 with backoff', async () => {
+    let attempts = 0;
+    fetchResponder = (_url, _init) => {
+      attempts += 1;
+      if (attempts < 3) return errorResponse(500, 'transient');
+      return jsonResponse({
+        id: 'p', channel_id: 'c', user_id: 'u', message: 'ok', root_id: '', create_at: 1,
+      });
+    };
+    const post = await makeClient().createPost('hi');
+    expect(post.message).toBe('ok');
+    expect(attempts).toBe(3);
+  }, 10_000);
+});

--- a/src/platform/slack/client.test.ts
+++ b/src/platform/slack/client.test.ts
@@ -1,11 +1,14 @@
 /**
  * Slack client unit tests
  *
- * Tests for Slack-specific functionality, particularly emoji handling.
+ * Tests for Slack-specific functionality, including emoji handling and the
+ * SlackClient HTTP surface (fetch-backed).
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { getEmojiName } from '../utils.js';
+import { SlackClient } from './client.js';
+import type { SlackPlatformConfig } from '../../config/types.js';
 
 describe('Slack Client Emoji Handling', () => {
   describe('getEmojiName conversion for reactions', () => {
@@ -34,14 +37,12 @@ describe('Slack Client Emoji Handling', () => {
 
     it('passes through unknown emoji unchanged', () => {
       expect(getEmojiName('custom_emoji')).toBe('custom_emoji');
-      expect(getEmojiName('🦄')).toBe('🦄'); // Not in our mapping
+      expect(getEmojiName('🦄')).toBe('🦄');
     });
   });
 
   describe('reaction emoji used in update prompts', () => {
-    // These are the actual emoji used in session/manager.ts for update prompts
     const updatePromptEmoji = ['👍', '👎'];
-
     it('converts all update prompt emoji to valid Slack names', () => {
       const converted = updatePromptEmoji.map(getEmojiName);
       expect(converted).toEqual(['+1', '-1']);
@@ -49,9 +50,7 @@ describe('Slack Client Emoji Handling', () => {
   });
 
   describe('reaction emoji used in permission prompts', () => {
-    // These are the actual emoji used in mcp/permission-server.ts
     const permissionPromptEmoji = ['👍', '✅', '👎'];
-
     it('converts all permission prompt emoji to valid Slack names', () => {
       const converted = permissionPromptEmoji.map(getEmojiName);
       expect(converted).toEqual(['+1', 'white_check_mark', '-1']);
@@ -59,12 +58,326 @@ describe('Slack Client Emoji Handling', () => {
   });
 
   describe('reaction emoji used in message approval', () => {
-    // These are the actual emoji used for message approval prompts
     const messageApprovalEmoji = ['👍', '✅', '👎'];
-
     it('converts all message approval emoji to valid Slack names', () => {
       const converted = messageApprovalEmoji.map(getEmojiName);
       expect(converted).toEqual(['+1', 'white_check_mark', '-1']);
     });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// SlackClient tests — fetch is stubbed; Socket Mode paths are exercised via
+// pure helpers that don't need a WebSocket.
+// -----------------------------------------------------------------------------
+
+type FetchResponder = (url: string, init?: RequestInit) => Promise<Response> | Response;
+
+let fetchResponder: FetchResponder = () =>
+  new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } });
+let fetchCalls: Array<{ url: string; method: string; headers: Record<string, string>; body?: unknown }> = [];
+
+const originalFetch = global.fetch;
+beforeEach(() => {
+  fetchCalls = [];
+  global.fetch = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headers[k] = h[k];
+    }
+    let body: unknown;
+    if (typeof init?.body === 'string') {
+      try { body = JSON.parse(init.body); } catch { body = init.body; }
+    }
+    fetchCalls.push({ url: urlStr, method, headers, body });
+    return fetchResponder(urlStr, init);
+  }) as typeof global.fetch;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+function ok(body: Record<string, unknown> = {}): Response {
+  return new Response(JSON.stringify({ ok: true, ...body }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function notOk(error: string, status = 200): Response {
+  return new Response(JSON.stringify({ ok: false, error }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function httpError(status: number, text = 'server error'): Response {
+  return new Response(text, { status });
+}
+
+function makeConfig(overrides: Partial<SlackPlatformConfig> = {}): SlackPlatformConfig {
+  return {
+    id: 'slack-main',
+    type: 'slack',
+    displayName: 'Slack Main',
+    botToken: 'xoxb-bot-token',
+    appToken: 'xapp-app-token',
+    channelId: 'C123',
+    botName: 'claude',
+    allowedUsers: ['alice', 'bob'],
+    skipPermissions: false,
+    apiUrl: 'https://mock.slack.test/api',
+    ...overrides,
+  };
+}
+
+function makeClient(overrides: Partial<SlackPlatformConfig> = {}): SlackClient {
+  return new SlackClient(makeConfig(overrides));
+}
+
+async function primeBotUser(client: SlackClient, userId = 'U-BOT') {
+  fetchResponder = (url) => {
+    if (url.endsWith('auth.test')) return ok({ user_id: userId, url: 'https://team.slack.com/' });
+    if (url.includes('users.info')) {
+      return ok({ user: { id: userId, name: 'claude', real_name: 'Claude', profile: {} } });
+    }
+    return ok();
+  };
+  await client.getBotUser();
+  fetchCalls = [];
+}
+
+describe('SlackClient pure helpers', () => {
+  it('getMessageLimits returns Slack-specific stricter limits', () => {
+    expect(makeClient().getMessageLimits()).toEqual({ maxLength: 12000, hardThreshold: 10000 });
+  });
+
+  it('isBotMentioned detects <@USERID> mentions when bot user id is known', async () => {
+    const c = makeClient();
+    await primeBotUser(c, 'U-BOT');
+    expect(c.isBotMentioned('<@U-BOT> hello')).toBe(true);
+    expect(c.isBotMentioned('<@U-OTHER> hi')).toBe(false);
+  });
+
+  it('isBotMentioned detects @botname (case-insensitive)', () => {
+    const c = makeClient({ botName: 'claude' });
+    expect(c.isBotMentioned('@claude help')).toBe(true);
+    expect(c.isBotMentioned('@CLAUDE help')).toBe(true);
+    expect(c.isBotMentioned('claude help')).toBe(false);
+  });
+
+  it('extractPrompt strips <@USERID> mentions when bot user id is known', async () => {
+    const c = makeClient();
+    await primeBotUser(c, 'U-BOT');
+    expect(c.extractPrompt('<@U-BOT> do something')).toBe('do something');
+    expect(c.extractPrompt('hey <@U-BOT>, fix this')).toBe('hey , fix this');
+  });
+
+  it('extractPrompt strips @botname mentions', () => {
+    const c = makeClient({ botName: 'claude' });
+    expect(c.extractPrompt('@claude write code')).toBe('write code');
+  });
+
+  it('sendTyping is a no-op and does not throw', () => {
+    expect(() => makeClient().sendTyping()).not.toThrow();
+  });
+
+  it('platform identity fields reflect config', () => {
+    const c = makeClient({ id: 'slack-x', displayName: 'X' });
+    expect(c.platformId).toBe('slack-x');
+    expect(c.displayName).toBe('X');
+    expect(c.platformType).toBe('slack');
+  });
+
+  it('getFormatter returns a stable formatter instance', () => {
+    const c = makeClient();
+    expect(c.getFormatter()).toBe(c.getFormatter());
+  });
+});
+
+describe('SlackClient API methods', () => {
+  it('createPost calls chat.postMessage with channel + thread + unfurl flags', async () => {
+    fetchResponder = () =>
+      ok({ ts: '1000.0001', channel: 'C123', message: { text: 'hi' } });
+    const post = await makeClient().createPost('hi', '999.0001');
+    expect(post.id).toBe('1000.0001');
+    expect(post.channelId).toBe('C123');
+    expect(post.rootId).toBe('999.0001');
+
+    const call = fetchCalls[0];
+    expect(call.url).toBe('https://mock.slack.test/api/chat.postMessage');
+    expect(call.method).toBe('POST');
+    expect(call.headers.Authorization).toBe('Bearer xoxb-bot-token');
+    const body = call.body as Record<string, unknown>;
+    expect(body.channel).toBe('C123');
+    expect(body.thread_ts).toBe('999.0001');
+    expect(body.unfurl_links).toBe(true);
+  });
+
+  it('createPost disables unfurling for channel-level posts by default', async () => {
+    fetchResponder = () => ok({ ts: '1.1', channel: 'C123', message: { text: 'ping' } });
+    await makeClient().createPost('ping');
+    const body = fetchCalls[0].body as Record<string, unknown>;
+    expect(body.unfurl_links).toBe(false);
+    expect(body.thread_ts).toBeUndefined();
+  });
+
+  it('createPost allows explicit unfurl=true for channel-level posts', async () => {
+    fetchResponder = () => ok({ ts: '1.1', channel: 'C123', message: { text: 'ping' } });
+    await makeClient().createPost('ping', undefined, { unfurl: true });
+    const body = fetchCalls[0].body as Record<string, unknown>;
+    expect(body.unfurl_links).toBe(true);
+  });
+
+  it('createPost truncates oversized messages before sending', async () => {
+    fetchResponder = () => ok({ ts: '1.1', channel: 'C123', message: { text: 'truncated' } });
+    const bigMessage = 'x'.repeat(20_000);
+    await makeClient().createPost(bigMessage);
+    const body = fetchCalls[0].body as Record<string, unknown>;
+    expect((body.text as string).length).toBeLessThanOrEqual(12_200);
+    expect(body.text).toContain('(truncated)');
+  });
+
+  it('updatePost calls chat.update', async () => {
+    fetchResponder = () =>
+      ok({ ts: '100.1', channel: 'C123', text: 'updated' });
+    const post = await makeClient().updatePost('100.1', 'updated');
+    expect(post.message).toBe('updated');
+    expect(fetchCalls[0].url).toContain('chat.update');
+  });
+
+  it('addReaction posts to reactions.add', async () => {
+    fetchResponder = () => ok();
+    await makeClient().addReaction('100.1', '+1');
+    expect(fetchCalls[0].url).toContain('reactions.add');
+    const body = fetchCalls[0].body as Record<string, unknown>;
+    expect(body.name).toBe('+1');
+    expect(body.timestamp).toBe('100.1');
+  });
+
+  it('removeReaction posts to reactions.remove', async () => {
+    fetchResponder = () => ok();
+    await makeClient().removeReaction('100.1', '+1');
+    expect(fetchCalls[0].url).toContain('reactions.remove');
+  });
+
+  it('pinPost swallows already_pinned errors', async () => {
+    fetchResponder = () => notOk('already_pinned');
+    await expect(makeClient().pinPost('100.1')).resolves.toBeUndefined();
+  });
+
+  it('unpinPost swallows no_pin errors', async () => {
+    fetchResponder = () => notOk('no_pin');
+    await expect(makeClient().unpinPost('100.1')).resolves.toBeUndefined();
+  });
+
+  it('pinPost rethrows unexpected errors', async () => {
+    fetchResponder = () => notOk('something_else');
+    await expect(makeClient().pinPost('100.1')).rejects.toThrow(/something_else/);
+  });
+
+  it('getPost returns null on API error', async () => {
+    fetchResponder = () => notOk('channel_not_found');
+    const post = await makeClient().getPost('100.1');
+    expect(post).toBeNull();
+  });
+
+  it('getPinnedPosts returns timestamps from items', async () => {
+    fetchResponder = () => ok({
+      items: [
+        { message: { ts: '1.1' } },
+        { message: { ts: '2.2' } },
+        { /* no message */ },
+      ],
+    });
+    const ids = await makeClient().getPinnedPosts();
+    expect(ids).toEqual(['1.1', '2.2']);
+  });
+
+  it('getThreadHistory sorts chronologically and filters bot messages', async () => {
+    const c = makeClient();
+    await primeBotUser(c, 'U-BOT');
+    fetchResponder = (url) => {
+      if (url.includes('conversations.replies')) {
+        return ok({
+          messages: [
+            { ts: '300.0', user: 'U-ALICE', text: 'first' },
+            { ts: '100.0', user: 'U-ALICE', text: 'second' },
+            { ts: '200.0', user: 'U-BOT', text: 'bot reply' },
+          ],
+        });
+      }
+      if (url.includes('users.info')) {
+        return ok({ user: { id: 'U-ALICE', name: 'alice', real_name: 'Alice', profile: {} } });
+      }
+      return ok();
+    };
+    const history = await c.getThreadHistory('thread-1', { excludeBotMessages: true });
+    expect(history).toHaveLength(2);
+    expect(history.every(m => m.username === 'alice')).toBe(true);
+  });
+
+  it('getThreadHistory returns [] on API error', async () => {
+    fetchResponder = () => notOk('channel_not_found');
+    const history = await makeClient().getThreadHistory('thread-1');
+    expect(history).toEqual([]);
+  });
+
+  it('getUser caches by user id', async () => {
+    const c = makeClient();
+    let calls = 0;
+    fetchResponder = (url) => {
+      if (url.includes('users.info?user=U-1')) {
+        calls += 1;
+        return ok({ user: { id: 'U-1', name: 'alice', real_name: 'Alice', profile: {} } });
+      }
+      return ok();
+    };
+    const first = await c.getUser('U-1');
+    const second = await c.getUser('U-1');
+    expect(first?.username).toBe('alice');
+    expect(second?.username).toBe('alice');
+    expect(calls).toBe(1);
+  });
+
+  it('getUser returns null when userId is empty', async () => {
+    expect(await makeClient().getUser('')).toBeNull();
+  });
+
+  it('getUser returns null on API error', async () => {
+    fetchResponder = () => notOk('user_not_found');
+    expect(await makeClient().getUser('U-missing')).toBeNull();
+  });
+
+  it('api() throws on HTTP non-2xx', async () => {
+    fetchResponder = () => httpError(500, 'server error');
+    await expect(makeClient().getPinnedPosts()).rejects.toThrow(/500/);
+  });
+
+  it('downloadFile fetches the private URL with bot token', async () => {
+    let second = false;
+    fetchResponder = (_url) => {
+      if (!second) {
+        second = true;
+        return ok({
+          file: {
+            url_private: 'https://files.test/abc',
+            id: 'F1', name: 'x', size: 3, mimetype: 'text/plain',
+          },
+        });
+      }
+      return new Response(new Uint8Array([7, 8, 9]), { status: 200 });
+    };
+    const buf = await makeClient().downloadFile('F1');
+    expect(buf.length).toBe(3);
+  });
+
+  it('downloadFile throws when no download URL is available', async () => {
+    fetchResponder = () => ok({ file: { id: 'F1', name: 'x', size: 0, mimetype: '' } });
+    await expect(makeClient().downloadFile('F1')).rejects.toThrow(/No download URL/);
   });
 });

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -887,3 +887,206 @@ describe('attemptMetadataFetch', () => {
     expect(ctx.ops.updateSessionHeader).toHaveBeenCalled();
   });
 });
+
+// ============================================================================
+// handleExit branch coverage — PR 1 safety net
+// ============================================================================
+
+/** Build a session whose .claude mock has isPermanentFailure & reason hooks. */
+function createExitTestSession(overrides: Partial<Session> & {
+  isPermanent?: boolean;
+  permanentReason?: string;
+  isRestarting?: boolean;
+  isCancelled?: boolean;
+  wasInterrupted?: boolean;
+  hasClaudeResponded?: boolean;
+  resumeFailCount?: number;
+} = {}): Session {
+  const session = createMockSession(overrides);
+  session.claude = {
+    ...session.claude,
+    isPermanentFailure: mock(() => overrides.isPermanent ?? false),
+    getPermanentFailureReason: mock(() => overrides.permanentReason ?? null),
+  } as any;
+  if (overrides.resumeFailCount !== undefined) {
+    session.lifecycle.resumeFailCount = overrides.resumeFailCount;
+  }
+  return session;
+}
+
+describe('handleExit', () => {
+  it('is a no-op when session is not found', async () => {
+    const ctx = createMockSessionContext(new Map());
+    await expect(lifecycle.handleExit('test-platform:missing', 0, ctx)).resolves.toBeUndefined();
+    expect(ctx.ops.updateStickyMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips cleanup and resets state when session is restarting', async () => {
+    const session = createExitTestSession({ isRestarting: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx);
+    expect(session.lifecycle.state).toBe('active');
+    expect(sessions.has(session.sessionId)).toBe(true);
+    expect(ctx.ops.updateStickyMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips cleanup when session was cancelled', async () => {
+    const session = createExitTestSession({ isCancelled: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 137, ctx);
+    // killSession handles cleanup; handleExit just returns.
+    expect(ctx.ops.updateStickyMessage).not.toHaveBeenCalled();
+    expect(ctx.ops.unpersistSession).not.toHaveBeenCalled();
+  });
+
+  it('preserves persistence when bot is shutting down', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+    (ctx.state as { isShuttingDown: boolean }).isShuttingDown = true;
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx);
+    expect(ctx.ops.unpersistSession).not.toHaveBeenCalled();
+  });
+
+  it('pauses session after interrupt when Claude has responded', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: true, wasInterrupted: true });
+    const mockCreatePost = mock(() => Promise.resolve({
+      id: 'pause-post', platformId: 'test-platform', channelId: 'c', userId: 'bot', message: '', createAt: 0,
+    }));
+    session.platform = createMockPlatform({ createPost: mockCreatePost as any });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx);
+
+    expect(session.lifecycle.state).toBe('paused');
+    expect(ctx.ops.persistSession).toHaveBeenCalled();
+    expect(sessions.has(session.sessionId)).toBe(false);
+    expect(ctx.ops.updateStickyMessage).toHaveBeenCalled();
+  });
+
+  it('does not persist interrupt when Claude has not yet responded', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: false, wasInterrupted: true });
+    session.platform = createMockPlatform({
+      createPost: mock(() => Promise.resolve({
+        id: 'p', platformId: 'test-platform', channelId: 'c', userId: 'bot', message: '', createAt: 0,
+      })) as any,
+    });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx);
+    expect(ctx.ops.persistSession).not.toHaveBeenCalled();
+  });
+
+  it('warns and cleans up when session exits before Claude responded', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: false });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 1, ctx);
+    expect(sessions.has(session.sessionId)).toBe(false);
+    expect(ctx.ops.updateStickyMessage).toHaveBeenCalled();
+  });
+
+  it('immediately unpersists on permanent failure for a resumed session', async () => {
+    const session = createExitTestSession({
+      hasClaudeResponded: true,
+      isPermanent: true,
+      permanentReason: 'corrupt session state',
+      resumeFailCount: 1,
+    });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 2, ctx);
+    expect(ctx.ops.unpersistSession).toHaveBeenCalledWith(session.sessionId);
+    expect(ctx.ops.persistSession).not.toHaveBeenCalled();
+  });
+
+  it('unpersists resumed session after MAX_RESUME_FAILURES', async () => {
+    const session = createExitTestSession({
+      hasClaudeResponded: true,
+      resumeFailCount: 2, // will increment to 3 = MAX
+    });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 1, ctx);
+    expect(session.lifecycle.resumeFailCount).toBe(3);
+    expect(ctx.ops.unpersistSession).toHaveBeenCalledWith(session.sessionId);
+  });
+
+  it('persists resumed session with retries left after transient failure', async () => {
+    const session = createExitTestSession({
+      hasClaudeResponded: true,
+      resumeFailCount: 0, // will increment to 1
+    });
+    // Force "resumed" state so handleExit hits the wasResumed branch.
+    session.lifecycle.state = 'active';
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 1, ctx);
+    expect(session.lifecycle.resumeFailCount).toBe(1);
+    expect(ctx.ops.persistSession).toHaveBeenCalled();
+    expect(ctx.ops.unpersistSession).not.toHaveBeenCalled();
+  });
+
+  it('unpersists on normal (code 0) exit', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx);
+    expect(ctx.ops.unpersistSession).toHaveBeenCalledWith(session.sessionId);
+    expect(sessions.has(session.sessionId)).toBe(false);
+  });
+
+  it('preserves persistence on non-zero exit (retry on restart)', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 137, ctx);
+    expect(ctx.ops.unpersistSession).not.toHaveBeenCalled();
+    expect(sessions.has(session.sessionId)).toBe(false);
+  });
+
+  it('unregisters worktree user when session has worktreeInfo', async () => {
+    const session = createExitTestSession({
+      hasClaudeResponded: true,
+      worktreeInfo: {
+        worktreePath: '/tmp/wt/abc',
+        branch: 'feature/x',
+        createdAt: new Date().toISOString(),
+      } as any,
+    });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx);
+    expect(ctx.ops.unregisterWorktreeUser).toHaveBeenCalledWith('/tmp/wt/abc', session.sessionId);
+  });
+
+  it('posts [Exited: code] notification on non-zero exit', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: true });
+    const mockCreatePost = mock(() => Promise.resolve({
+      id: 'p', platformId: 'test-platform', channelId: 'c', userId: 'bot', message: '', createAt: 0,
+    }));
+    session.platform = createMockPlatform({ createPost: mockCreatePost as any });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 42, ctx);
+    const posts = (mockCreatePost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(posts.some((msg: string) => msg.includes('[Exited: 42]'))).toBe(true);
+  });
+});
+
+

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -486,4 +486,144 @@ describe('SessionManager', () => {
       expect(mockSession.pendingSideConversations[0].fromUser).toBe('newuser');
     });
   });
+
+  // ==========================================================================
+  // PR 1 safety net — targeted tests that exercise injected-session paths
+  // ==========================================================================
+
+  /** Inject a realistic-ish session directly into the registry. */
+  function injectSession(
+    mgr: SessionManager,
+    platform: PlatformClient,
+    threadId: string,
+    overrides: Record<string, unknown> = {}
+  ) {
+    const sessionId = `test-platform:${threadId}`;
+    const session: any = {
+      platformId: 'test-platform',
+      threadId,
+      sessionId,
+      claudeSessionId: `claude-${threadId}`,
+      startedBy: 'alice',
+      startedByDisplayName: 'Alice',
+      startedAt: new Date(),
+      lastActivityAt: new Date(),
+      sessionNumber: 1,
+      workingDir: '/test/dir',
+      platform,
+      claude: {
+        isRunning: mock(() => true),
+        kill: mock(() => Promise.resolve()),
+        isPermanentFailure: mock(() => false),
+        getPermanentFailureReason: mock(() => null),
+      },
+      planApproved: false,
+      sessionAllowedUsers: new Set(['alice']),
+      forceInteractivePermissions: false,
+      sessionStartPostId: null,
+      timers: { timeoutTimer: null, warningTimer: null, cleanupTimer: null },
+      lifecycle: { state: 'active', resumeFailCount: 0, hasClaudeResponded: true },
+      timeoutWarningPosted: false,
+      messageCount: 0,
+      messageManager: {
+        getPendingContextPrompt: mock(() => null),
+        getTaskListState: mock(() => ({ postId: null, content: null, isCompleted: false, isMinimized: false })),
+        dispose: mock(() => {}),
+      },
+      ...overrides,
+    };
+    (mgr.registry as any).sessions.set(sessionId, session);
+    return session;
+  }
+
+  describe('isSessionActive with injected session', () => {
+    test('returns true when at least one session is registered', () => {
+      injectSession(manager, platform as unknown as PlatformClient, 'thread-X');
+      expect(manager.isSessionActive()).toBe(true);
+    });
+  });
+
+  describe('isInSessionThread', () => {
+    test('returns true for a registered thread', () => {
+      injectSession(manager, platform as unknown as PlatformClient, 'thread-X');
+      expect(manager.isInSessionThread('thread-X')).toBe(true);
+    });
+  });
+
+  describe('getActiveThreadIds', () => {
+    test('returns registered thread ids', () => {
+      injectSession(manager, platform as unknown as PlatformClient, 'A');
+      injectSession(manager, platform as unknown as PlatformClient, 'B');
+      expect(manager.getActiveThreadIds().sort()).toEqual(['A', 'B']);
+    });
+  });
+
+  describe('isUserAllowedInSession', () => {
+    test('returns true for session owner', () => {
+      injectSession(manager, platform as unknown as PlatformClient, 'thread-X', {
+        sessionAllowedUsers: new Set(['alice']),
+      });
+      expect(manager.isUserAllowedInSession('thread-X', 'alice')).toBe(true);
+    });
+
+    test('returns true for globally-allowed user', () => {
+      injectSession(manager, platform as unknown as PlatformClient, 'thread-X', {
+        sessionAllowedUsers: new Set(['alice']),
+      });
+      expect(manager.isUserAllowedInSession('thread-X', 'admin')).toBe(true);
+    });
+
+    test('returns false for random user not invited', () => {
+      injectSession(manager, platform as unknown as PlatformClient, 'thread-X', {
+        sessionAllowedUsers: new Set(['alice']),
+      });
+      expect(manager.isUserAllowedInSession('thread-X', 'mallory')).toBe(false);
+    });
+  });
+
+  describe('killSession (injected)', () => {
+    test('kills an active session and drops it from registry', async () => {
+      const session = injectSession(manager, platform as unknown as PlatformClient, 'thread-X');
+      await manager.killSession('thread-X');
+      expect(session.claude.kill).toHaveBeenCalled();
+      expect((manager.registry as any).sessions.has('test-platform:thread-X')).toBe(false);
+    });
+  });
+
+  describe('handleReaction (injected) — security gate', () => {
+    test('ignores reactions from unauthorized users', async () => {
+      const session = injectSession(manager, platform as unknown as PlatformClient, 'thread-X', {
+        sessionStartPostId: 'start-post',
+        sessionAllowedUsers: new Set(['alice']),
+      });
+      // Register the post so getSessionByPost finds it.
+      (manager as any).registry.postIndex = (manager as any).registry.postIndex || new Map();
+      (manager as any).registry.registerPost?.('start-post', 'thread-X', session.sessionId);
+      // The test platform mock's isUserAllowed accepts 'admin'/'allowed-user'.
+      // 'mallory' is NOT allowed anywhere.
+      await (manager as any).handleReaction('test-platform', 'start-post', 'x', 'mallory', 'added');
+      // killSession should not have been called (cancel would trigger it).
+      expect(session.claude.kill).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handlePostDeleted', () => {
+    test('is a no-op for unknown posts', () => {
+      // Smoke test — any explicit post-delete cleanup hooks should tolerate unknown posts.
+      // We simply confirm the method (if present) doesn't throw.
+      if (typeof (manager as any).handlePostDeleted === 'function') {
+        expect(() => (manager as any).handlePostDeleted('test-platform', 'unknown-post')).not.toThrow();
+      }
+    });
+  });
+
+  describe('setSkipPermissions + isSessionInteractive (injected session)', () => {
+    test('forceInteractivePermissions overrides a skipPermissions=true manager', () => {
+      // Fresh manager created with skipPermissions=true in outer beforeEach.
+      injectSession(manager, platform as unknown as PlatformClient, 'thread-F', {
+        forceInteractivePermissions: true,
+      });
+      expect(manager.isSessionInteractive('thread-F')).toBe(true);
+    });
+  });
 });

--- a/src/test-utils/wait-for.test.ts
+++ b/src/test-utils/wait-for.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'bun:test';
+import { waitFor } from './wait-for.js';
+
+describe('waitFor', () => {
+  it('returns immediately when condition is truthy on first call', async () => {
+    const start = Date.now();
+    const result = await waitFor(() => 'ready', { timeoutMs: 1000, intervalMs: 50 });
+    expect(result).toBe('ready');
+    expect(Date.now() - start).toBeLessThan(20);
+  });
+
+  it('returns when condition becomes truthy before timeout', async () => {
+    let attempts = 0;
+    const result = await waitFor(() => {
+      attempts += 1;
+      return attempts >= 3 ? attempts : null;
+    }, { timeoutMs: 1000, intervalMs: 10 });
+    expect(result).toBe(3);
+  });
+
+  it('supports async conditions', async () => {
+    let attempts = 0;
+    const result = await waitFor(async () => {
+      attempts += 1;
+      return attempts >= 2 ? 'done' : null;
+    }, { timeoutMs: 1000, intervalMs: 10 });
+    expect(result).toBe('done');
+  });
+
+  it('throws after timeout when condition never becomes truthy', async () => {
+    await expect(
+      waitFor(() => false, { timeoutMs: 50, intervalMs: 10 })
+    ).rejects.toThrow(/timed out/);
+  });
+
+  it('uses custom error message', async () => {
+    await expect(
+      waitFor(() => null, { timeoutMs: 50, intervalMs: 10, message: 'custom boom' })
+    ).rejects.toThrow(/custom boom/);
+  });
+});

--- a/src/test-utils/wait-for.ts
+++ b/src/test-utils/wait-for.ts
@@ -1,0 +1,35 @@
+/**
+ * waitFor — poll `cond` until it returns truthy, or throw on timeout.
+ *
+ * Use in integration tests instead of arbitrary `setTimeout` sleeps. The
+ * polling resolves as soon as `cond` is truthy, so fast machines do not
+ * wait the full duration.
+ */
+
+export interface WaitForOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  message?: string;
+}
+
+export async function waitFor<T>(
+  cond: () => T | Promise<T>,
+  options: WaitForOptions = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const intervalMs = options.intervalMs ?? 25;
+  const message = options.message ?? 'waitFor timed out';
+  const deadline = Date.now() + timeoutMs;
+
+  // First attempt — cheap path for the common case where cond is already true.
+  const first = await cond();
+  if (first) return first;
+
+  while (Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+    const result = await cond();
+    if (result) return result;
+  }
+
+  throw new Error(`${message} (after ${timeoutMs}ms)`);
+}


### PR DESCRIPTION
## Summary

First of five PRs from the refactor roadmap. Raises coverage on the god-objects and previously untested modules so subsequent structural refactors (PR 2–5) can ship without silent regressions.

**New test files:**
- ` src/mcp/permission-server.test.ts` — 14 tests, was 0% covered
- `src/operations/plugin/handler.test.ts` — 10 tests, was 6% covered
- `src/platform/mattermost/client.test.ts` — 28 tests, no prior dedicated test file
- `src/test-utils/wait-for.test.ts` — 5 tests for the new wait-for util

**Expanded:**
- `src/session/lifecycle.test.ts` — +13 ` handleExit` branch tests
- `src/session/manager.test.ts` — +11 injected-session tests for reaction routing, user allowlist, killSession, active thread tracking
- `src/platform/slack/client.test.ts` — +28 API-surface tests beyond the existing emoji conversion tests

**New test utility:**
- `src/test-utils/wait-for.ts` — poll-with-timeout helper, available to later PRs for replacing ad-hoc ` setTimeout` sleeps in integration tests

**Small testability refactor:**
- `src/mcp/permission-server.ts` — extract ` handlePermissionWith()` with injected config so the permission flow is unit-testable without spinning up a real `PermissionApi` or reading `process.env` at module load. No behavior change.

## Coverage deltas

| File | Before | After |
|------|--------|-------|
| `src/mcp/permission-server.ts` | 0% | 60% fn / 80% lines |
| `src/operations/plugin/handler.ts` | 0% fn / 6% lines | 100% fn / 60% lines |
| `src/session/lifecycle.ts` | 60% fn / 21% lines | 77% fn / 31% lines |
| `src/session/manager.ts` | 39% fn / 36% lines | 45% fn / 39% lines |
| `src/platform/mattermost/client.ts` | untested | 74% fn / 41% lines |
| `src/platform/slack/client.ts` | ~5% | 72% fn / 36% lines |

Totals: 1970 → 2079 tests passing (+109).

## Test plan

- [x] `bun test src/` — 2079 pass, 0 fail
- [x] `bun test src/ --coverage` — deltas confirmed against pre-PR baseline
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] Red-green verified: spot-mutations in permission-server, lifecycle, Mattermost client, and plugin handler each cause 1–6 tests to fail
- [ ] `bun run test:integration` — to run before merge

## Notes

- `src/test-utils/wait-for.ts` is introduced here but no call sites migrate yet. Later PRs will replace ad-hoc sleeps as they touch integration tests.
- `createMockPlatform` / `createMockSession` remain duplicated across test files for now; consolidation happens opportunistically as later PRs touch those files.
- The plugin install/uninstall success paths are not covered here because they call `restartClaudeSession`, which transitively pulls in the real `claude/cli.js` module. That module's identity matters for `commands/restart-rebind.test.ts` in the same process; the success paths are covered by integration tests instead. The failure paths are fully covered.
- Open question 2 from the roadmap resolved: `src/operations/plugin/` IS reachable — `!plugin` commands route through `SessionManager.handlePluginList/Install/Uninstall` at `src/session/manager.ts:1213–1225`. Plugin module stays, gets smoke tests.

Next: PR 2 (security quick wins + dead code + DRY) can be worked against this coverage floor.