### PR TITLE
feat: three-way permission modes — default | auto | bypass

### DIFF
--- a/src/claude/cli.test.ts
+++ b/src/claude/cli.test.ts
@@ -41,7 +41,7 @@ describe('ClaudeCli', () => {
       const options: ClaudeCliOptions = {
         workingDir: '/test/dir',
         threadId: 'thread-123',
-        skipPermissions: true,
+        permissionMode: 'bypass',
         sessionId: 'session-uuid',
         resume: false,
         chrome: true,
@@ -130,8 +130,8 @@ describe('ClaudeCli', () => {
   });
 
   describe('start', () => {
-    test('throws when skipPermissions is false but no platformConfig', () => {
-      const cli = new ClaudeCli({ workingDir: '/test', skipPermissions: false });
+    test('throws when permissionMode is not bypass but platformConfig is missing', () => {
+      const cli = new ClaudeCli({ workingDir: '/test', permissionMode: 'default' });
       expect(() => cli.start()).toThrow('platformConfig is required');
     });
   });

--- a/src/claude/cli.test.ts
+++ b/src/claude/cli.test.ts
@@ -10,6 +10,7 @@ import {
   ClaudeCli,
   buildClaudeChildEnv,
   materializeMcpConfig,
+  buildPermissionArgs,
   type ClaudeCliOptions,
   type StatusLineData,
   type McpConfigBlob,
@@ -394,3 +395,97 @@ function readdirOrEmpty(dir: string): string[] {
     return [];
   }
 }
+
+// ============================================================================
+// buildPermissionArgs — verifies the three-mode permission spawn logic
+// (bypass → --dangerously-skip-permissions; default → MCP server only;
+//  auto → MCP server + --permission-mode auto).
+// ============================================================================
+describe('buildPermissionArgs', () => {
+  const baseOpts = {
+    mcpServerPath: '/path/to/permission-server.js',
+    platformConfig: {
+      type: 'mattermost' as const,
+      url: 'https://example.test',
+      token: 'SECRET-TOKEN',
+      channelId: 'c-1',
+      allowedUsers: ['alice'],
+    },
+    threadId: 't-1',
+    sessionId: 's-1',
+    permissionTimeoutMs: 120_000,
+    debug: false,
+    inline: true, // keep tests off disk
+  };
+
+  it("bypass: emits --dangerously-skip-permissions and nothing else", () => {
+    const { args, tempFile } = buildPermissionArgs({ ...baseOpts, permissionMode: 'bypass' });
+    expect(args).toEqual(['--dangerously-skip-permissions']);
+    expect(tempFile).toBeNull();
+    // Critical: the token is NOT in the argv.
+    expect(args.join(' ')).not.toContain('SECRET-TOKEN');
+  });
+
+  it("default: emits --mcp-config + --permission-prompt-tool, no --permission-mode", () => {
+    const { args } = buildPermissionArgs({ ...baseOpts, permissionMode: 'default' });
+    expect(args).toContain('--mcp-config');
+    expect(args).toContain('--permission-prompt-tool');
+    expect(args).toContain('mcp__claude-threads-permissions__permission_prompt');
+    expect(args).not.toContain('--permission-mode');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it("auto: emits --mcp-config AND --permission-mode auto", () => {
+    const { args } = buildPermissionArgs({ ...baseOpts, permissionMode: 'auto' });
+    expect(args).toContain('--mcp-config');
+    expect(args).toContain('--permission-prompt-tool');
+    expect(args).toContain('--permission-mode');
+    // The `auto` value must follow `--permission-mode` (commander-style argv).
+    const modeIndex = args.indexOf('--permission-mode');
+    expect(args[modeIndex + 1]).toBe('auto');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it("default + auto throw if platformConfig is missing (MCP path can't run without credentials)", () => {
+    expect(() => buildPermissionArgs({
+      ...baseOpts,
+      platformConfig: undefined,
+      permissionMode: 'default',
+    })).toThrow(/platformConfig is required/);
+
+    expect(() => buildPermissionArgs({
+      ...baseOpts,
+      platformConfig: undefined,
+      permissionMode: 'auto',
+    })).toThrow(/platformConfig is required/);
+  });
+
+  it("bypass: does NOT require platformConfig (no MCP server is spawned)", () => {
+    expect(() => buildPermissionArgs({
+      ...baseOpts,
+      platformConfig: undefined,
+      permissionMode: 'bypass',
+    })).not.toThrow();
+  });
+
+  it("inline mode returns tempFile=null (rollback flag path)", () => {
+    const { tempFile } = buildPermissionArgs({ ...baseOpts, permissionMode: 'default', inline: true });
+    expect(tempFile).toBeNull();
+  });
+
+  it("file mode returns a path for later cleanup", () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'perm-args-'));
+    try {
+      // Temporarily override the tmpdir the test will write to.
+      const { tempFile } = buildPermissionArgs({
+        ...baseOpts,
+        permissionMode: 'default',
+        inline: false,
+      });
+      expect(tempFile).toBeString();
+      if (tempFile) rmSync(tempFile);
+    } finally {
+      rmSync(scratch, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -9,6 +9,7 @@ import { join } from 'path';
 import { createLogger } from '../utils/logger.js';
 import { getClaudePath } from './version-check.js';
 import { detectRateLimit, cooldownDeadline } from './rate-limit-detector.js';
+import type { PermissionMode } from '../config/types.js';
 
 const log = createLogger('claude');
 
@@ -129,7 +130,7 @@ export interface ClaudeCliOptions {
    *
    * Defaults to `'default'` when omitted.
    */
-  permissionMode?: 'default' | 'auto' | 'bypass';
+  permissionMode?: PermissionMode;
   sessionId?: string;  // Claude session ID (UUID) for --session-id or --resume
   resume?: boolean;    // If true, use --resume instead of --session-id
   chrome?: boolean;    // If true, enable Chrome integration with --chrome
@@ -250,7 +251,7 @@ export function materializeMcpConfig(
  * caller on process exit.
  */
 export function buildPermissionArgs(opts: {
-  permissionMode: 'default' | 'auto' | 'bypass';
+  permissionMode: PermissionMode;
   mcpServerPath: string;
   platformConfig: PlatformMcpConfig | undefined;
   threadId: string | undefined;
@@ -447,7 +448,7 @@ export class ClaudeCli extends EventEmitter {
     // Resolve the effective permission mode. New `permissionMode` wins; legacy
     // `skipPermissions` is honored when `permissionMode` is unset. Default is
     // 'default' (prompt user) — the safe choice when config is ambiguous.
-    const permissionMode: 'default' | 'auto' | 'bypass' =
+    const permissionMode: PermissionMode =
       this.options.permissionMode ?? 'default';
 
     // SECURITY NOTE ON MCP CONFIG: The `--mcp-config` blob includes the

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -127,11 +127,9 @@ export interface ClaudeCliOptions {
    *   via the MCP server (so `platformConfig` is still required).
    * - `'bypass'`: pass `--dangerously-skip-permissions`; no MCP server spawned.
    *
-   * When omitted, falls back to the legacy `skipPermissions` boolean.
+   * Defaults to `'default'` when omitted.
    */
   permissionMode?: 'default' | 'auto' | 'bypass';
-  /** @deprecated Use `permissionMode` instead. Kept for backward compatibility. */
-  skipPermissions?: boolean;
   sessionId?: string;  // Claude session ID (UUID) for --session-id or --resume
   resume?: boolean;    // If true, use --resume instead of --session-id
   chrome?: boolean;    // If true, enable Chrome integration with --chrome
@@ -450,8 +448,7 @@ export class ClaudeCli extends EventEmitter {
     // `skipPermissions` is honored when `permissionMode` is unset. Default is
     // 'default' (prompt user) — the safe choice when config is ambiguous.
     const permissionMode: 'default' | 'auto' | 'bypass' =
-      this.options.permissionMode
-      ?? (this.options.skipPermissions ? 'bypass' : 'default');
+      this.options.permissionMode ?? 'default';
 
     // SECURITY NOTE ON MCP CONFIG: The `--mcp-config` blob includes the
     // platform bot token. Passing it as an argv string would expose the

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -119,7 +119,19 @@ export interface PlatformMcpConfig {
 export interface ClaudeCliOptions {
   workingDir: string;
   threadId?: string;  // Thread ID for permission requests
-  skipPermissions?: boolean;  // If true, use --dangerously-skip-permissions
+  /**
+   * How tool-use permissions are enforced.
+   *
+   * - `'default'`: MCP permission server posts prompts; user reacts to approve.
+   * - `'auto'`: Claude's classifier decides per-tool; high-risk tools still prompt
+   *   via the MCP server (so `platformConfig` is still required).
+   * - `'bypass'`: pass `--dangerously-skip-permissions`; no MCP server spawned.
+   *
+   * When omitted, falls back to the legacy `skipPermissions` boolean.
+   */
+  permissionMode?: 'default' | 'auto' | 'bypass';
+  /** @deprecated Use `permissionMode` instead. Kept for backward compatibility. */
+  skipPermissions?: boolean;
   sessionId?: string;  // Claude session ID (UUID) for --session-id or --resume
   resume?: boolean;    // If true, use --resume instead of --session-id
   chrome?: boolean;    // If true, enable Chrome integration with --chrome
@@ -228,6 +240,79 @@ export function materializeMcpConfig(
   const path = join(dir, `claude-threads-mcp-${sessionId ?? process.pid}-${Date.now()}.json`);
   writeFileSync(path, JSON.stringify(config), { mode: 0o600 });
   return { mode: 'file', path };
+}
+
+/**
+ * Compute the permission-related CLI arguments for Claude and, when applicable,
+ * materialize the MCP config tempfile. Extracted so the three-mode branching
+ * is covered by unit tests (spawning the real Claude CLI is not viable).
+ *
+ * Returns `{ args, tempFile }`. `tempFile` is set only when the MCP config
+ * was written to disk (i.e. not inline-mode) and must be cleaned up by the
+ * caller on process exit.
+ */
+export function buildPermissionArgs(opts: {
+  permissionMode: 'default' | 'auto' | 'bypass';
+  mcpServerPath: string;
+  platformConfig: PlatformMcpConfig | undefined;
+  threadId: string | undefined;
+  sessionId: string | undefined;
+  permissionTimeoutMs: number;
+  debug: boolean;
+  inline?: boolean; // for tests
+}): { args: string[]; tempFile: string | null } {
+  const args: string[] = [];
+  if (opts.permissionMode === 'bypass') {
+    args.push('--dangerously-skip-permissions');
+    return { args, tempFile: null };
+  }
+
+  if (!opts.platformConfig) {
+    throw new Error(
+      `platformConfig is required when permissionMode is '${opts.permissionMode}'`,
+    );
+  }
+
+  const mcpEnv: Record<string, string> = {
+    PLATFORM_TYPE: opts.platformConfig.type,
+    PLATFORM_URL: opts.platformConfig.url,
+    PLATFORM_TOKEN: opts.platformConfig.token,
+    PLATFORM_CHANNEL_ID: opts.platformConfig.channelId,
+    PLATFORM_THREAD_ID: opts.threadId || '',
+    ALLOWED_USERS: opts.platformConfig.allowedUsers.join(','),
+    DEBUG: opts.debug ? '1' : '',
+    PERMISSION_TIMEOUT_MS: String(opts.permissionTimeoutMs),
+  };
+  if (opts.platformConfig.appToken) {
+    mcpEnv.PLATFORM_APP_TOKEN = opts.platformConfig.appToken;
+  }
+
+  const mcpConfig: McpConfigBlob = {
+    mcpServers: {
+      'claude-threads-permissions': {
+        type: 'stdio',
+        command: 'node',
+        args: [opts.mcpServerPath],
+        env: mcpEnv,
+      },
+    },
+  };
+
+  const materialized = materializeMcpConfig(mcpConfig, opts.sessionId, { inline: opts.inline });
+  let tempFile: string | null = null;
+  if (materialized.mode === 'file') {
+    tempFile = materialized.path;
+    args.push('--mcp-config', materialized.path);
+  } else {
+    args.push('--mcp-config', materialized.value);
+  }
+  args.push('--permission-prompt-tool', 'mcp__claude-threads-permissions__permission_prompt');
+
+  if (opts.permissionMode === 'auto') {
+    args.push('--permission-mode', 'auto');
+  }
+
+  return { args, tempFile };
 }
 
 // Per-instance stderr cap (enough to surface the most recent error chain).
@@ -361,63 +446,30 @@ export class ClaudeCli extends EventEmitter {
       }
     }
 
-    // Either use skip permissions or the MCP-based permission system
-    if (this.options.skipPermissions) {
-      args.push('--dangerously-skip-permissions');
-    } else {
-      // Configure the permission MCP server
-      const mcpServerPath = this.getMcpServerPath();
+    // Resolve the effective permission mode. New `permissionMode` wins; legacy
+    // `skipPermissions` is honored when `permissionMode` is unset. Default is
+    // 'default' (prompt user) — the safe choice when config is ambiguous.
+    const permissionMode: 'default' | 'auto' | 'bypass' =
+      this.options.permissionMode
+      ?? (this.options.skipPermissions ? 'bypass' : 'default');
 
-      // Platform config is required for MCP permission server
-      const platformConfig = this.options.platformConfig;
-      if (!platformConfig) {
-        throw new Error('platformConfig is required when skipPermissions is false');
-      }
-      // Platform-agnostic environment variables for MCP permission server
-      const mcpEnv: Record<string, string> = {
-        PLATFORM_TYPE: platformConfig.type,
-        PLATFORM_URL: platformConfig.url,
-        PLATFORM_TOKEN: platformConfig.token,
-        PLATFORM_CHANNEL_ID: platformConfig.channelId,
-        PLATFORM_THREAD_ID: this.options.threadId || '',
-        ALLOWED_USERS: platformConfig.allowedUsers.join(','),
-        DEBUG: this.debug ? '1' : '',
-        PERMISSION_TIMEOUT_MS: String(this.options.permissionTimeoutMs ?? 120000),
-      };
-
-      // Add Slack-specific app token if present (needed for Socket Mode)
-      if (platformConfig.appToken) {
-        mcpEnv.PLATFORM_APP_TOKEN = platformConfig.appToken;
-      }
-
-      const mcpConfig: McpConfigBlob = {
-        mcpServers: {
-          'claude-threads-permissions': {
-            type: 'stdio',
-            command: 'node',
-            args: [mcpServerPath],
-            env: mcpEnv,
-          },
-        },
-      };
-      // SECURITY: The MCP config contains the bot's platform token. Passing
-      // it as a --mcp-config '<JSON>' argv exposes the token in `ps` output
-      // on systems that let unprivileged users read other processes' argv.
-      // Default: write to an owner-only tempfile (mode 0600) and pass the
-      // path. Opt out with CLAUDE_THREADS_MCP_CONFIG_INLINE=1 for one release
-      // as a rollback hatch in case the file form regresses on any 2.1.x.
-      //
-      // Claude CLI `--mcp-config <configs...>` accepts "JSON files or
-      // strings" — file form verified against 2.1.x via `claude --help`.
-      const materialized = materializeMcpConfig(mcpConfig, this.options.sessionId);
-      if (materialized.mode === 'file') {
-        this.mcpConfigTempFile = materialized.path;
-        args.push('--mcp-config', materialized.path);
-      } else {
-        args.push('--mcp-config', materialized.value);
-      }
-      args.push('--permission-prompt-tool', 'mcp__claude-threads-permissions__permission_prompt');
-    }
+    // SECURITY NOTE ON MCP CONFIG: The `--mcp-config` blob includes the
+    // platform bot token. Passing it as an argv string would expose the
+    // token in `ps`. `buildPermissionArgs` writes it to an owner-only
+    // tempfile (mode 0600) and records the path on `this` for cleanup on
+    // exit. Set CLAUDE_THREADS_MCP_CONFIG_INLINE=1 to fall back to inline
+    // JSON as a one-release rollback hatch.
+    const permResult = buildPermissionArgs({
+      permissionMode,
+      mcpServerPath: this.getMcpServerPath(),
+      platformConfig: this.options.platformConfig,
+      threadId: this.options.threadId,
+      sessionId: this.options.sessionId,
+      permissionTimeoutMs: this.options.permissionTimeoutMs ?? 120000,
+      debug: this.debug,
+    });
+    args.push(...permResult.args);
+    this.mcpConfigTempFile = permResult.tempFile;
 
     // Chrome integration
     if (this.options.chrome) {

--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -6,6 +6,7 @@
  */
 
 import { COMMAND_REGISTRY } from './registry.js';
+import type { PermissionMode } from '../config/index.js';
 import type {
   CommandExecutorContext,
   CommandHandler,
@@ -190,7 +191,7 @@ const handleCd: CommandHandler = async (ctx, args) => {
  */
 function parsePermissionMode(
   arg: string | undefined,
-): 'default' | 'auto' | 'bypass' | null {
+): PermissionMode | null {
   switch (arg?.toLowerCase()) {
     case 'default':
     case 'interactive':

--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -183,30 +183,62 @@ const handleCd: CommandHandler = async (ctx, args) => {
 };
 
 /**
+ * Normalize a `!permissions` argument to one of the three canonical modes.
+ * Accepts `default`, `auto`, `bypass` directly plus legacy aliases
+ * `interactive` (→ default) and `skip` (→ bypass).
+ * Returns null for unknown values.
+ */
+function parsePermissionMode(
+  arg: string | undefined,
+): 'default' | 'auto' | 'bypass' | null {
+  switch (arg?.toLowerCase()) {
+    case 'default':
+    case 'interactive':
+      return 'default';
+    case 'auto':
+      return 'auto';
+    case 'bypass':
+    case 'skip':
+      return 'bypass';
+    default:
+      return null;
+  }
+}
+
+/**
  * Handle !permissions command.
+ *
+ * Accepts `default` | `auto` | `bypass` (canonical) and `interactive` | `skip`
+ * (legacy aliases). In first-message context, sets the session's initial mode.
+ * In-session, respawns Claude with the new mode.
  */
 const handlePermissions: CommandHandler = async (ctx, args) => {
-  const mode = args?.toLowerCase();
+  const mode = parsePermissionMode(args);
 
   if (ctx.commandContext === 'first-message') {
-    if (mode === 'interactive') {
+    if (mode) {
       return {
-        sessionOptions: { forceInteractivePermissions: true },
+        sessionOptions: {
+          permissionMode: mode,
+          // Legacy field kept in sync so older consumers still see the downgrade.
+          forceInteractivePermissions: mode === 'default',
+        },
         continueProcessing: true,
       };
     }
     return { handled: false };
   }
 
-  // In-session: toggle permissions
-  if (mode === 'interactive') {
-    await ctx.sessionManager.enableInteractivePermissions(ctx.threadId, ctx.username);
-  } else {
+  // In-session: change mode and respawn.
+  if (!mode) {
     await ctx.client.createPost(
-      `⚠️ Cannot upgrade to auto permissions - can only downgrade to interactive`,
-      ctx.threadId
+      `⚠️ Unknown permission mode. Usage: \`!permissions default|auto|bypass\` (aliases: \`interactive\`, \`skip\`).`,
+      ctx.threadId,
     );
+    return { handled: true };
   }
+
+  await ctx.sessionManager.setSessionPermissionMode(ctx.threadId, ctx.username, mode);
   return { handled: true };
 };
 

--- a/src/commands/parser.ts
+++ b/src/commands/parser.ts
@@ -63,8 +63,9 @@ const COMMAND_PATTERNS: Array<[string, RegExp]> = [
   ['invite', /^!invite\s+@?([\w.-]+)\s*$/i],
   ['kick', /^!kick\s+@?([\w.-]+)\s*$/i],
 
-  // Permissions
-  ['permissions', /^!permissions?\s+(interactive|auto)\s*$/i],
+  // Permissions — accepts the canonical modes (default|auto|bypass) plus the
+  // legacy `interactive` (→ default) and `skip` (→ bypass) aliases.
+  ['permissions', /^!permissions?\s+(default|auto|bypass|interactive|skip)\s*$/i],
 
   // Updates
   ['update', /^!update(?:\s+(now|defer))?\s*$/i],
@@ -200,8 +201,8 @@ export function removeCommandFromText(text: string, command: ParsedCommand): str
 const STACKABLE_PATTERNS: Array<[string, RegExp, number, number]> = [
   // !cd <path> [remainder]
   ['cd', /^!cd\s+(\S+)(?:\s+(.*))?$/i, 1, 2],
-  // !permissions interactive [remainder]
-  ['permissions', /^!permissions?\s+(interactive)(?:\s+(.*))?$/i, 1, 2],
+  // !permissions <mode> [remainder]. Accepts all canonical and legacy modes.
+  ['permissions', /^!permissions?\s+(default|auto|bypass|interactive|skip)(?:\s+(.*))?$/i, 1, 2],
   // !worktree - capture everything after !worktree as args
   // The executor will parse subcommand vs branch from the args
   ['worktree', /^!worktree\s+(.+)$/i, 1, -1],  // -1 means no remainder group

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect, beforeEach, afterEach, it } from 'bun:test';
-import { resolveLimits, LIMITS_DEFAULTS } from './index.js';
+import {
+  resolveLimits,
+  LIMITS_DEFAULTS,
+  resolvePermissionMode,
+  permissionModeDisplay,
+  permissionModeDescription,
+  permissionModeForRestart,
+} from './index.js';
 import { rmSync, existsSync, statSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
 import { join } from 'path';
@@ -223,5 +230,65 @@ describe('resolveLimits — flushDelayMs tunable', () => {
     const r = resolveLimits({ flushDelayMs: 123 });
     expect(r.maxSessions).toBe(LIMITS_DEFAULTS.maxSessions);
     expect(r.sessionTimeoutMinutes).toBe(LIMITS_DEFAULTS.sessionTimeoutMinutes);
+  });
+});
+
+describe('resolvePermissionMode', () => {
+  it('returns permissionMode verbatim when set', () => {
+    expect(resolvePermissionMode({ permissionMode: 'auto' })).toBe('auto');
+    expect(resolvePermissionMode({ permissionMode: 'bypass' })).toBe('bypass');
+    expect(resolvePermissionMode({ permissionMode: 'default' })).toBe('default');
+  });
+
+  it('prefers permissionMode over legacy skipPermissions when both set', () => {
+    expect(resolvePermissionMode({ permissionMode: 'auto', skipPermissions: true })).toBe('auto');
+    expect(resolvePermissionMode({ permissionMode: 'default', skipPermissions: true })).toBe('default');
+  });
+
+  it('falls back to skipPermissions when permissionMode is unset', () => {
+    expect(resolvePermissionMode({ skipPermissions: true })).toBe('bypass');
+    expect(resolvePermissionMode({ skipPermissions: false })).toBe('default');
+  });
+
+  it("defaults to 'default' when neither is set", () => {
+    expect(resolvePermissionMode({})).toBe('default');
+  });
+});
+
+describe('permissionModeDisplay', () => {
+  it('returns icon + label + chip for each mode', () => {
+    expect(permissionModeDisplay('default')).toEqual({ icon: '🔐', label: 'Default', chip: '🔐 Default' });
+    expect(permissionModeDisplay('auto')).toEqual({ icon: '⚡', label: 'Auto', chip: '⚡ Auto' });
+    expect(permissionModeDisplay('bypass')).toEqual({ icon: '⚠️', label: 'Bypass', chip: '⚠️ Bypass' });
+  });
+});
+
+describe('permissionModeDescription', () => {
+  it('returns a distinct human-readable description per mode', () => {
+    const d = permissionModeDescription('default');
+    const a = permissionModeDescription('auto');
+    const b = permissionModeDescription('bypass');
+    expect(d).not.toBe(a);
+    expect(a).not.toBe(b);
+    expect(d).toContain('prompt');
+    expect(b.toLowerCase()).toContain('allow');
+  });
+});
+
+describe('permissionModeForRestart', () => {
+  it("bypass: session respawn stays 'bypass' regardless of override", () => {
+    expect(permissionModeForRestart(false, 'bypass')).toBe('bypass');
+    expect(permissionModeForRestart(true, 'bypass')).toBe('bypass');
+  });
+
+  it("default bot mode without session override → 'bypass' (pre-existing quirk)", () => {
+    // This preserves the legacy formula; see `permissionModeForRestart` doc.
+    expect(permissionModeForRestart(false, 'default')).toBe('bypass');
+    expect(permissionModeForRestart(false, 'auto')).toBe('bypass');
+  });
+
+  it("with forceInteractivePermissions=true, respawn stays 'default' for non-bypass modes", () => {
+    expect(permissionModeForRestart(true, 'default')).toBe('default');
+    expect(permissionModeForRestart(true, 'auto')).toBe('default');
   });
 });

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -276,18 +276,17 @@ describe('permissionModeDescription', () => {
 });
 
 describe('permissionModeForRestart', () => {
-  it("bypass: session respawn stays 'bypass' regardless of override", () => {
+  it("bypass: respawn stays 'bypass' regardless of session override", () => {
     expect(permissionModeForRestart(false, 'bypass')).toBe('bypass');
     expect(permissionModeForRestart(true, 'bypass')).toBe('bypass');
   });
 
-  it("default bot mode without session override → 'bypass' (pre-existing quirk)", () => {
-    // This preserves the legacy formula; see `permissionModeForRestart` doc.
-    expect(permissionModeForRestart(false, 'default')).toBe('bypass');
-    expect(permissionModeForRestart(false, 'auto')).toBe('bypass');
+  it("session without override: respawn inherits the current mode verbatim", () => {
+    expect(permissionModeForRestart(false, 'default')).toBe('default');
+    expect(permissionModeForRestart(false, 'auto')).toBe('auto');
   });
 
-  it("with forceInteractivePermissions=true, respawn stays 'default' for non-bypass modes", () => {
+  it("session with forceInteractivePermissions=true: respawn is 'default' (the user opted in)", () => {
     expect(permissionModeForRestart(true, 'default')).toBe('default');
     expect(permissionModeForRestart(true, 'auto')).toBe('default');
   });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,7 +29,7 @@ export {
   permissionModeForRestart,
 } from './types.js';
 
-import type { Config, WorktreeMode as WorktreeModeType } from './types.js';
+import type { Config, WorktreeMode as WorktreeModeType, PermissionMode } from './types.js';
 
 // YAML config path
 export const CONFIG_PATH = resolve(homedir(), '.config', 'claude-threads', 'config.yaml');
@@ -104,7 +104,7 @@ export interface CliArgs {
   /** @deprecated Use `permissionMode` instead. Kept for backward compatibility. */
   skipPermissions?: boolean;
   /** Explicit permission mode — `default`, `auto`, or `bypass`. */
-  permissionMode?: 'default' | 'auto' | 'bypass';
+  permissionMode?: PermissionMode;
   chrome?: boolean;
   worktreeMode?: WorktreeModeType;
   keepAlive?: boolean;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -18,8 +18,16 @@ export type {
   AutoUpdateConfig,
   AutoRestartMode,
   ScheduledWindow,
+  PermissionMode,
 } from './types.js';
-export { LIMITS_DEFAULTS, resolveLimits } from './types.js';
+export {
+  LIMITS_DEFAULTS,
+  resolveLimits,
+  resolvePermissionMode,
+  permissionModeDisplay,
+  permissionModeDescription,
+  permissionModeForRestart,
+} from './types.js';
 
 import type { Config, WorktreeMode as WorktreeModeType } from './types.js';
 
@@ -93,7 +101,10 @@ export interface CliArgs {
   channel?: string;
   botName?: string;
   allowedUsers?: string;
+  /** @deprecated Use `permissionMode` instead. Kept for backward compatibility. */
   skipPermissions?: boolean;
+  /** Explicit permission mode — `default`, `auto`, or `bypass`. */
+  permissionMode?: 'default' | 'auto' | 'bypass';
   chrome?: boolean;
   worktreeMode?: WorktreeModeType;
   keepAlive?: boolean;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -203,6 +203,33 @@ export function resolvePermissionMode(opts: {
 }
 
 /**
+ * Single source of truth for user-facing metadata per permission mode.
+ * Every consumer (sticky message, session header, `!permissions` post) reads
+ * from this record — add a new field here and it's available everywhere.
+ */
+const MODE_INFO: Record<PermissionMode, {
+  icon: string;
+  label: string;
+  description: string;
+}> = {
+  default: {
+    icon: '🔐',
+    label: 'Default',
+    description: 'Every tool-use prompts for approval.',
+  },
+  auto: {
+    icon: '⚡',
+    label: 'Auto',
+    description: 'Claude classifier auto-approves low-risk tools; high-risk still prompts.',
+  },
+  bypass: {
+    icon: '⚠️',
+    label: 'Bypass',
+    description: 'No prompts — every tool-use is allowed.',
+  },
+};
+
+/**
  * Display metadata for a permission mode. One source of truth for the
  * `{icon} {label}` chips used in the sticky message, session header, and the
  * `!permissions` confirmation post.
@@ -210,14 +237,8 @@ export function resolvePermissionMode(opts: {
 export function permissionModeDisplay(
   mode: PermissionMode,
 ): { icon: string; label: string; /** "🔐 Default" */ chip: string } {
-  switch (mode) {
-    case 'default':
-      return { icon: '🔐', label: 'Default', chip: '🔐 Default' };
-    case 'auto':
-      return { icon: '⚡', label: 'Auto',    chip: '⚡ Auto' };
-    case 'bypass':
-      return { icon: '⚠️', label: 'Bypass',  chip: '⚠️ Bypass' };
-  }
+  const info = MODE_INFO[mode];
+  return { icon: info.icon, label: info.label, chip: `${info.icon} ${info.label}` };
 }
 
 /**
@@ -225,34 +246,36 @@ export function permissionModeDisplay(
  * Used in `!permissions` confirmation posts so users know what they opted into.
  */
 export function permissionModeDescription(mode: PermissionMode): string {
-  switch (mode) {
-    case 'default': return 'Every tool-use prompts for approval.';
-    case 'auto':    return 'Claude classifier auto-approves low-risk tools; high-risk still prompts.';
-    case 'bypass':  return 'No prompts — every tool-use is allowed.';
-  }
+  return MODE_INFO[mode].description;
 }
 
 /**
  * Mode to spawn Claude with when respawning an existing session (because of
  * `!cd`, plugin install/uninstall, or worktree switch).
  *
- * This preserves pre-existing behavior from before PR #343: the old code was
- * `skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions`.
- * That formula has a subtle quirk — it downgrades 'default' sessions to
- * 'bypass' on respawn unless the session explicitly opted into interactive
- * via `!permissions`. Kept here verbatim to avoid smuggling a behavior
- * change into a refactor; separately tracked for a follow-up.
+ * Semantics:
+ * - If the bot-wide mode is `'bypass'` (permissions globally off), the
+ *   respawn stays `'bypass'` — a global bypass isn't selectively re-tightened
+ *   per-session.
+ * - If the session explicitly opted into `'default'` via `!permissions`
+ *   (i.e. `forceInteractivePermissions === true`), the respawn stays
+ *   `'default'` — the user's opt-in is sticky.
+ * - Otherwise, the respawn inherits the current mode verbatim. A session
+ *   running in `'auto'` stays in `'auto'` after `!cd`.
  *
- * @param sessionHasInteractiveOverride `Session.forceInteractivePermissions`
- * @param currentMode current effective permission mode (bot-wide or override)
+ * The pre-PR-343 formula was
+ * `skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions`,
+ * which also demoted `'default'` sessions to `'bypass'` unless the user had
+ * explicitly opted in. Now that the bot knows about three modes the demotion
+ * is unnecessary; the function just honors the current mode.
  */
 export function permissionModeForRestart(
   sessionHasInteractiveOverride: boolean,
   currentMode: PermissionMode,
 ): PermissionMode {
-  return currentMode === 'bypass' || !sessionHasInteractiveOverride
-    ? 'bypass'
-    : 'default';
+  if (currentMode === 'bypass') return 'bypass';
+  if (sessionHasInteractiveOverride) return 'default';
+  return currentMode;
 }
 
 // =============================================================================

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -160,6 +160,105 @@ export interface PlatformInstanceConfig {
   [key: string]: unknown;
 }
 
+// =============================================================================
+// Permission modes
+// =============================================================================
+
+/**
+ * How tool-use permissions are enforced for Claude sessions.
+ *
+ * - `default`: Claude always asks before using a tool; the bot posts a permission
+ *   prompt in the thread and the user reacts 👍 / ✅ / 👎 to allow/allow-all/deny.
+ *   This is the safest option and the historical behavior when
+ *   `skipPermissions: false`.
+ *
+ * - `auto`: Claude's built-in classifier decides per-tool-use. Low-risk tools
+ *   (Read, Grep, Write within the working dir) are auto-approved; high-risk
+ *   tools (shell with external effects, writes outside the working dir) still
+ *   prompt via the MCP permission server. Introduced in Claude CLI 2.1.x.
+ *   New in this config; no backward-compat shim needed.
+ *
+ * - `bypass`: No prompts, no classifier — every tool-use is allowed. Equivalent
+ *   to passing `--dangerously-skip-permissions` to the Claude CLI. This is what
+ *   the legacy `skipPermissions: true` maps to.
+ */
+export type PermissionMode = 'default' | 'auto' | 'bypass';
+
+/**
+ * Resolve the effective permission mode from new + legacy fields. New config
+ * wins; legacy `skipPermissions` is honored when `permissionMode` is unset.
+ *
+ * Returns `'default'` when both are unset — the safe choice for ambiguous
+ * configs (asks the user to decide rather than silently bypassing).
+ */
+export function resolvePermissionMode(opts: {
+  permissionMode?: PermissionMode;
+  /** @deprecated Use `permissionMode` instead. Kept for backward compat. */
+  skipPermissions?: boolean;
+}): PermissionMode {
+  if (opts.permissionMode) return opts.permissionMode;
+  if (opts.skipPermissions === true) return 'bypass';
+  if (opts.skipPermissions === false) return 'default';
+  return 'default';
+}
+
+/**
+ * Display metadata for a permission mode. One source of truth for the
+ * `{icon} {label}` chips used in the sticky message, session header, and the
+ * `!permissions` confirmation post.
+ */
+export function permissionModeDisplay(
+  mode: PermissionMode,
+): { icon: string; label: string; /** "🔐 Default" */ chip: string } {
+  switch (mode) {
+    case 'default':
+      return { icon: '🔐', label: 'Default', chip: '🔐 Default' };
+    case 'auto':
+      return { icon: '⚡', label: 'Auto',    chip: '⚡ Auto' };
+    case 'bypass':
+      return { icon: '⚠️', label: 'Bypass',  chip: '⚠️ Bypass' };
+  }
+}
+
+/**
+ * Human-readable description of what a permission mode actually does.
+ * Used in `!permissions` confirmation posts so users know what they opted into.
+ */
+export function permissionModeDescription(mode: PermissionMode): string {
+  switch (mode) {
+    case 'default': return 'Every tool-use prompts for approval.';
+    case 'auto':    return 'Claude classifier auto-approves low-risk tools; high-risk still prompts.';
+    case 'bypass':  return 'No prompts — every tool-use is allowed.';
+  }
+}
+
+/**
+ * Mode to spawn Claude with when respawning an existing session (because of
+ * `!cd`, plugin install/uninstall, or worktree switch).
+ *
+ * This preserves pre-existing behavior from before PR #343: the old code was
+ * `skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions`.
+ * That formula has a subtle quirk — it downgrades 'default' sessions to
+ * 'bypass' on respawn unless the session explicitly opted into interactive
+ * via `!permissions`. Kept here verbatim to avoid smuggling a behavior
+ * change into a refactor; separately tracked for a follow-up.
+ *
+ * @param sessionHasInteractiveOverride `Session.forceInteractivePermissions`
+ * @param currentMode current effective permission mode (bot-wide or override)
+ */
+export function permissionModeForRestart(
+  sessionHasInteractiveOverride: boolean,
+  currentMode: PermissionMode,
+): PermissionMode {
+  return currentMode === 'bypass' || !sessionHasInteractiveOverride
+    ? 'bypass'
+    : 'default';
+}
+
+// =============================================================================
+// Platform configs
+// =============================================================================
+
 export interface MattermostPlatformConfig extends PlatformInstanceConfig {
   type: 'mattermost';
   url: string;
@@ -167,7 +266,13 @@ export interface MattermostPlatformConfig extends PlatformInstanceConfig {
   channelId: string;
   botName: string;
   allowedUsers: string[];
-  skipPermissions: boolean;
+  /**
+   * @deprecated Use `permissionMode` instead. Kept for backward compatibility
+   * with existing config.yaml files. When both are set, `permissionMode` wins.
+   */
+  skipPermissions?: boolean;
+  /** Preferred way to configure permissions. See `PermissionMode`. */
+  permissionMode?: PermissionMode;
 }
 
 export interface SlackPlatformConfig extends PlatformInstanceConfig {
@@ -177,7 +282,13 @@ export interface SlackPlatformConfig extends PlatformInstanceConfig {
   channelId: string;
   botName: string;
   allowedUsers: string[];
-  skipPermissions: boolean;
+  /**
+   * @deprecated Use `permissionMode` instead. Kept for backward compatibility
+   * with existing config.yaml files. When both are set, `permissionMode` wins.
+   */
+  skipPermissions?: boolean;
+  /** Preferred way to configure permissions. See `PermissionMode`. */
+  permissionMode?: PermissionMode;
   /** Optional API URL override for testing (defaults to https://slack.com/api) */
   apiUrl?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   type MattermostPlatformConfig,
   type SlackPlatformConfig,
   type PlatformInstanceConfig,
+  type PermissionMode,
 } from './config/index.js';
 import type { CliArgs } from './config/index.js';
 import { runOnboarding } from './onboarding.js';
@@ -271,7 +272,7 @@ async function startWithoutDaemon() {
     botName: opts.botName,
     allowedUsers: opts.allowedUsers,
     skipPermissions: opts.skipPermissions,
-    permissionMode: opts.permissionMode as 'default' | 'auto' | 'bypass' | undefined,
+    permissionMode: opts.permissionMode as PermissionMode | undefined,
     chrome: opts.chrome,
     worktreeMode: opts.worktreeMode,
     keepAlive: opts.keepAlive,
@@ -318,7 +319,7 @@ async function startWithoutDaemon() {
   // (legacy) > platform config's `permissionMode` > platform config's legacy
   // `skipPermissions` > 'default' (safe fallback).
   const firstPlatformConfig = config.platforms[0] as MattermostPlatformConfig | SlackPlatformConfig;
-  const initialPermissionMode: 'default' | 'auto' | 'bypass' = resolvePermissionMode({
+  const initialPermissionMode: PermissionMode = resolvePermissionMode({
     permissionMode:
       cliArgs.permissionMode
       ?? firstPlatformConfig.permissionMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { program } from 'commander';
 import {
   loadConfigWithMigration,
   configExists as checkConfigExists,
+  resolvePermissionMode,
   type MattermostPlatformConfig,
   type SlackPlatformConfig,
   type PlatformInstanceConfig,
@@ -100,8 +101,9 @@ program
   .option('--channel <id>', 'Mattermost channel ID')
   .option('--bot-name <name>', 'Bot mention name (default: claude-code)')
   .option('--allowed-users <users>', 'Comma-separated allowed usernames')
-  .option('--skip-permissions', 'Skip interactive permission prompts')
-  .option('--no-skip-permissions', 'Enable interactive permission prompts (override env)')
+  .option('--permission-mode <mode>', 'Permission mode: default | auto | bypass (default: from config)')
+  .option('--skip-permissions', '[deprecated] Alias for --permission-mode bypass')
+  .option('--no-skip-permissions', '[deprecated] Alias for --permission-mode default')
   .option('--chrome', 'Enable Claude in Chrome integration')
   .option('--no-chrome', 'Disable Claude in Chrome integration')
   .option('--worktree-mode <mode>', 'Git worktree mode: off, prompt, require (default: prompt)')
@@ -251,6 +253,16 @@ async function startWithoutDaemon() {
     process.env.DEBUG = '1';
   }
 
+  // Validate --permission-mode if provided. Commander passes it through
+  // verbatim, so we need to check it's one of the three canonical values.
+  if (
+    opts.permissionMode !== undefined &&
+    !['default', 'auto', 'bypass'].includes(opts.permissionMode)
+  ) {
+    console.error(red(`  ❌ Invalid --permission-mode: "${opts.permissionMode}". Must be one of: default, auto, bypass.`));
+    process.exit(1);
+  }
+
   // Build CLI args object
   const cliArgs: CliArgs = {
     url: opts.url,
@@ -259,6 +271,7 @@ async function startWithoutDaemon() {
     botName: opts.botName,
     allowedUsers: opts.allowedUsers,
     skipPermissions: opts.skipPermissions,
+    permissionMode: opts.permissionMode as 'default' | 'auto' | 'bypass' | undefined,
     chrome: opts.chrome,
     worktreeMode: opts.worktreeMode,
     keepAlive: opts.keepAlive,
@@ -299,10 +312,21 @@ async function startWithoutDaemon() {
 
   const config = newConfig;
 
-  // Get the first platform's skipPermissions setting as the default
-  // (for backwards compatibility with single-platform setups)
+  // Get the first platform's effective permission mode as the default
+  // (for backwards compatibility with single-platform setups). Precedence:
+  // --permission-mode CLI flag > --skip-permissions / --no-skip-permissions
+  // (legacy) > platform config's `permissionMode` > platform config's legacy
+  // `skipPermissions` > 'default' (safe fallback).
   const firstPlatformConfig = config.platforms[0] as MattermostPlatformConfig | SlackPlatformConfig;
-  const initialSkipPermissions = firstPlatformConfig.skipPermissions ?? false;
+  const initialPermissionMode: 'default' | 'auto' | 'bypass' = resolvePermissionMode({
+    permissionMode:
+      cliArgs.permissionMode
+      ?? firstPlatformConfig.permissionMode,
+    skipPermissions:
+      cliArgs.skipPermissions
+      ?? firstPlatformConfig.skipPermissions,
+  });
+  const initialSkipPermissions = initialPermissionMode === 'bypass';
 
   // Check Claude CLI version
   const claudeValidation = validateClaudeCli();
@@ -483,12 +507,14 @@ async function startWithoutDaemon() {
   // Now that log handler is set, enable keep-alive (will route logs through UI)
   keepAlive.setEnabled(keepAliveEnabled);
 
-  // Create session manager (shared across all platforms)
+  // Create session manager (shared across all platforms).
+  // Pass the resolved permission mode string (not the legacy boolean) so the
+  // manager tracks all three modes correctly.
   const threadLogsEnabled = config.threadLogs?.enabled ?? true;
   const threadLogsRetentionDays = config.threadLogs?.retentionDays ?? 30;
   const session = new SessionManager(
     workingDir,
-    initialSkipPermissions,
+    initialPermissionMode,
     config.chrome,
     config.worktreeMode,
     undefined,  // sessionsPath - use default

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -60,6 +60,7 @@ function createMockSessionManager() {
     inviteUser: mock(async () => {}),
     kickUser: mock(async () => {}),
     enableInteractivePermissions: mock(async () => {}),
+    setSessionPermissionMode: mock(async () => {}),
     changeDirectory: mock(async () => {}),
     listWorktreesCommand: mock(async () => {}),
     switchToWorktree: mock(async () => {}),
@@ -284,7 +285,9 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.enableInteractivePermissions).toHaveBeenCalledWith('thread1', 'allowed-user');
+      // 'interactive' is the legacy alias for 'default'; the command now
+      // dispatches through setSessionPermissionMode with the canonical name.
+      expect(session.setSessionPermissionMode).toHaveBeenCalledWith('thread1', 'allowed-user', 'default');
     });
 
     test('handles !cd command', async () => {
@@ -896,7 +899,7 @@ describe('handleMessage', () => {
           'test-platform',
           'User',
           'post1',
-          { forceInteractivePermissions: true }  // initialOptions with permission flag
+          { permissionMode: 'default', forceInteractivePermissions: true }  // initialOptions with permission mode
         );
       });
 
@@ -942,7 +945,7 @@ describe('handleMessage', () => {
           'test-platform',
           'User',
           'post1',
-          { workingDir: '/tmp', forceInteractivePermissions: true }
+          { workingDir: '/tmp', permissionMode: 'default', forceInteractivePermissions: true }
         );
       });
 
@@ -1011,7 +1014,7 @@ describe('handleMessage', () => {
       (session.registry.findByThreadId as any).mockReturnValue({ sessionId: 'test:thread1' });
     });
 
-    test('rejects upgrade to auto permissions', async () => {
+    test('dispatches !permissions auto through setSessionPermissionMode', async () => {
       const post: PlatformPost = {
         id: 'post1',
         platformId: 'test',
@@ -1025,10 +1028,44 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.enableInteractivePermissions).not.toHaveBeenCalled();
-      expect(client.createPost).toHaveBeenCalled();
-      const postContent = (client.createPost as any).mock.calls[0][0];
-      expect(postContent).toContain('Cannot upgrade to auto');
+      // `auto` is a canonical mode; it should respawn Claude with --permission-mode auto.
+      expect(session.setSessionPermissionMode).toHaveBeenCalledWith('thread1', 'allowed-user', 'auto');
+    });
+
+    test('dispatches !permissions bypass through setSessionPermissionMode', async () => {
+      const post: PlatformPost = {
+        id: 'post1',
+        platformId: 'test',
+        channelId: 'channel1',
+        userId: 'user1',
+        message: '!permissions bypass',
+        rootId: 'thread1',
+        createAt: Date.now(),
+      };
+      const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+
+      await handleMessage(client, session, post, user, options);
+
+      expect(session.setSessionPermissionMode).toHaveBeenCalledWith('thread1', 'allowed-user', 'bypass');
+    });
+
+    test('rejects !permissions with unknown mode', async () => {
+      const post: PlatformPost = {
+        id: 'post1',
+        platformId: 'test',
+        channelId: 'channel1',
+        userId: 'user1',
+        message: '!permissions bogus',
+        rootId: 'thread1',
+        createAt: Date.now(),
+      };
+      const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+
+      await handleMessage(client, session, post, user, options);
+
+      // Parser regex doesn't match; command is ignored. `setSessionPermissionMode`
+      // is not called.
+      expect(session.setSessionPermissionMode).not.toHaveBeenCalled();
     });
   });
 

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -117,7 +117,6 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
     config: {
       workingDir: '/test',
       permissionMode: 'bypass',
-      skipPermissions: true,
       chromeEnabled: false,
       debug: false,
       maxSessions: 5,

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -116,6 +116,7 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
   return {
     config: {
       workingDir: '/test',
+      permissionMode: 'bypass',
       skipPermissions: true,
       chromeEnabled: false,
       debug: false,

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -8,6 +8,11 @@ import type { Session } from '../../session/types.js';
 import { transitionTo } from '../../session/types.js';
 import type { SessionContext } from '../session-context/index.js';
 import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../../claude/cli.js';
+import {
+  permissionModeDisplay,
+  permissionModeDescription,
+  permissionModeForRestart,
+} from '../../config/index.js';
 import { handleRateLimit } from '../../session/lifecycle.js';
 import { ClaudeCli } from '../../claude/cli.js';
 import { randomUUID } from 'crypto';
@@ -379,7 +384,8 @@ export async function changeDirectory(
   const cliOptions: ClaudeCliOptions = {
     workingDir: absoluteDir,
     threadId: session.threadId,
-    skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions,
+    // Preserve the pre-existing formula (see `permissionModeForRestart`).
+    permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
     sessionId: newSessionId,
     resume: false, // Fresh start - can't resume across directories
     chrome: ctx.config.chromeEnabled,
@@ -507,67 +513,59 @@ export async function kickUser(
 // ---------------------------------------------------------------------------
 
 /**
- * Enable interactive permissions for a session.
+ * Change the effective permission mode for a single session.
+ *
+ * The bot-wide mode is used as a ceiling for how-strict the default is; this
+ * function always accepts any of the three modes (so operators can relax too).
+ * Claude is respawned with the new mode via `restartClaudeSession`.
  */
-export async function enableInteractivePermissions(
+export async function setSessionPermissionMode(
   session: Session,
   username: string,
-  ctx: SessionContext
+  mode: 'default' | 'auto' | 'bypass',
+  ctx: SessionContext,
 ): Promise<void> {
-  // Only session owner or globally allowed users can change permissions
   if (!await requireSessionOwner(session, username, 'change permissions')) {
     return;
   }
 
-  // Can only downgrade, not upgrade
-  if (!ctx.config.skipPermissions) {
-    await post(session, 'info', `Permissions are already interactive for this session`);
-    sessionLog(session).debug(`🔐 Permissions already interactive (global setting)`);
-    return;
-  }
+  // Sticky-override flag: only 'default' (interactive) carries across restarts
+  // as a session-scoped override. 'auto' and 'bypass' revert to bot-wide mode
+  // on bot restart. This matches pre-existing behavior of
+  // `forceInteractivePermissions`.
+  session.forceInteractivePermissions = mode === 'default';
 
-  // Already enabled for this session
-  if (session.forceInteractivePermissions) {
-    await post(session, 'info', `Interactive permissions already enabled for this session`);
-    sessionLog(session).debug(`🔐 Permissions already interactive (session override)`);
-    return;
-  }
+  sessionLog(session).info(`🔐 Setting permission mode to "${mode}"`);
+  session.threadLogger?.logCommand('permissions', mode, username);
 
-  // Set the flag
-  session.forceInteractivePermissions = true;
-
-  sessionLog(session).info(`🔐 Enabling interactive permissions`);
-  session.threadLogger?.logCommand('permissions', 'interactive', username);
-
-  // Create new CLI options with interactive permissions
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
-    skipPermissions: false, // Force interactive permissions
+    permissionMode: mode,
     sessionId: session.claudeSessionId,
-    resume: true, // Resume to keep conversation context
+    resume: true,
     chrome: ctx.config.chromeEnabled,
     platformConfig: session.platform.getMcpConfig(),
-    logSessionId: session.sessionId,  // Route logs to session panel
+    logSessionId: session.sessionId,
     permissionTimeoutMs: ctx.config.permissionTimeoutMs,
     account: sessionAccountOption(session, ctx),
   };
 
-  // Restart Claude with new options
-  const success = await restartClaudeSession(session, cliOptions, ctx, 'Enable interactive permissions');
+  const success = await restartClaudeSession(
+    session, cliOptions, ctx, `Set permission mode to ${mode}`,
+  );
   if (!success) return;
 
-  // Update session header with new permission status
   await updateSessionHeader(session, ctx);
 
-  // Post confirmation
   const formatter = session.platform.getFormatter();
-  await post(session, 'secure', `${formatter.formatBold('Interactive permissions enabled')} for this session by ${formatter.formatUserMention(username)}\n${formatter.formatItalic('Claude Code restarted with permission prompts')}`);
-  sessionLog(session).info(`🔐 Interactive permissions enabled by @${username}`);
-
-  // Reset activity and clear timeout tracking (prevents updating stale posts in long threads)
-  resetSessionActivity(session);
-  ctx.ops.persistSession(session);
+  const display = permissionModeDisplay(mode);
+  await post(session, 'secure',
+    `${display.icon} ${formatter.formatBold(`Permission mode: ${display.label}`)} set for this session by ${formatter.formatUserMention(username)}\n` +
+    `${formatter.formatItalic(permissionModeDescription(mode))}\n` +
+    `${formatter.formatItalic('Claude Code restarted.')}`,
+  );
+  sessionLog(session).info(`🔐 Permission mode set to "${mode}" by @${username}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -631,9 +629,13 @@ export async function updateSessionHeader(
     ? { path: session.worktreeInfo.worktreePath, branch: session.worktreeInfo.branch }
     : undefined;
   const shortDir = shortenPath(session.workingDir, undefined, worktreeContext);
-  // Check session-level permission override
-  const isInteractive = !ctx.config.skipPermissions || session.forceInteractivePermissions;
-  const permMode = isInteractive ? '🔐 Interactive' : '⚡ Auto';
+  // Effective permission mode for this session: session-scoped interactive
+  // override (legacy forceInteractivePermissions === 'default' sticky) wins
+  // over the bot-wide mode. 'auto' and 'bypass' are not sticky per-session.
+  const effectiveMode = session.forceInteractivePermissions
+    ? 'default'
+    : ctx.config.permissionMode;
+  const permMode = permissionModeDisplay(effectiveMode).chip;
 
   // Build participants list (excluding owner)
   const otherParticipants = [...session.sessionAllowedUsers]

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -13,6 +13,7 @@ import {
   permissionModeDescription,
   permissionModeForRestart,
 } from '../../config/index.js';
+import type { PermissionMode } from '../../config/index.js';
 import { handleRateLimit } from '../../session/lifecycle.js';
 import { ClaudeCli } from '../../claude/cli.js';
 import { randomUUID } from 'crypto';
@@ -522,7 +523,7 @@ export async function kickUser(
 export async function setSessionPermissionMode(
   session: Session,
   username: string,
-  mode: 'default' | 'auto' | 'bypass',
+  mode: PermissionMode,
   ctx: SessionContext,
 ): Promise<void> {
   if (!await requireSessionOwner(session, username, 'change permissions')) {

--- a/src/operations/commands/index.ts
+++ b/src/operations/commands/index.ts
@@ -20,7 +20,7 @@ export {
   kickUser,
 
   // Permission management
-  enableInteractivePermissions,
+  setSessionPermissionMode,
 
   // Message approval
   requestMessageApproval,

--- a/src/operations/events/handler.test.ts
+++ b/src/operations/events/handler.test.ts
@@ -120,7 +120,6 @@ function createSessionContext(): SessionContext {
       debug: false,
       workingDir: '/test',
       permissionMode: 'bypass',
-      skipPermissions: true,
       chromeEnabled: false,
       maxSessions: 5,
     },

--- a/src/operations/events/handler.test.ts
+++ b/src/operations/events/handler.test.ts
@@ -119,6 +119,7 @@ function createSessionContext(): SessionContext {
     config: {
       debug: false,
       workingDir: '/test',
+      permissionMode: 'bypass',
       skipPermissions: true,
       chromeEnabled: false,
       maxSessions: 5,

--- a/src/operations/monitor/handler.test.ts
+++ b/src/operations/monitor/handler.test.ts
@@ -14,6 +14,7 @@ function createMockContext(): SessionContext {
     },
     config: {
       workingDir: '/tmp',
+      permissionMode: 'bypass',
       skipPermissions: true,
       chromeEnabled: false,
       debug: false,

--- a/src/operations/monitor/handler.test.ts
+++ b/src/operations/monitor/handler.test.ts
@@ -15,7 +15,6 @@ function createMockContext(): SessionContext {
     config: {
       workingDir: '/tmp',
       permissionMode: 'bypass',
-      skipPermissions: true,
       chromeEnabled: false,
       debug: false,
       maxSessions: 5,

--- a/src/operations/plugin/handler.ts
+++ b/src/operations/plugin/handler.ts
@@ -9,6 +9,7 @@ import { crossSpawn } from '../../utils/spawn.js';
 import type { Session } from '../../session/types.js';
 import type { SessionContext } from '../session-context/index.js';
 import type { ClaudeCliOptions } from '../../claude/cli.js';
+import { permissionModeForRestart } from '../../config/index.js';
 import { post, postError } from '../post-helpers/index.js';
 import { restartClaudeSession } from '../commands/index.js';
 import { createLogger } from '../../utils/logger.js';
@@ -123,7 +124,7 @@ export async function handlePluginInstall(
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
-    skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions,
+    permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
     sessionId: session.claudeSessionId,
     resume: true, // Resume to keep conversation context
     chrome: ctx.config.chromeEnabled,
@@ -181,7 +182,7 @@ export async function handlePluginUninstall(
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
-    skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions,
+    permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
     sessionId: session.claudeSessionId,
     resume: true, // Resume to keep conversation context
     chrome: ctx.config.chromeEnabled,

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -30,7 +30,16 @@ import type { AccountPoolStatus } from '../../claude/account-pool.js';
 export interface SessionConfig {
   /** Base working directory for sessions */
   workingDir: string;
-  /** Whether to skip permission prompts (dangerously-skip-permissions) */
+  /**
+   * Effective permission mode. See `PermissionMode` for semantics. New code
+   * should read this; `skipPermissions` (below) is kept as a derived boolean
+   * for legacy consumers that only need to know "is this bypass or not".
+   */
+  permissionMode: 'default' | 'auto' | 'bypass';
+  /**
+   * @deprecated Read `permissionMode` instead. True iff
+   * `permissionMode === 'bypass'`.
+   */
   skipPermissions: boolean;
   /** Whether Chrome browser automation is enabled */
   chromeEnabled: boolean;

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -17,7 +17,7 @@ import type { PlatformClient, PlatformFile } from '../../platform/index.js';
 import type { SessionStore } from '../../persistence/session-store.js';
 import type { SessionInfo } from '../../ui/types.js';
 import type { BuiltMessageContent } from '../streaming/handler.js';
-import type { ClaudeAccount } from '../../config/index.js';
+import type { ClaudeAccount, PermissionMode } from '../../config/index.js';
 import type { AccountPoolStatus } from '../../claude/account-pool.js';
 
 // =============================================================================
@@ -31,7 +31,7 @@ export interface SessionConfig {
   /** Base working directory for sessions */
   workingDir: string;
   /** Effective permission mode. See `PermissionMode` for semantics. */
-  permissionMode: 'default' | 'auto' | 'bypass';
+  permissionMode: PermissionMode;
   /** Whether Chrome browser automation is enabled */
   chromeEnabled: boolean;
   /** Debug mode flag */

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -30,17 +30,8 @@ import type { AccountPoolStatus } from '../../claude/account-pool.js';
 export interface SessionConfig {
   /** Base working directory for sessions */
   workingDir: string;
-  /**
-   * Effective permission mode. See `PermissionMode` for semantics. New code
-   * should read this; `skipPermissions` (below) is kept as a derived boolean
-   * for legacy consumers that only need to know "is this bypass or not".
-   */
+  /** Effective permission mode. See `PermissionMode` for semantics. */
   permissionMode: 'default' | 'auto' | 'bypass';
-  /**
-   * @deprecated Read `permissionMode` instead. True iff
-   * `permissionMode === 'bypass'`.
-   */
-  skipPermissions: boolean;
   /** Whether Chrome browser automation is enabled */
   chromeEnabled: boolean;
   /** Debug mode flag */

--- a/src/operations/sticky-message/handler.test.ts
+++ b/src/operations/sticky-message/handler.test.ts
@@ -10,7 +10,6 @@ const testConfig: StickyMessageConfig = {
   maxSessions: 5,
   chromeEnabled: false,
   permissionMode: 'default',
-  skipPermissions: false,
   worktreeMode: 'prompt',
   workingDir: '/home/user/projects',
   debug: false,

--- a/src/operations/sticky-message/handler.test.ts
+++ b/src/operations/sticky-message/handler.test.ts
@@ -9,6 +9,7 @@ import { mockFormatter } from '../../test-utils/mock-formatter.js';
 const testConfig: StickyMessageConfig = {
   maxSessions: 5,
   chromeEnabled: false,
+  permissionMode: 'default',
   skipPermissions: false,
   worktreeMode: 'prompt',
   workingDir: '/home/user/projects',
@@ -182,19 +183,27 @@ describe('buildStickyMessage', () => {
     expect(result).not.toContain('Chrome');
   });
 
-  it('shows Interactive permission mode by default', async () => {
+  it('shows Default permission mode for permissionMode=default', async () => {
     const sessions = new Map<string, Session>();
     const result = await buildStickyMessage(sessions, 'test-platform', testConfig, mockFormatter, (threadId) => `/_redirect/pl/${threadId}`);
 
-    expect(result).toContain('`🔐 Interactive`');
+    expect(result).toContain('`🔐 Default`');
   });
 
-  it('shows Auto permission mode when skipPermissions is true', async () => {
+  it('shows Auto permission mode for permissionMode=auto', async () => {
     const sessions = new Map<string, Session>();
-    const autoConfig = { ...testConfig, skipPermissions: true };
+    const autoConfig = { ...testConfig, permissionMode: 'auto' as const, skipPermissions: false };
     const result = await buildStickyMessage(sessions, 'test-platform', autoConfig, mockFormatter, (threadId) => `/_redirect/pl/${threadId}`);
 
     expect(result).toContain('`⚡ Auto`');
+  });
+
+  it('shows Bypass permission mode for permissionMode=bypass', async () => {
+    const sessions = new Map<string, Session>();
+    const bypassConfig = { ...testConfig, permissionMode: 'bypass' as const, skipPermissions: true };
+    const result = await buildStickyMessage(sessions, 'test-platform', bypassConfig, mockFormatter, (threadId) => `/_redirect/pl/${threadId}`);
+
+    expect(result).toContain('`⚠️ Bypass`');
   });
 
   it('shows worktree mode when not default prompt', async () => {

--- a/src/operations/sticky-message/handler.ts
+++ b/src/operations/sticky-message/handler.ts
@@ -152,8 +152,6 @@ export interface StickyMessageConfig {
   maxSessions: number;
   chromeEnabled: boolean;
   permissionMode: 'default' | 'auto' | 'bypass';
-  /** @deprecated Read `permissionMode` instead. Derived for legacy call sites. */
-  skipPermissions: boolean;
   worktreeMode: WorktreeMode;
   workingDir: string;
   debug: boolean;

--- a/src/operations/sticky-message/handler.ts
+++ b/src/operations/sticky-message/handler.ts
@@ -12,6 +12,7 @@ import type { PlatformClient, PlatformFormatter } from '../../platform/index.js'
 import { getPlatformIcon } from '../../platform/utils.js';
 import type { SessionStore, PersistedSession } from '../../persistence/session-store.js';
 import type { WorktreeMode } from '../../config/index.js';
+import { permissionModeDisplay } from '../../config/index.js';
 import type { AccountPoolStatus } from '../../claude/account-pool.js';
 import { formatBatteryStatus } from '../../utils/battery.js';
 import { formatUptime } from '../../utils/uptime.js';
@@ -150,6 +151,8 @@ export interface UpdateStatusInfo {
 export interface StickyMessageConfig {
   maxSessions: number;
   chromeEnabled: boolean;
+  permissionMode: 'default' | 'auto' | 'bypass';
+  /** @deprecated Read `permissionMode` instead. Derived for legacy call sites. */
   skipPermissions: boolean;
   worktreeMode: WorktreeMode;
   workingDir: string;
@@ -429,9 +432,8 @@ async function buildStatusBar(
     items.push(formatter.formatCode(label));
   }
 
-  // Permission mode
-  const permMode = config.skipPermissions ? '⚡ Auto' : '🔐 Interactive';
-  items.push(formatter.formatCode(permMode));
+  // Permission mode chip: single source of truth in `permissionModeDisplay`.
+  items.push(formatter.formatCode(permissionModeDisplay(config.permissionMode).chip));
 
   // Worktree mode (only show if not default 'prompt')
   if (config.worktreeMode === 'require') {

--- a/src/operations/sticky-message/handler.ts
+++ b/src/operations/sticky-message/handler.ts
@@ -11,7 +11,7 @@ import { getSessionStatus } from '../../session/types.js';
 import type { PlatformClient, PlatformFormatter } from '../../platform/index.js';
 import { getPlatformIcon } from '../../platform/utils.js';
 import type { SessionStore, PersistedSession } from '../../persistence/session-store.js';
-import type { WorktreeMode } from '../../config/index.js';
+import type { WorktreeMode, PermissionMode } from '../../config/index.js';
 import { permissionModeDisplay } from '../../config/index.js';
 import type { AccountPoolStatus } from '../../claude/account-pool.js';
 import { formatBatteryStatus } from '../../utils/battery.js';
@@ -151,7 +151,7 @@ export interface UpdateStatusInfo {
 export interface StickyMessageConfig {
   maxSessions: number;
   chromeEnabled: boolean;
-  permissionMode: 'default' | 'auto' | 'bypass';
+  permissionMode: PermissionMode;
   worktreeMode: WorktreeMode;
   workingDir: string;
   debug: boolean;

--- a/src/operations/worktree/handler.test.ts
+++ b/src/operations/worktree/handler.test.ts
@@ -152,7 +152,7 @@ function createMockSession(overrides?: Partial<Session>): Session {
 
 function createMockOptions() {
   return {
-    skipPermissions: true,
+    permissionMode: 'bypass' as const,
     chromeEnabled: false,
     worktreeMode: 'prompt' as const,
     handleEvent: mock(() => {}),

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -7,6 +7,7 @@
 import type { Session } from '../../session/types.js';
 import { transitionTo } from '../../session/types.js';
 import type { WorktreeMode } from '../../config/index.js';
+import { permissionModeForRestart } from '../../config/index.js';
 import type { PlatformFile } from '../../platform/index.js';
 import { suggestBranchNames } from '../suggestions/branch.js';
 import {
@@ -375,7 +376,7 @@ export async function createAndSwitchToWorktree(
   branch: string,
   username: string,
   options: {
-    skipPermissions: boolean;
+    permissionMode: 'default' | 'auto' | 'bypass';
     chromeEnabled: boolean;
     worktreeMode: WorktreeMode;
     permissionTimeoutMs?: number;
@@ -473,7 +474,7 @@ export async function createAndSwitchToWorktree(
         const cliOptions: ClaudeCliOptions = {
           workingDir: existing.path,
           threadId: session.threadId,
-          skipPermissions: options.skipPermissions || !session.forceInteractivePermissions,
+          permissionMode: permissionModeForRestart(session.forceInteractivePermissions, options.permissionMode),
           sessionId: newSessionId,
           resume: false,
           chrome: options.chromeEnabled,
@@ -619,7 +620,7 @@ export async function createAndSwitchToWorktree(
       const cliOptions: ClaudeCliOptions = {
         workingDir: worktreePath,
         threadId: session.threadId,
-        skipPermissions: options.skipPermissions || !session.forceInteractivePermissions,
+        permissionMode: permissionModeForRestart(session.forceInteractivePermissions, options.permissionMode),
         sessionId: newSessionId,
         resume: false,  // Fresh start - can't resume across directories
         chrome: options.chromeEnabled,

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -6,7 +6,7 @@
 
 import type { Session } from '../../session/types.js';
 import { transitionTo } from '../../session/types.js';
-import type { WorktreeMode } from '../../config/index.js';
+import type { WorktreeMode, PermissionMode } from '../../config/index.js';
 import { permissionModeForRestart } from '../../config/index.js';
 import type { PlatformFile } from '../../platform/index.js';
 import { suggestBranchNames } from '../suggestions/branch.js';
@@ -376,7 +376,7 @@ export async function createAndSwitchToWorktree(
   branch: string,
   username: string,
   options: {
-    permissionMode: 'default' | 'auto' | 'bypass';
+    permissionMode: PermissionMode;
     chromeEnabled: boolean;
     worktreeMode: WorktreeMode;
     permissionTimeoutMs?: number;

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -86,7 +86,7 @@ export class SlackClient extends BasePlatformClient {
     this.channelId = platformConfig.channelId;
     this.botName = platformConfig.botName;
     this.allowedUsers = platformConfig.allowedUsers;
-    this.skipPermissions = platformConfig.skipPermissions;
+    this.skipPermissions = platformConfig.skipPermissions ?? false;
     this.apiUrl = platformConfig.apiUrl || 'https://slack.com/api';
   }
 

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -159,6 +159,7 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
   return {
     config: {
       workingDir: '/test',
+      permissionMode: 'bypass',
       skipPermissions: true,
       chromeEnabled: false,
       debug: false,

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -160,7 +160,6 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
     config: {
       workingDir: '/test',
       permissionMode: 'bypass',
-      skipPermissions: true,
       chromeEnabled: false,
       debug: false,
       maxSessions: 5,

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -800,7 +800,10 @@ export async function startSession(
   // Apply initial options from first-message commands (!cd, !permissions)
   // ---------------------------------------------------------------------------
   let workingDir = ctx.config.workingDir;
-  let skipPermissions = ctx.config.skipPermissions;
+  // Start from the bot-wide default. The legacy `skipPermissions` boolean is
+  // still consumed by some callers, but the effective mode is what drives
+  // Claude CLI spawn below.
+  let permissionMode = ctx.config.permissionMode;
   let forceInteractivePermissions = false;
   const formatter = platform.getFormatter();
 
@@ -829,10 +832,18 @@ export async function startSession(
     log.info(`Starting session in directory: ${workingDir} (from !cd command)`);
   }
 
-  if (initialOptions?.forceInteractivePermissions) {
-    // !permissions interactive in first message
+  // First-message `!permissions <mode>` — honor the explicit mode.
+  // `forceInteractivePermissions` is the only mode that's sticky across
+  // bot restarts (matches legacy behavior); `auto` and `bypass` revert to
+  // the bot-wide default on resume.
+  if (initialOptions?.permissionMode) {
+    permissionMode = initialOptions.permissionMode;
+    forceInteractivePermissions = permissionMode === 'default';
+    log.info(`Starting session with permission mode "${permissionMode}" (from !permissions command)`);
+  } else if (initialOptions?.forceInteractivePermissions) {
+    // Legacy alias: forceInteractivePermissions === 'default'.
     forceInteractivePermissions = true;
-    skipPermissions = false;
+    permissionMode = 'default';
     log.info(`Starting session with interactive permissions (from !permissions command)`);
   }
 
@@ -852,7 +863,7 @@ export async function startSession(
   const cliOptions: ClaudeCliOptions = {
     workingDir,
     threadId: actualThreadId,
-    skipPermissions,
+    permissionMode,
     sessionId: claudeSessionId,
     resume: false,
     chrome: ctx.config.chromeEnabled,
@@ -1072,8 +1083,11 @@ export async function resumeSession(
   const platformId = state.platformId;
   const sessionId = ctx.ops.getSessionId(platformId, state.threadId);
 
-  // Create Claude CLI with resume flag
-  const skipPerms = ctx.config.skipPermissions && !state.forceInteractivePermissions;
+  // Resume: honor the bot's current permissionMode, but a session that was
+  // started with !permissions interactive keeps that stricter setting across
+  // bot restarts — it persists via state.forceInteractivePermissions.
+  const resumePermissionMode: 'default' | 'auto' | 'bypass' =
+    state.forceInteractivePermissions ? 'default' : ctx.config.permissionMode;
   const platformMcpConfig = platform.getMcpConfig();
 
   // Include system prompt for resumed sessions (provides platform context and command info)
@@ -1094,7 +1108,7 @@ export async function resumeSession(
   const cliOptions: ClaudeCliOptions = {
     workingDir: state.workingDir,
     threadId: state.threadId,
-    skipPermissions: skipPerms,
+    permissionMode: resumePermissionMode,
     sessionId: state.claudeSessionId,
     resume: true,
     chrome: ctx.config.chromeEnabled,

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -13,6 +13,7 @@ import {
   isSessionRestarting,
   isSessionCancelled,
 } from './types.js';
+import type { PermissionMode } from '../config/index.js';
 import { clearAllTimers } from './timer-manager.js';
 import type { PlatformClient, PlatformFile } from '../platform/index.js';
 import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../claude/cli.js';
@@ -1083,10 +1084,15 @@ export async function resumeSession(
   const platformId = state.platformId;
   const sessionId = ctx.ops.getSessionId(platformId, state.threadId);
 
-  // Resume: honor the bot's current permissionMode, but a session that was
-  // started with !permissions interactive keeps that stricter setting across
-  // bot restarts — it persists via state.forceInteractivePermissions.
-  const resumePermissionMode: 'default' | 'auto' | 'bypass' =
+  // Resume: honor the bot's current permissionMode, with one asymmetry:
+  // - A session that opted into `default` via `!permissions default|interactive`
+  //   keeps `default` across bot restart (stickiness persists via
+  //   `state.forceInteractivePermissions`). Safer-than-default overrides win.
+  // - `auto` and `bypass` per-session overrides are NOT persisted — resumed
+  //   sessions inherit whatever the bot-wide mode is at resume time. If a
+  //   user had run `!permissions auto` before a crash, they pick up the
+  //   bot-wide default on resume and would need to rerun the command.
+  const resumePermissionMode: PermissionMode =
     state.forceInteractivePermissions ? 'default' : ctx.config.permissionMode;
   const platformMcpConfig = platform.getMcpConfig();
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -71,19 +71,8 @@ export class SessionManager extends EventEmitter {
   // Platform management
   private platforms: Map<string, PlatformClient> = new Map();
   private workingDir: string;
-  /**
-   * Effective permission mode. New code reads/writes this; `skipPermissions` in
-   * legacy call sites now shadows it via the `skipPermissions` getter below.
-   */
+  /** Effective permission mode. Mutated via `setPermissionMode`. */
   private permissionMode: PermissionMode;
-  /**
-   * Derived from `permissionMode` for backward compatibility with code that
-   * still asks "is this bypass?". True iff mode === 'bypass'. Do not write —
-   * use `setPermissionMode`.
-   */
-  private get skipPermissions(): boolean {
-    return this.permissionMode === 'bypass';
-  }
   private chromeEnabled: boolean;
   private worktreeMode: WorktreeMode;
   private threadLogsEnabled: boolean;
@@ -269,7 +258,6 @@ export class SessionManager extends EventEmitter {
     const config: SessionConfig = {
       workingDir: this.workingDir,
       permissionMode: this.permissionMode,
-      skipPermissions: this.skipPermissions, // derived from permissionMode
       chromeEnabled: this.chromeEnabled,
       debug: this.debug,
       maxSessions: this.limits.maxSessions,
@@ -793,7 +781,6 @@ export class SessionManager extends EventEmitter {
       maxSessions: this.limits.maxSessions,
       chromeEnabled: this.chromeEnabled,
       permissionMode: this.permissionMode,
-      skipPermissions: this.skipPermissions, // derived; kept for backward-compat reads
       worktreeMode: this.worktreeMode,
       workingDir: this.workingDir,
       debug: this.debug,
@@ -1295,10 +1282,17 @@ export class SessionManager extends EventEmitter {
     await plugin.handlePluginUninstall(session, pluginName, username, this.getContext());
   }
 
+  /**
+   * Whether a session's tool-uses will trigger permission prompts. True when
+   * either (a) the bot-wide mode is not `bypass`, or (b) the session opted
+   * into `default` via `!permissions` and thus prompts regardless of the
+   * bot-wide mode.
+   */
   isSessionInteractive(threadId: string): boolean {
+    const botWideInteractive = this.permissionMode !== 'bypass';
     const session = this.findSessionByThreadId(threadId);
-    if (!session) return !this.skipPermissions;
-    if (!this.skipPermissions) return true;
+    if (!session) return botWideInteractive;
+    if (botWideInteractive) return true;
     return session.forceInteractivePermissions;
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -16,7 +16,7 @@ import { EventEmitter } from 'events';
 import { ClaudeEvent } from '../claude/cli.js';
 import type { PlatformClient, PlatformUser, PlatformPost, PlatformFile } from '../platform/index.js';
 import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persistence/session-store.js';
-import { WorktreeMode, type LimitsConfig, type ResolvedLimits, type ClaudeAccount, resolveLimits } from '../config/index.js';
+import { WorktreeMode, type LimitsConfig, type ResolvedLimits, type ClaudeAccount, type PermissionMode, resolveLimits } from '../config/index.js';
 import { AccountPool } from '../claude/account-pool.js';
 import type { SessionInfo } from '../ui/types.js';
 import {
@@ -71,7 +71,19 @@ export class SessionManager extends EventEmitter {
   // Platform management
   private platforms: Map<string, PlatformClient> = new Map();
   private workingDir: string;
-  private skipPermissions: boolean;
+  /**
+   * Effective permission mode. New code reads/writes this; `skipPermissions` in
+   * legacy call sites now shadows it via the `skipPermissions` getter below.
+   */
+  private permissionMode: PermissionMode;
+  /**
+   * Derived from `permissionMode` for backward compatibility with code that
+   * still asks "is this bypass?". True iff mode === 'bypass'. Do not write —
+   * use `setPermissionMode`.
+   */
+  private get skipPermissions(): boolean {
+    return this.permissionMode === 'bypass';
+  }
   private chromeEnabled: boolean;
   private worktreeMode: WorktreeMode;
   private threadLogsEnabled: boolean;
@@ -112,7 +124,14 @@ export class SessionManager extends EventEmitter {
 
   constructor(
     workingDir: string,
-    skipPermissions = false,
+    /**
+     * Permission mode. Accepts either the new `PermissionMode` string OR the
+     * legacy `skipPermissions: boolean` for backward compatibility:
+     * - `true`  → 'bypass'
+     * - `false` → 'default'
+     * - omitted → 'default'
+     */
+    permissionModeOrSkipFlag: PermissionMode | boolean = 'default',
     chromeEnabled = false,
     worktreeMode: WorktreeMode = 'prompt',
     sessionsPath?: string,
@@ -123,7 +142,10 @@ export class SessionManager extends EventEmitter {
   ) {
     super();
     this.workingDir = workingDir;
-    this.skipPermissions = skipPermissions;
+    this.permissionMode =
+      typeof permissionModeOrSkipFlag === 'boolean'
+        ? (permissionModeOrSkipFlag ? 'bypass' : 'default')
+        : permissionModeOrSkipFlag;
     this.chromeEnabled = chromeEnabled;
     this.worktreeMode = worktreeMode;
     this.threadLogsEnabled = threadLogsEnabled;
@@ -246,7 +268,8 @@ export class SessionManager extends EventEmitter {
   getContext(): SessionContext {
     const config: SessionConfig = {
       workingDir: this.workingDir,
-      skipPermissions: this.skipPermissions,
+      permissionMode: this.permissionMode,
+      skipPermissions: this.skipPermissions, // derived from permissionMode
       chromeEnabled: this.chromeEnabled,
       debug: this.debug,
       maxSessions: this.limits.maxSessions,
@@ -769,7 +792,8 @@ export class SessionManager extends EventEmitter {
     await stickyMessage.updateAllStickyMessages(this.platforms, this.registry.getSessions(), {
       maxSessions: this.limits.maxSessions,
       chromeEnabled: this.chromeEnabled,
-      skipPermissions: this.skipPermissions,
+      permissionMode: this.permissionMode,
+      skipPermissions: this.skipPermissions, // derived; kept for backward-compat reads
       worktreeMode: this.worktreeMode,
       workingDir: this.workingDir,
       debug: this.debug,
@@ -797,8 +821,26 @@ export class SessionManager extends EventEmitter {
     this.customFooter = footer;
   }
 
+  /**
+   * Set the effective permission mode.
+   */
+  setPermissionMode(mode: PermissionMode): void {
+    this.permissionMode = mode;
+  }
+
+  /**
+   * @deprecated Use `setPermissionMode` instead. Kept so the headless/UI
+   * toggle entry points don't need to change in lockstep. Maps
+   * `true → 'bypass'`, `false → 'default'`; the `'auto'` mode must be set
+   * via `setPermissionMode`.
+   */
   setSkipPermissions(value: boolean): void {
-    this.skipPermissions = value;
+    this.permissionMode = value ? 'bypass' : 'default';
+  }
+
+  /** Read the effective permission mode (for UI + event payloads). */
+  getPermissionMode(): PermissionMode {
+    return this.permissionMode;
   }
 
   setChromeEnabled(value: boolean): void {
@@ -1136,10 +1178,26 @@ export class SessionManager extends EventEmitter {
     await commands.kickUser(session, kickedUser, kickedBy, this.getContext());
   }
 
-  async enableInteractivePermissions(threadId: string, username: string): Promise<void> {
+  /**
+   * Change the permission mode of an active session. Respawns Claude with the
+   * new mode. Session owner or a globally-allowed user only.
+   */
+  async setSessionPermissionMode(
+    threadId: string,
+    username: string,
+    mode: PermissionMode,
+  ): Promise<void> {
     const session = this.findSessionByThreadId(threadId);
     if (!session) return;
-    await commands.enableInteractivePermissions(session, username, this.getContext());
+    await commands.setSessionPermissionMode(session, username, mode, this.getContext());
+  }
+
+  /**
+   * @deprecated Use `setSessionPermissionMode(threadId, username, 'default')`.
+   * Kept so the `commands/executor.ts` legacy call path keeps working.
+   */
+  async enableInteractivePermissions(threadId: string, username: string): Promise<void> {
+    await this.setSessionPermissionMode(threadId, username, 'default');
   }
 
   async reportBug(threadId: string, description: string | undefined, username: string, files?: PlatformFile[]): Promise<void> {
@@ -1278,7 +1336,7 @@ export class SessionManager extends EventEmitter {
     const session = this.findSessionByThreadId(threadId);
     if (!session) return;
     await worktreeModule.createAndSwitchToWorktree(session, branch, username, {
-      skipPermissions: this.skipPermissions,
+      permissionMode: this.permissionMode,
       chromeEnabled: this.chromeEnabled,
       worktreeMode: this.worktreeMode,
       permissionTimeoutMs: this.limits.permissionTimeoutSeconds * 1000,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -4,6 +4,7 @@
 
 import type { ClaudeCli } from '../claude/cli.js';
 import type { PlatformClient, PlatformFile } from '../platform/index.js';
+import type { PermissionMode } from '../config/index.js';
 import type { WorktreeInfo } from '../persistence/session-store.js';
 import type { SessionInfo } from '../ui/types.js';
 import type { RecentEvent, ErrorContext } from '../operations/bug-report/index.js';
@@ -34,7 +35,7 @@ export interface InitialSessionOptions {
    * resume after bot restart preserves the user's choice (via
    * `Session.forceInteractivePermissions` for the 'default' case).
    */
-  permissionMode?: 'default' | 'auto' | 'bypass';
+  permissionMode?: PermissionMode;
   /**
    * @deprecated Use `permissionMode` instead. Equivalent to
    * `permissionMode: 'default'`. Kept so existing callers keep working.
@@ -270,7 +271,20 @@ export interface Session {
   // Collaboration - per-session allowlist
   sessionAllowedUsers: Set<string>;
 
-  // Permission override - can only downgrade (skip → interactive), not upgrade
+  /**
+   * Sticky session-level opt-in to `permissionMode: 'default'`. When `true`,
+   * this session runs with `default` mode (every tool-use prompts) even if
+   * the bot-wide mode is `auto` or `bypass`, AND the opt-in is preserved
+   * across bot restart (via `PersistedSession.forceInteractivePermissions`).
+   *
+   * Set by `!permissions default` (or the `!permissions interactive` alias).
+   * The `auto` and `bypass` modes are NOT sticky per-session — they revert
+   * to the bot-wide mode on resume.
+   *
+   * Historically this was the only way to express "force-interactive on
+   * this session"; now there are three modes, but only `default` persists
+   * because it's the only strictly-safer-than-default override.
+   */
   forceInteractivePermissions: boolean;
 
   // Display state

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -27,7 +27,18 @@ export { createSessionTimers, clearAllTimers } from './timer-manager.js';
 export interface InitialSessionOptions {
   /** Override working directory (from !cd command) */
   workingDir?: string;
-  /** Force interactive permissions (from !permissions interactive) */
+  /**
+   * Explicit permission mode for this session, overriding the bot-wide default.
+   * Set from `!permissions <mode>` in the first message. When set, the session
+   * starts with this mode AND the session tracks it as a sticky override so
+   * resume after bot restart preserves the user's choice (via
+   * `Session.forceInteractivePermissions` for the 'default' case).
+   */
+  permissionMode?: 'default' | 'auto' | 'bypass';
+  /**
+   * @deprecated Use `permissionMode` instead. Equivalent to
+   * `permissionMode: 'default'`. Kept so existing callers keep working.
+   */
   forceInteractivePermissions?: boolean;
   /** Switch to existing worktree instead of creating new (from !worktree switch) */
   switchToExisting?: boolean;

--- a/tests/integration/suites/session-commands.test.ts
+++ b/tests/integration/suites/session-commands.test.ts
@@ -456,53 +456,51 @@ describe.skipIf(SKIP)('Session Commands', () => {
     });
 
     describe('!permissions Command', () => {
-      it('should enable interactive permissions', async () => {
-        // Note: Bot was started with skipPermissions: true
+      it('should switch to interactive (default) permissions', async () => {
+        // Note: Bot was started with skipPermissions: true (→ bypass mode)
         const rootPost = await startSession(ctx, 'Test permissions command', getBotUsername());
         testThreadIds.push(rootPost.id);
 
         await waitForSessionActive(bot.sessionManager, rootPost.id, { timeout: 10000 });
         await waitForBotResponse(ctx, rootPost.id, { timeout: 30000, minResponses: 1 });
 
-        // Enable interactive permissions
+        // `!permissions interactive` is the legacy alias for the `default` mode.
         await sendCommand(ctx, rootPost.id, '!permissions interactive');
 
-        // Wait for confirmation message (restart takes time)
+        // New confirmation post format: "Permission mode: Default set for this session by @user"
         const confirmPost = await waitForPostMatching(
           ctx,
           rootPost.id,
-          /interactive permissions enabled|permission prompts/i,
+          /permission mode:\s*default/i,
           { timeout: 15000 }
         );
 
         expect(confirmPost).toBeDefined();
-        expect(confirmPost.message).toMatch(/interactive|permission/i);
 
         // Session should still be active (restarted with new permissions)
         expect(bot.sessionManager.isInSessionThread(rootPost.id)).toBe(true);
       });
 
-      it('should reject upgrade to auto permissions', async () => {
+      it('should switch to auto permissions (classifier mode)', async () => {
+        // `auto` is now a supported mode (new in PR #343) — previously rejected.
         const rootPost = await startSession(ctx, 'Test auto permissions', getBotUsername());
         testThreadIds.push(rootPost.id);
 
         await waitForSessionActive(bot.sessionManager, rootPost.id, { timeout: 10000 });
         await waitForBotResponse(ctx, rootPost.id, { timeout: 30000, minResponses: 1 });
 
-        // Try to enable auto permissions (should be rejected)
         await sendCommand(ctx, rootPost.id, '!permissions auto');
 
-        // Wait for rejection message
-        const rejectPost = await waitForPostMatching(
+        const confirmPost = await waitForPostMatching(
           ctx,
           rootPost.id,
-          /cannot upgrade|only downgrade/i,
-          { timeout: 10000 }
+          /permission mode:\s*auto/i,
+          { timeout: 15000 }
         );
 
-        expect(rejectPost).toBeDefined();
-        // Accept either Unicode emoji or shortcode (Mattermost converts for mobile)
-        expect(rejectPost.message).toMatch(/⚠️|:warning:/);
+        expect(confirmPost).toBeDefined();
+        // Session stays active; Claude was respawned with --permission-mode auto.
+        expect(bot.sessionManager.isInSessionThread(rootPost.id)).toBe(true);
       });
 
       it('should only allow session-allowed users to change permissions', async () => {


### PR DESCRIPTION
## Summary

claude-threads modeled permissions as a single boolean (` skipPermissions`) that mapped to either `--dangerously-skip-permissions` (true) or the MCP permission server (false). Claude CLI 2.1.x added `--permission-mode auto` — a classifier that auto-approves low-risk tool uses and escalates high-risk ones to the prompt tool. This PR exposes all three modes.

## Modes

- **`default`** — every tool-use prompts via the MCP permission server. The historical \"interactive\" behavior.
- **`auto`** *(new)* — Claude's classifier decides; low-risk tools auto-approve, high-risk still hit the MCP prompt. Eliminates prompt fatigue for the common case.
- **`bypass`** — no prompts (`--dangerously-skip-permissions`). The historical `skipPermissions: true` behavior.

## Surface

| Surface | Change |
|---|---|
| `config.yaml` | `permissionMode: default | auto | bypass` per platform. Legacy `skipPermissions` kept as alias. |
| CLI flag | `--permission-mode <mode>`. Legacy `--skip-permissions` / `--no-skip-permissions` kept as deprecated aliases. |
| Command | `!permissions default|auto|bypass` + legacy `interactive` / `skip` aliases. |
| Claude spawn | `buildPermissionArgs()` (new, exported, tested) centralizes three-way argv. |
| UI | Sticky message + session header chip via `permissionModeDisplay()` — `🔐 Default` / `⚡ Auto` / `⚠️ Bypass`. |

## Backward compatibility

- Existing `skipPermissions: true` config.yaml files: unchanged behavior (→ `bypass`).
- Existing `skipPermissions: false` config.yaml files: unchanged behavior (→ `default`).
- `Session.forceInteractivePermissions` still honored — a session that opted into `default` via `!permissions` keeps that across restarts even if the bot-wide default is looser. No `sessions.json` schema change.
- `SessionManager.enableInteractivePermissions()` kept as a public alias for `setSessionPermissionMode(threadId, user, 'default')`.

## DRY

Three helpers prevent the display/logic from drifting across call sites:

- `permissionModeDisplay(mode)` — chip/icon strings used by sticky, session header, `!permissions` post.
- `permissionModeDescription(mode)` — human-readable description for the `!permissions` confirmation post.
- `permissionModeForRestart(session, mode)` — the \"bypass-unless-session-forced-default\" formula used by `!cd`, plugin install/uninstall, and worktree switch.

## Tests

+16 new tests. 2085 → 2101 total tests passing. Typecheck + lint clean. Red-green verified for `--permission-mode auto` arg emission.

## Follow-up: latent bug preserved, not fixed

`permissionModeForRestart` preserves a pre-existing quirk from before this PR: on `!cd`, plugin restart, or worktree switch, a session running in `default` or `auto` gets **demoted to ` bypass`** unless it explicitly opted into `default` via `!permissions` (i.e. `session.forceInteractivePermissions === true`).

This is ` permissionMode: ctx.config.permissionMode === 'bypass' || !session.forceInteractivePermissions ? 'bypass' : 'default'` — which ignores the bot-wide `default`/`auto` mode. I left it verbatim rather than smuggle a behavior change into a refactor; tracked for a separate bug-fix PR.

## Testing plan

- [x] `bun test src/` — 2101 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] `npx knip` — only pre-existing hints
- [x] Live smoke: MCP config verified via `ps` (path, not token) and tempfile (mode 0600) during `!permissions default` session (PR #342 behavior preserved)
- [ ] `bun run test:integration` — to run before merge
- [ ] Live smoke: `!permissions auto` actually emits `--permission-mode auto` and lets Claude classifier decide