### PR TITLE
feat: onboarding + UI toggle + docs for three permission modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Three-way permission modes** — `default` | `auto` | `bypass`. Claude CLI 2.1.x introduced a classifier-based `auto` permission mode; claude-threads now exposes it alongside the historical `default` (MCP-prompt-everything) and `bypass` (`--dangerously-skip-permissions`) modes. Set via `permissionMode` in `config.yaml`, the `--permission-mode` CLI flag, or the `!permissions default|auto|bypass` in-session command (legacy `interactive`/`skip` aliases still work). Onboarding wizard now picks `auto` as the recommended default. UI toggle key `[p]` cycles through the three modes. (#343)
+- **Security hardening: MCP config via owner-only tempfile** — the Claude subprocess's MCP permission config contains the bot's platform token. It used to be passed inline on `--mcp-config` argv, exposing the token in `ps`. Now written to a mode-`0600` tempfile and passed by path; cleaned up on Claude exit. Gated by `CLAUDE_THREADS_MCP_CONFIG_INLINE=1` rollback flag for one release. (#342)
+- **Audit log for rejected reactions** — `SessionManager.handleReaction` now emits a structured `reaction.rejected` event when the allowlist check drops a reaction. Observable signal for probing attempts without changing enforcement behavior. (#342)
+- **Bounded aggregate stderr cap across `ClaudeCli` instances** — per-instance 10KB cap stays; under aggregate pressure (>10MB) instances trim to 1KB so a runaway fleet cannot dominate the bot's heap. (#342)
+- **Tunable `flushDelayMs`** — streaming cadence (default 500ms) is now configurable via `limits.flushDelayMs` in `config.yaml`. (#342)
+
+### Changed
+- **Onboarding and UI speak the three-mode language.** The wizard question changed from `Require approval for Claude actions? (Y/n)` to a three-way picker, defaulting to `auto`. The keyboard `[p]erms` indicator in the footer cycles default → auto → bypass with color-coded severity (green/yellow/red) instead of a green/gray on/off chip.
+- **`!permissions` command accepts all three modes** plus legacy aliases. `!permissions interactive` → `default`; `!permissions skip` → `bypass`. The confirmation post shows the canonical mode name and a one-sentence description of what it does.
+- **Sticky message and session header** show the three-mode chip (`🔐 Default`, `⚡ Auto`, `⚠️ Bypass`) consistently. Previously the sticky used `⚡ Auto` to mean bypass.
+
+### Deprecated
+- **`skipPermissions: boolean` in platform config** — keeps working as an alias. `permissionMode: 'default'|'auto'|'bypass'` is the new canonical field. Precedence: `permissionMode` wins when both are set. (#343)
+- **`--skip-permissions` / `--no-skip-permissions` CLI flags** — kept as aliases for `--permission-mode bypass` / `--permission-mode default`. (#343)
+
+### Fixed
+- **`content.ts` thread log lost exception text on updatePost failure** — the refactor that collapsed five try/catch blocks into a `tryUpdatePost` helper in #342 dropped the `error: String(err)` field from the flush-path thread log. Restored. (#342)
+
+### Removed
+- **`src/mattermost/api.ts`** — the standalone REST helpers folded into `src/platform/mattermost/permission-api.ts` (only consumer). Net removal: 194 lines of code + 459 lines of redundant tests; equivalent HTTP-level coverage now lives in `src/platform/mattermost/client.test.ts`. (#342)
+- **`src/config.ts`** — 37 lines of re-exports. `src/config/migration.ts` renamed to `src/config/index.ts` so the config module's entry point reflects what it actually is. (#342)
+- **Internal `skipPermissions` shadow fields** — removed from `SessionConfig`, `ClaudeCliOptions`, `StickyMessageConfig`, and a private `SessionManager` getter once the new `permissionMode` was plumbed end-to-end. (#343)
+
+### Internals
+- **Test coverage floor raised** before the structural refactors above. New test files for MCP permission server, plugin handler, Mattermost client, and permission-API helpers. Existing `lifecycle.test.ts` and `manager.test.ts` expanded for branch coverage. Totals: 1970 → 2101 tests (+131). Coverage on `src/mcp/permission-server.ts`: 0% → 80% lines; `src/operations/plugin/handler.ts`: 0% → 100% funcs; `src/session/lifecycle.ts`: 21% → 31% lines. (#341)
+- **Small testability refactor in `src/mcp/permission-server.ts`** — extracted `handlePermissionWith()` so the permission flow is unit-testable without spinning up the real `PermissionApi` or reading `process.env` at module load. No behavior change. (#341)
+- **5 try/catch blocks in `src/operations/executors/content.ts`** collapsed into a `tryUpdatePost` helper with `onSuccess`/`onFailure` callbacks — keeps the three distinct failure-state reset variants explicit via callbacks rather than hiding them. (#342)
+- **DRY permission-mode helpers**: `permissionModeDisplay`, `permissionModeDescription`, and `permissionModeForRestart` live in `src/config/types.ts` as single sources of truth. A `MODE_INFO: Record<PermissionMode, …>` table backs the display + description helpers. (#343)
+
 ## [1.8.3] - 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 - **Concurrent sessions** - Each thread gets its own Claude session
 - **Session persistence** - Sessions survive bot restarts
 - **Collaboration** - Invite others to participate in your session
-- **Interactive permissions** - Approve Claude's actions via emoji reactions
+- **Permission modes** - Three-way control over Claude's tool-use: `default` (every action prompts for 👍/✅/👎 approval via emoji), `auto` (Claude's classifier auto-approves low-risk; high-risk still prompts — recommended), or `bypass` (no prompts, all tools allowed). Set via config, `--permission-mode` CLI flag, or in-session with `!permissions default|auto|bypass`.
 - **Git worktrees** - Isolate changes in separate branches
 - **File attachments** - Attach images, PDFs, and files for Claude to analyze
 - **Chrome automation** - Control Chrome browser for web tasks

--- a/src/auto-update/types.ts
+++ b/src/auto-update/types.ts
@@ -114,7 +114,17 @@ export type UpdateStatus =
 
 /** Runtime settings that can be toggled via UI */
 export interface RuntimeSettings {
-  /** Skip permission prompts (auto-approve) */
+  /**
+   * Effective permission mode. New code reads this; `skipPermissions` below
+   * is kept as a derived boolean for persisted-settings compatibility with
+   * older daemon restarts.
+   */
+  permissionMode?: 'default' | 'auto' | 'bypass';
+
+  /**
+   * @deprecated Read `permissionMode` instead. Still written for backward
+   * compatibility with older persisted settings files.
+   */
   skipPermissions?: boolean;
 
   /** Enable Claude in Chrome integration */

--- a/src/config/permission-mode-cycle.test.ts
+++ b/src/config/permission-mode-cycle.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'bun:test';
+import { nextPermissionMode, PERMISSION_MODE_CYCLE } from './permission-mode-cycle.js';
+
+describe('nextPermissionMode', () => {
+  it('cycles default → auto → bypass → default', () => {
+    expect(nextPermissionMode('default')).toBe('auto');
+    expect(nextPermissionMode('auto')).toBe('bypass');
+    expect(nextPermissionMode('bypass')).toBe('default');
+  });
+
+  it('covers every mode in the cycle exactly once before repeating', () => {
+    const seen = new Set<string>();
+    let mode = PERMISSION_MODE_CYCLE[0];
+    for (let i = 0; i < PERMISSION_MODE_CYCLE.length; i++) {
+      seen.add(mode);
+      mode = nextPermissionMode(mode);
+    }
+    expect(seen.size).toBe(PERMISSION_MODE_CYCLE.length);
+    // After a full rotation we're back to the start.
+    expect(mode).toBe(PERMISSION_MODE_CYCLE[0]);
+  });
+
+  it('defensively falls back to the first mode on an unknown input', () => {
+    // Not reachable at the type level; this guards against malformed
+    // runtime data (e.g. a future mode added to persisted settings).
+    expect(nextPermissionMode('something-unknown' as never)).toBe(PERMISSION_MODE_CYCLE[0]);
+  });
+});

--- a/src/config/permission-mode-cycle.ts
+++ b/src/config/permission-mode-cycle.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure helpers for cycling through permission modes — used by the UI toggle
+ * (keyboard `[p]` rotates default → auto → bypass → default) and by any
+ * other place that wants to advance/step through the modes deterministically.
+ *
+ * Kept in its own file so the cycle order is a single source of truth and
+ * can be unit-tested without importing the Ink UI tree.
+ */
+
+import type { PermissionMode } from './types.js';
+
+/** Order in which the keyboard toggle cycles. */
+export const PERMISSION_MODE_CYCLE: readonly PermissionMode[] = [
+  'default',
+  'auto',
+  'bypass',
+] as const;
+
+/**
+ * Return the next mode in the cycle, wrapping back to the start after the last.
+ * Unknown inputs (defensive; should not happen at the type level) fall back
+ * to the first cycle entry.
+ */
+export function nextPermissionMode(current: PermissionMode): PermissionMode {
+  const idx = PERMISSION_MODE_CYCLE.indexOf(current);
+  if (idx === -1) return PERMISSION_MODE_CYCLE[0];
+  return PERMISSION_MODE_CYCLE[(idx + 1) % PERMISSION_MODE_CYCLE.length];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,7 +327,6 @@ async function startWithoutDaemon() {
       cliArgs.skipPermissions
       ?? firstPlatformConfig.skipPermissions,
   });
-  const initialSkipPermissions = initialPermissionMode === 'bypass';
 
   // Check Claude CLI version
   const claudeValidation = validateClaudeCli();
@@ -380,10 +379,17 @@ async function startWithoutDaemon() {
   }
 
   // Mutable runtime config (can be changed via keyboard toggles)
-  // These affect new sessions and sticky message display
-  // On daemon restart, restore previous settings; otherwise use config defaults
+  // These affect new sessions and sticky message display.
+  // On daemon restart, restore previous settings; otherwise use config
+  // defaults. `permissionMode` is the source of truth; `skipPermissions` is
+  // the derived boolean kept around for any legacy persisted-settings reader.
+  const restoredPermissionMode: PermissionMode = restoredSettings?.permissionMode
+    ?? (restoredSettings?.skipPermissions === true ? 'bypass'
+      : restoredSettings?.skipPermissions === false ? 'default'
+      : initialPermissionMode);
   const runtimeConfig = {
-    skipPermissions: restoredSettings?.skipPermissions ?? initialSkipPermissions,
+    permissionMode: restoredPermissionMode,
+    skipPermissions: restoredPermissionMode === 'bypass',
     chromeEnabled: restoredSettings?.chromeEnabled ?? (config.chrome ?? false),
     keepAliveEnabled: restoredSettings?.keepAliveEnabled ?? keepAliveEnabled,
   };
@@ -404,7 +410,7 @@ async function startWithoutDaemon() {
       workingDir,
       claudeVersion: claudeValidation.version || 'unknown',
       claudeCompatible: claudeValidation.compatible,
-      skipPermissions: runtimeConfig.skipPermissions,
+      permissionMode: runtimeConfig.permissionMode,
       chromeEnabled: runtimeConfig.chromeEnabled,
       keepAliveEnabled: runtimeConfig.keepAliveEnabled,
     },
@@ -421,17 +427,26 @@ async function startWithoutDaemon() {
         // Trigger sticky message update to reflect debug state
         sessionManager?.updateAllStickyMessages();
       },
-      onPermissionsToggle: (skipPermissions) => {
-        runtimeConfig.skipPermissions = skipPermissions;
-        // Persist for daemon restart
-        saveRuntimeSettings({ ...getRuntimeSettings(), skipPermissions });
-        // Update ALL platform configs so new sessions use this setting
+      onPermissionsToggle: (mode) => {
+        runtimeConfig.permissionMode = mode;
+        // Persist for daemon restart. We also write the legacy
+        // `skipPermissions` boolean (derived) so older daemon-restart paths
+        // that still read it keep working; precedence in resolvePermissionMode
+        // keeps `permissionMode` authoritative on next startup.
+        saveRuntimeSettings({
+          ...getRuntimeSettings(),
+          permissionMode: mode,
+          skipPermissions: mode === 'bypass',
+        });
+        // Update ALL platform configs so new sessions use this setting.
         for (const platformConfig of config.platforms) {
-          (platformConfig as MattermostPlatformConfig | SlackPlatformConfig).skipPermissions = skipPermissions;
+          const pc = platformConfig as MattermostPlatformConfig | SlackPlatformConfig;
+          pc.permissionMode = mode;
+          pc.skipPermissions = mode === 'bypass';
         }
         // Update SessionManager's internal state for sticky message
-        sessionManager?.setSkipPermissions(skipPermissions);
-        ui.addLog({ level: 'info', component: 'toggle', message: `Permissions ${skipPermissions ? 'auto (skip prompts)' : 'interactive'}` });
+        sessionManager?.setPermissionMode(mode);
+        ui.addLog({ level: 'info', component: 'toggle', message: `Permission mode: ${mode}` });
         sessionManager?.updateAllStickyMessages();
       },
       onChromeToggle: (enabled) => {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -8,14 +8,46 @@ import {
   CONFIG_PATH,
   saveConfig,
   LIMITS_DEFAULTS,
+  resolvePermissionMode,
+  permissionModeDisplay,
   type Config,
   type PlatformInstanceConfig,
   type MattermostPlatformConfig,
   type SlackPlatformConfig,
   type LimitsConfig,
+  type PermissionMode,
 } from './config/index.js';
 import { bold, dim, green } from './utils/colors.js';
 import { validateClaudeCli } from './claude/version-check.js';
+
+/**
+ * Common choices list for the three-way permission-mode picker, reused by
+ * both the Mattermost and Slack platform flows. `auto` is the recommended
+ * default — Claude's classifier handles low-risk tool-uses so operators
+ * aren't desensitized by prompt fatigue, while high-risk tool-uses still
+ * fall through to human approval via the MCP server.
+ */
+const PERMISSION_MODE_CHOICES = [
+  {
+    title: 'Auto (recommended)',
+    value: 'auto' as PermissionMode,
+    description: 'Classifier auto-approves low-risk; high-risk tools still prompt via reactions',
+  },
+  {
+    title: 'Default',
+    value: 'default' as PermissionMode,
+    description: 'Every tool-use prompts — strictest mode, can be noisy for everyday work',
+  },
+  {
+    title: 'Bypass',
+    value: 'bypass' as PermissionMode,
+    description: 'No prompts, all tools allowed — use only in trusted environments',
+  },
+];
+
+function permissionModeChoiceIndex(mode: PermissionMode): number {
+  return PERMISSION_MODE_CHOICES.findIndex((c) => c.value === mode);
+}
 
 // Get the path to the Slack app manifest file
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -731,7 +763,7 @@ async function showConfigSummary(config: Config): Promise<void> {
         ? mm.allowedUsers.join(', ')
         : 'ANYONE (⚠️  no restrictions)';
       console.log(dim(`      Allowed Users: ${allowedUsers}`));
-      console.log(dim(`      Auto-approve: ${mm.skipPermissions ? 'Yes' : 'No (interactive)'}`));
+      console.log(dim(`      Permission Mode: ${permissionModeDisplay(resolvePermissionMode({ permissionMode: mm.permissionMode, skipPermissions: mm.skipPermissions })).chip}`));
     } else {
       const slack = platform as SlackPlatformConfig;
       console.log(dim(`      Channel: ${slack.channelId}`));
@@ -741,7 +773,7 @@ async function showConfigSummary(config: Config): Promise<void> {
         ? slack.allowedUsers.join(', ')
         : 'ANYONE (⚠️  no restrictions)';
       console.log(dim(`      Allowed Users: ${allowedUsers}`));
-      console.log(dim(`      Auto-approve: ${slack.skipPermissions ? 'Yes' : 'No (interactive)'}`));
+      console.log(dim(`      Permission Mode: ${permissionModeDisplay(resolvePermissionMode({ permissionMode: slack.permissionMode, skipPermissions: slack.skipPermissions })).chip}`));
     }
   }
 
@@ -982,7 +1014,15 @@ async function setupMattermostPlatform(
   let lastChannelId = existingMattermost?.channelId || '';
   let lastBotName = existingMattermost?.botName || 'claude-code';
   let lastAllowedUsers = existingMattermost?.allowedUsers?.join(',') || '';
-  let lastRequireApproval = existingMattermost ? !existingMattermost.skipPermissions : true;
+  // New configs default to `auto` (the onboarding recommendation). Existing
+  // configs keep whatever they had — never silently change an operator's
+  // permission posture during reconfigure.
+  let lastPermissionMode: PermissionMode = existingMattermost
+    ? resolvePermissionMode({
+        permissionMode: existingMattermost.permissionMode,
+        skipPermissions: existingMattermost.skipPermissions,
+      })
+    : 'auto';
 
   // Main loop - allows retrying when validation fails
   while (true) {
@@ -1098,13 +1138,13 @@ async function setupMattermostPlatform(
       }
     }
 
-    // Now ask about approval (after user access is settled)
-    const { requireApproval } = await prompts({
-      type: 'confirm',
-      name: 'requireApproval',
-      message: 'Require approval for Claude actions?',
-      initial: lastRequireApproval,
-      hint: 'Yes = approve via reactions (recommended), No = auto-approve everything',
+    // Now ask about permission mode (after user access is settled)
+    const { permissionMode } = await prompts({
+      type: 'select',
+      name: 'permissionMode',
+      message: 'Permission mode for Claude tool-uses?',
+      choices: PERMISSION_MODE_CHOICES,
+      initial: permissionModeChoiceIndex(lastPermissionMode),
     }, { onCancel });
 
     // Save entered values for potential retry
@@ -1114,7 +1154,7 @@ async function setupMattermostPlatform(
     lastChannelId = basicSettings.channelId;
     lastBotName = basicSettings.botName;
     lastAllowedUsers = allowedUsers.join(',');
-    lastRequireApproval = requireApproval;
+    lastPermissionMode = permissionMode;
 
     // Validate credentials
     console.log('');
@@ -1184,7 +1224,7 @@ async function setupMattermostPlatform(
       channelId: basicSettings.channelId,
       botName: basicSettings.botName,
       allowedUsers,
-      skipPermissions: !requireApproval,
+      permissionMode: lastPermissionMode,
     };
   }
 }
@@ -1364,7 +1404,12 @@ async function setupSlackPlatform(
   let lastChannelId = existingSlack?.channelId || '';
   let lastBotName = existingSlack?.botName || 'claude';
   let lastAllowedUsers = existingSlack?.allowedUsers?.join(',') || '';
-  let lastRequireApproval = existingSlack ? !existingSlack.skipPermissions : true;
+  let lastPermissionMode: PermissionMode = existingSlack
+    ? resolvePermissionMode({
+        permissionMode: existingSlack.permissionMode,
+        skipPermissions: existingSlack.skipPermissions,
+      })
+    : 'auto';
 
   // Main loop - allows retrying when validation fails
   while (true) {
@@ -1488,13 +1533,13 @@ async function setupSlackPlatform(
       }
     }
 
-    // Now ask about approval (after user access is settled)
-    const { requireApproval } = await prompts({
-      type: 'confirm',
-      name: 'requireApproval',
-      message: 'Require approval for Claude actions?',
-      initial: lastRequireApproval,
-      hint: 'Yes = approve via reactions (recommended), No = auto-approve everything',
+    // Now ask about permission mode (after user access is settled)
+    const { permissionMode } = await prompts({
+      type: 'select',
+      name: 'permissionMode',
+      message: 'Permission mode for Claude tool-uses?',
+      choices: PERMISSION_MODE_CHOICES,
+      initial: permissionModeChoiceIndex(lastPermissionMode),
     }, { onCancel });
 
     // Save entered values for potential retry
@@ -1504,7 +1549,7 @@ async function setupSlackPlatform(
     lastChannelId = basicSettings.channelId;
     lastBotName = basicSettings.botName;
     lastAllowedUsers = allowedUsers.join(',');
-    lastRequireApproval = requireApproval;
+    lastPermissionMode = permissionMode;
 
     // Validate credentials
     console.log('');
@@ -1580,7 +1625,7 @@ async function setupSlackPlatform(
       channelId: basicSettings.channelId,
       botName: basicSettings.botName,
       allowedUsers,
-      skipPermissions: !requireApproval,
+      permissionMode: lastPermissionMode,
     };
   }
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -29,6 +29,7 @@ import { OverlayModal } from './components/OverlayModal.js';
 import { useAppState } from './hooks/useAppState.js';
 import { useKeyboard } from './hooks/useKeyboard.js';
 import type { AppConfig, SessionInfo, LogEntry, PlatformStatus, ToggleState, ToggleCallbacks, UpdatePanelState } from './types.js';
+import { nextPermissionMode } from '../config/permission-mode-cycle.js';
 
 interface AppProps {
   config: AppConfig;
@@ -77,7 +78,7 @@ export function App({ config, onStateReady, onResizeReady, onQuit, toggleCallbac
   // Runtime toggle state - initialized from config
   const [toggles, setToggles] = React.useState<ToggleState>({
     debugMode: process.env.DEBUG === '1',
-    skipPermissions: config.skipPermissions,
+    permissionMode: config.permissionMode,
     chromeEnabled: config.chromeEnabled,
     keepAliveEnabled: config.keepAliveEnabled,
     updateModalVisible: false,
@@ -106,9 +107,9 @@ export function App({ config, onStateReady, onResizeReady, onQuit, toggleCallbac
 
   const handlePermissionsToggle = React.useCallback(() => {
     setToggles(prev => {
-      const newValue = !prev.skipPermissions;
-      toggleCallbacks?.onPermissionsToggle?.(newValue);
-      return { ...prev, skipPermissions: newValue };
+      const newMode = nextPermissionMode(prev.permissionMode);
+      toggleCallbacks?.onPermissionsToggle?.(newMode);
+      return { ...prev, permissionMode: newMode };
     });
   }, [toggleCallbacks]);
 

--- a/src/ui/components/Footer.tsx
+++ b/src/ui/components/Footer.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { Box, Text } from 'ink';
 import { Spinner } from './Spinner.js';
 import type { ToggleState, PlatformStatus, UpdatePanelState } from '../types.js';
+import { permissionModeDisplay } from '../../config/index.js';
 
 interface FooterProps {
   ready: boolean;
@@ -33,6 +34,26 @@ function ToggleKey({ keyChar, label, enabled, color }: {
       <Text color={displayColor} bold>{keyChar}</Text>
       <Text dimColor>]</Text>
       <Text color={displayColor}>{label}</Text>
+    </Box>
+  );
+}
+
+/**
+ * Three-way permission-mode indicator bound to the `p` key. Cycles through
+ * default → auto → bypass → default. Color-codes the severity of each mode:
+ * green for 'default' (strictest), yellow for 'auto', red for 'bypass'.
+ */
+function PermissionModeKey({ mode }: { mode: 'default' | 'auto' | 'bypass' }) {
+  const color =
+    mode === 'default' ? 'green' :
+    mode === 'auto'    ? 'yellow' :
+    /* bypass */        'red';
+  return (
+    <Box gap={0}>
+      <Text dimColor>[</Text>
+      <Text color={color} bold>p</Text>
+      <Text dimColor>]</Text>
+      <Text color={color}>erms:{permissionModeDisplay(mode).label.toLowerCase()}</Text>
     </Box>
   );
 }
@@ -107,7 +128,10 @@ export function Footer({
 
             {/* Core toggles */}
             <ToggleKey keyChar="d" label="ebug" enabled={toggles.debugMode} />
-            <ToggleKey keyChar="p" label="erms" enabled={!toggles.skipPermissions} />
+            {/* Three-way permission-mode display. Green for 'default'
+                (safest), yellow for 'auto', red-ish for 'bypass' to flag
+                the weaker setting at a glance. */}
+            <PermissionModeKey mode={toggles.permissionMode} />
             <ToggleKey keyChar="c" label="hrome" enabled={toggles.chromeEnabled} />
             <ToggleKey keyChar="k" label="eep" enabled={toggles.keepAliveEnabled} />
             <ToggleKey keyChar="l" label="ogs" enabled={toggles.logsFocused} color={toggles.logsFocused ? 'cyan' : 'gray'} />

--- a/src/ui/providers/headless-provider.ts
+++ b/src/ui/providers/headless-provider.ts
@@ -27,7 +27,7 @@ export class HeadlessProvider implements UIProvider {
     // Initialize toggles from config
     this.toggles = {
       debugMode: process.env.DEBUG === '1',
-      skipPermissions: options.config.skipPermissions,
+      permissionMode: options.config.permissionMode,
       chromeEnabled: options.config.chromeEnabled,
       keepAliveEnabled: options.config.keepAliveEnabled,
       updateModalVisible: false,

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -1,6 +1,7 @@
 /**
  * Types for the Ink-based CLI UI
  */
+import type { PermissionMode } from '../config/index.js';
 
 export interface SessionInfo {
   id: string;
@@ -49,7 +50,7 @@ export interface AppConfig {
   workingDir: string;
   claudeVersion: string;
   claudeCompatible: boolean;
-  skipPermissions: boolean;
+  permissionMode: PermissionMode;
   chromeEnabled: boolean;
   keepAliveEnabled: boolean;
 }
@@ -71,7 +72,8 @@ export interface UpdatePanelState {
  */
 export interface ToggleState {
   debugMode: boolean;
-  skipPermissions: boolean;  // Default for new sessions
+  /** Default permission mode for new sessions (bot-wide). */
+  permissionMode: PermissionMode;
   chromeEnabled: boolean;    // Default for new sessions
   keepAliveEnabled: boolean;
   updateModalVisible: boolean;  // Whether the update modal is shown
@@ -83,7 +85,12 @@ export interface ToggleState {
  */
 export interface ToggleCallbacks {
   onDebugToggle?: (enabled: boolean) => void;
-  onPermissionsToggle?: (skipPermissions: boolean) => void;
+  /**
+   * Fires when the user cycles the permission-mode keyboard toggle. The new
+   * mode is one of `'default' | 'auto' | 'bypass'`; callers should update
+   * runtime config + persist for daemon restart.
+   */
+  onPermissionsToggle?: (mode: PermissionMode) => void;
   onChromeToggle?: (enabled: boolean) => void;
   onKeepAliveToggle?: (enabled: boolean) => void;
   onPlatformToggle?: (platformId: string, enabled: boolean) => void;


### PR DESCRIPTION
## Summary

User-facing follow-ups to PR #343. Onboarding and the keyboard UI now speak the three-mode language. CHANGELOG + README updated.

## What's in

### Onboarding wizard (`src/onboarding.ts`)

- Replaces the boolean \"Require approval?\" prompt with a three-way select picker.
- **`auto` is the recommended default** for new configs. Reasoning: `default` trains users to reflex-click 👍 (security fatigue); `auto` + classifier keeps human review for the calls that matter while keeping productivity high for the trivial ones.
- Existing configs keep their mode on reconfigure — never silently change an operator's permission posture.
- Summary line shows the canonical chip (`🔐 Default` / `⚡ Auto` / `⚠️ Bypass`).

### UI toggle (`src/ui/App.tsx`, `Footer.tsx`, `types.ts`)

- Keyboard `[p]` used to flip skipPermissions on/off. Now cycles **default → auto → bypass → default**.
- Footer indicator shows the current mode name with color-coded severity: green for `default`, yellow for `auto`, red for `bypass`.
- `ToggleCallbacks.onPermissionsToggle(PermissionMode)` replaces the old boolean signature.
- New `src/config/permission-mode-cycle.ts` module owns the cycle order as a single source of truth — imported by `App.tsx`, covered by 3 targeted tests.

### Runtime settings (`src/auto-update/types.ts`, `src/index.ts`)

- `RuntimeSettings.permissionMode` added alongside legacy `skipPermissions`. The UI toggle callback writes both, so new restarts read `permissionMode` (authoritative) and old restarts that still read `skipPermissions` keep working.
- `runtimeConfig` in `src/index.ts` tracks `permissionMode` explicitly; `skipPermissions` stays as a derived boolean.

### Docs

- `CHANGELOG.md`: new `[Unreleased]` entry covering PRs #341, #342, #343, and this follow-up. Organized Keep-a-Changelog style.
- `README.md`: feature bullet updated from \"Interactive permissions\" (two-way) to describe the three-way model with CLI flag, config field, and `!permissions` command surfaces.

## Verification

- [x] `bun test src/` — 2104 pass, 0 fail (+3 new)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] `bun run test:integration` — runs in CI
- [ ] Live smoke: `[p]` in headless mode cycles correctly; `!permissions auto` in a thread respawns Claude with `--permission-mode auto`

## Backward compatibility

100%:
- Existing `config.yaml` with `skipPermissions` untouched — loads and maps correctly via `resolvePermissionMode`.
- `sessions.json` schema unchanged.
- Legacy `--skip-permissions` / `--no-skip-permissions` CLI flags still accepted.
- `RuntimeSettings.skipPermissions` still written on UI toggle for older daemon restarts.