### PR TITLE
fix: three permission-mode bugs from live smoke

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -210,13 +210,13 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
   },
   {
     command: 'permissions',
-    description: 'Toggle permission prompts',
-    args: 'interactive|skip',
+    description: 'Set permission mode (default prompts; auto lets Claude classify; bypass skips all)',
+    args: 'default / auto / bypass',
     category: 'settings',
     audience: 'user',
     claudeNotes: 'User decisions, not yours',
     worksInFirstMessage: true,
-    isStackable: true,  // !permissions interactive can be followed by more commands or prompt
+    isStackable: true,  // !permissions <mode> can be followed by more commands or prompt
   },
 
   // ---------------------------------------------------------------------------

--- a/src/config/index.test.ts
+++ b/src/config/index.test.ts
@@ -5,7 +5,7 @@ import {
   resolvePermissionMode,
   permissionModeDisplay,
   permissionModeDescription,
-  permissionModeForRestart,
+  effectivePermissionMode,
 } from './index.js';
 import { rmSync, existsSync, statSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import yaml from 'js-yaml';
@@ -275,19 +275,24 @@ describe('permissionModeDescription', () => {
   });
 });
 
-describe('permissionModeForRestart', () => {
-  it("bypass: respawn stays 'bypass' regardless of session override", () => {
-    expect(permissionModeForRestart(false, 'bypass')).toBe('bypass');
-    expect(permissionModeForRestart(true, 'bypass')).toBe('bypass');
+describe('effectivePermissionMode', () => {
+  const noOverride = undefined;
+
+  it('returns bot-wide mode when no session-level overrides are set', () => {
+    expect(effectivePermissionMode({ override: noOverride, sessionHasInteractiveOverride: false, botWideMode: 'default' })).toBe('default');
+    expect(effectivePermissionMode({ override: noOverride, sessionHasInteractiveOverride: false, botWideMode: 'auto' })).toBe('auto');
+    expect(effectivePermissionMode({ override: noOverride, sessionHasInteractiveOverride: false, botWideMode: 'bypass' })).toBe('bypass');
   });
 
-  it("session without override: respawn inherits the current mode verbatim", () => {
-    expect(permissionModeForRestart(false, 'default')).toBe('default');
-    expect(permissionModeForRestart(false, 'auto')).toBe('auto');
+  it('forceInteractivePermissions forces default, even over auto or bypass bot-wide', () => {
+    expect(effectivePermissionMode({ override: noOverride, sessionHasInteractiveOverride: true, botWideMode: 'default' })).toBe('default');
+    expect(effectivePermissionMode({ override: noOverride, sessionHasInteractiveOverride: true, botWideMode: 'auto' })).toBe('default');
+    expect(effectivePermissionMode({ override: noOverride, sessionHasInteractiveOverride: true, botWideMode: 'bypass' })).toBe('default');
   });
 
-  it("session with forceInteractivePermissions=true: respawn is 'default' (the user opted in)", () => {
-    expect(permissionModeForRestart(true, 'default')).toBe('default');
-    expect(permissionModeForRestart(true, 'auto')).toBe('default');
+  it('explicit override wins over both sticky flag and bot-wide', () => {
+    expect(effectivePermissionMode({ override: 'auto', sessionHasInteractiveOverride: false, botWideMode: 'bypass' })).toBe('auto');
+    expect(effectivePermissionMode({ override: 'bypass', sessionHasInteractiveOverride: true, botWideMode: 'default' })).toBe('bypass');
+    expect(effectivePermissionMode({ override: 'default', sessionHasInteractiveOverride: false, botWideMode: 'auto' })).toBe('default');
   });
 });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,7 +26,7 @@ export {
   resolvePermissionMode,
   permissionModeDisplay,
   permissionModeDescription,
-  permissionModeForRestart,
+  effectivePermissionMode,
 } from './types.js';
 
 import type { Config, WorktreeMode as WorktreeModeType, PermissionMode } from './types.js';

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -250,32 +250,28 @@ export function permissionModeDescription(mode: PermissionMode): string {
 }
 
 /**
- * Mode to spawn Claude with when respawning an existing session (because of
- * `!cd`, plugin install/uninstall, or worktree switch).
+ * Compute a session's effective permission mode.
  *
- * Semantics:
- * - If the bot-wide mode is `'bypass'` (permissions globally off), the
- *   respawn stays `'bypass'` — a global bypass isn't selectively re-tightened
- *   per-session.
- * - If the session explicitly opted into `'default'` via `!permissions`
- *   (i.e. `forceInteractivePermissions === true`), the respawn stays
- *   `'default'` — the user's opt-in is sticky.
- * - Otherwise, the respawn inherits the current mode verbatim. A session
- *   running in `'auto'` stays in `'auto'` after `!cd`.
+ * Precedence (highest wins):
+ *   1. `override` — explicit in-process override set by `!permissions <mode>`
+ *      on this session. Not persisted.
+ *   2. `sessionHasInteractiveOverride` — sticky `default` opt-in flag
+ *      (persists across bot restart via `PersistedSession.forceInteractivePermissions`).
+ *   3. `botWideMode` — the bot's current default mode.
  *
- * The pre-PR-343 formula was
- * `skipPermissions: ctx.config.skipPermissions || !session.forceInteractivePermissions`,
- * which also demoted `'default'` sessions to `'bypass'` unless the user had
- * explicitly opted in. Now that the bot knows about three modes the demotion
- * is unnecessary; the function just honors the current mode.
+ * Used both for user-facing display (session header, `isSessionInteractive`)
+ * and for choosing the mode when respawning Claude after `!cd` / plugin
+ * install/uninstall / worktree switch. In both cases the semantic is the
+ * same: "what mode should THIS session run under right now?"
  */
-export function permissionModeForRestart(
-  sessionHasInteractiveOverride: boolean,
-  currentMode: PermissionMode,
-): PermissionMode {
-  if (currentMode === 'bypass') return 'bypass';
-  if (sessionHasInteractiveOverride) return 'default';
-  return currentMode;
+export function effectivePermissionMode(input: {
+  override?: PermissionMode;
+  sessionHasInteractiveOverride: boolean;
+  botWideMode: PermissionMode;
+}): PermissionMode {
+  if (input.override) return input.override;
+  if (input.sessionHasInteractiveOverride) return 'default';
+  return input.botWideMode;
 }
 
 // =============================================================================

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -11,7 +11,7 @@ import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../../claude/c
 import {
   permissionModeDisplay,
   permissionModeDescription,
-  permissionModeForRestart,
+  effectivePermissionMode,
 } from '../../config/index.js';
 import type { PermissionMode } from '../../config/index.js';
 import { handleRateLimit } from '../../session/lifecycle.js';
@@ -385,8 +385,12 @@ export async function changeDirectory(
   const cliOptions: ClaudeCliOptions = {
     workingDir: absoluteDir,
     threadId: session.threadId,
-    // Preserve the pre-existing formula (see `permissionModeForRestart`).
-    permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
+    // Keep the session in its current effective mode across the respawn.
+    permissionMode: effectivePermissionMode({
+      override: session.permissionModeOverride,
+      sessionHasInteractiveOverride: session.forceInteractivePermissions,
+      botWideMode: ctx.config.permissionMode,
+    }),
     sessionId: newSessionId,
     resume: false, // Fresh start - can't resume across directories
     chrome: ctx.config.chromeEnabled,
@@ -530,10 +534,14 @@ export async function setSessionPermissionMode(
     return;
   }
 
-  // Sticky-override flag: only 'default' (interactive) carries across restarts
-  // as a session-scoped override. 'auto' and 'bypass' revert to bot-wide mode
-  // on bot restart. This matches pre-existing behavior of
-  // `forceInteractivePermissions`.
+  // Two flags track the mode for this session:
+  // - `permissionModeOverride` captures the current in-process mode. It's
+  //   used by the session header, `isSessionInteractive`, and any code that
+  //   asks "what mode is THIS session in?". Not persisted.
+  // - `forceInteractivePermissions` is the sticky legacy flag that only
+  //   encodes the `default` opt-in. Persists across bot restart so a user
+  //   who opted into `default` doesn't silently lose it on resume.
+  session.permissionModeOverride = mode;
   session.forceInteractivePermissions = mode === 'default';
 
   sessionLog(session).info(`🔐 Setting permission mode to "${mode}"`);
@@ -637,12 +645,11 @@ export async function updateSessionHeader(
     ? { path: session.worktreeInfo.worktreePath, branch: session.worktreeInfo.branch }
     : undefined;
   const shortDir = shortenPath(session.workingDir, undefined, worktreeContext);
-  // Effective permission mode for this session: session-scoped interactive
-  // override (legacy forceInteractivePermissions === 'default' sticky) wins
-  // over the bot-wide mode. 'auto' and 'bypass' are not sticky per-session.
-  const effectiveMode = session.forceInteractivePermissions
-    ? 'default'
-    : ctx.config.permissionMode;
+  const effectiveMode = effectivePermissionMode({
+    override: session.permissionModeOverride,
+    sessionHasInteractiveOverride: session.forceInteractivePermissions,
+    botWideMode: ctx.config.permissionMode,
+  });
   const permMode = permissionModeDisplay(effectiveMode).chip;
 
   // Build participants list (excluding owner)

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -539,12 +539,19 @@ export async function setSessionPermissionMode(
   sessionLog(session).info(`🔐 Setting permission mode to "${mode}"`);
   session.threadLogger?.logCommand('permissions', mode, username);
 
+  // If Claude has never responded (user ran `!permissions` before the first
+  // turn), there is nothing to resume — Claude CLI will reject `--resume
+  // <uuid>` with "No conversation found with session ID". In that case we
+  // start fresh under the same UUID so the chat thread continuity is
+  // preserved (it lives in the platform, not Claude).
+  const canResume = session.lifecycle.hasClaudeResponded;
+
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
     permissionMode: mode,
     sessionId: session.claudeSessionId,
-    resume: true,
+    resume: canResume,
     chrome: ctx.config.chromeEnabled,
     platformConfig: session.platform.getMcpConfig(),
     logSessionId: session.sessionId,

--- a/src/operations/plugin/handler.ts
+++ b/src/operations/plugin/handler.ts
@@ -120,13 +120,16 @@ export async function handlePluginInstall(
     `✅ Plugin installed: ${formatter.formatCode(pluginName)}\n🔄 Restarting Claude to load plugin...`
   );
 
-  // Build CLI options from session state (can't access private session.claude.options)
+  // Build CLI options from session state (can't access private session.claude.options).
+  // Only resume when Claude has actually responded — an early restart (e.g.
+  // plugin install before the first turn) has no conversation to resume and
+  // Claude CLI rejects `--resume <uuid>` with "No conversation found".
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
     permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
     sessionId: session.claudeSessionId,
-    resume: true, // Resume to keep conversation context
+    resume: session.lifecycle.hasClaudeResponded,
     chrome: ctx.config.chromeEnabled,
     platformConfig: session.platform.getMcpConfig(),
     logSessionId: session.sessionId,
@@ -178,13 +181,16 @@ export async function handlePluginUninstall(
     `✅ Plugin uninstalled: ${formatter.formatCode(pluginName)}\n🔄 Restarting Claude...`
   );
 
-  // Build CLI options from session state (can't access private session.claude.options)
+  // Build CLI options from session state (can't access private session.claude.options).
+  // Only resume when Claude has actually responded — an early restart (e.g.
+  // plugin install before the first turn) has no conversation to resume and
+  // Claude CLI rejects `--resume <uuid>` with "No conversation found".
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
     permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
     sessionId: session.claudeSessionId,
-    resume: true, // Resume to keep conversation context
+    resume: session.lifecycle.hasClaudeResponded,
     chrome: ctx.config.chromeEnabled,
     platformConfig: session.platform.getMcpConfig(),
     logSessionId: session.sessionId,

--- a/src/operations/plugin/handler.ts
+++ b/src/operations/plugin/handler.ts
@@ -9,7 +9,7 @@ import { crossSpawn } from '../../utils/spawn.js';
 import type { Session } from '../../session/types.js';
 import type { SessionContext } from '../session-context/index.js';
 import type { ClaudeCliOptions } from '../../claude/cli.js';
-import { permissionModeForRestart } from '../../config/index.js';
+import { effectivePermissionMode } from '../../config/index.js';
 import { post, postError } from '../post-helpers/index.js';
 import { restartClaudeSession } from '../commands/index.js';
 import { createLogger } from '../../utils/logger.js';
@@ -127,7 +127,11 @@ export async function handlePluginInstall(
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
-    permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
+    permissionMode: effectivePermissionMode({
+      override: session.permissionModeOverride,
+      sessionHasInteractiveOverride: session.forceInteractivePermissions,
+      botWideMode: ctx.config.permissionMode,
+    }),
     sessionId: session.claudeSessionId,
     resume: session.lifecycle.hasClaudeResponded,
     chrome: ctx.config.chromeEnabled,
@@ -188,7 +192,11 @@ export async function handlePluginUninstall(
   const cliOptions: ClaudeCliOptions = {
     workingDir: session.workingDir,
     threadId: session.threadId,
-    permissionMode: permissionModeForRestart(session.forceInteractivePermissions, ctx.config.permissionMode),
+    permissionMode: effectivePermissionMode({
+      override: session.permissionModeOverride,
+      sessionHasInteractiveOverride: session.forceInteractivePermissions,
+      botWideMode: ctx.config.permissionMode,
+    }),
     sessionId: session.claudeSessionId,
     resume: session.lifecycle.hasClaudeResponded,
     chrome: ctx.config.chromeEnabled,

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -7,7 +7,7 @@
 import type { Session } from '../../session/types.js';
 import { transitionTo } from '../../session/types.js';
 import type { WorktreeMode, PermissionMode } from '../../config/index.js';
-import { permissionModeForRestart } from '../../config/index.js';
+import { effectivePermissionMode } from '../../config/index.js';
 import type { PlatformFile } from '../../platform/index.js';
 import { suggestBranchNames } from '../suggestions/branch.js';
 import {
@@ -474,7 +474,11 @@ export async function createAndSwitchToWorktree(
         const cliOptions: ClaudeCliOptions = {
           workingDir: existing.path,
           threadId: session.threadId,
-          permissionMode: permissionModeForRestart(session.forceInteractivePermissions, options.permissionMode),
+          permissionMode: effectivePermissionMode({
+            override: session.permissionModeOverride,
+            sessionHasInteractiveOverride: session.forceInteractivePermissions,
+            botWideMode: options.permissionMode,
+          }),
           sessionId: newSessionId,
           resume: false,
           chrome: options.chromeEnabled,
@@ -620,7 +624,11 @@ export async function createAndSwitchToWorktree(
       const cliOptions: ClaudeCliOptions = {
         workingDir: worktreePath,
         threadId: session.threadId,
-        permissionMode: permissionModeForRestart(session.forceInteractivePermissions, options.permissionMode),
+        permissionMode: effectivePermissionMode({
+          override: session.permissionModeOverride,
+          sessionHasInteractiveOverride: session.forceInteractivePermissions,
+          botWideMode: options.permissionMode,
+        }),
         sessionId: newSessionId,
         resume: false,  // Fresh start - can't resume across directories
         chrome: options.chromeEnabled,

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -806,6 +806,10 @@ export async function startSession(
   // Claude CLI spawn below.
   let permissionMode = ctx.config.permissionMode;
   let forceInteractivePermissions = false;
+  // Per-session override tracked on the Session object so the header + any
+  // subsequent `effectivePermissionMode` call sees the mode the user chose
+  // in the first message (not just the bot-wide default).
+  let sessionPermissionModeOverride: PermissionMode | undefined;
   const formatter = platform.getFormatter();
 
   if (initialOptions?.workingDir) {
@@ -840,6 +844,11 @@ export async function startSession(
   if (initialOptions?.permissionMode) {
     permissionMode = initialOptions.permissionMode;
     forceInteractivePermissions = permissionMode === 'default';
+    // Record the explicit override so the session header reflects it. Only
+    // needed for 'auto' and 'bypass' — 'default' is covered by
+    // forceInteractivePermissions, but we set the override uniformly for
+    // clarity.
+    sessionPermissionModeOverride = permissionMode;
     log.info(`Starting session with permission mode "${permissionMode}" (from !permissions command)`);
   } else if (initialOptions?.forceInteractivePermissions) {
     // Legacy alias: forceInteractivePermissions === 'default'.
@@ -896,6 +905,7 @@ export async function startSession(
     planApproved: false,
     sessionAllowedUsers: new Set([username]),
     forceInteractivePermissions,
+    permissionModeOverride: sessionPermissionModeOverride,
     sessionStartPostId: startPost.id,
     // NOTE: Task state (tasksPostId, lastTasksContent, etc.) is now managed by MessageManager.
     // These fields are intentionally NOT initialized here - MessageManager is the source of truth.

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -16,7 +16,7 @@ import { EventEmitter } from 'events';
 import { ClaudeEvent } from '../claude/cli.js';
 import type { PlatformClient, PlatformUser, PlatformPost, PlatformFile } from '../platform/index.js';
 import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persistence/session-store.js';
-import { WorktreeMode, type LimitsConfig, type ResolvedLimits, type ClaudeAccount, type PermissionMode, resolveLimits } from '../config/index.js';
+import { WorktreeMode, type LimitsConfig, type ResolvedLimits, type ClaudeAccount, type PermissionMode, resolveLimits, effectivePermissionMode } from '../config/index.js';
 import { AccountPool } from '../claude/account-pool.js';
 import type { SessionInfo } from '../ui/types.js';
 import {
@@ -1283,17 +1283,19 @@ export class SessionManager extends EventEmitter {
   }
 
   /**
-   * Whether a session's tool-uses will trigger permission prompts. True when
-   * either (a) the bot-wide mode is not `bypass`, or (b) the session opted
-   * into `default` via `!permissions` and thus prompts regardless of the
-   * bot-wide mode.
+   * Whether a session's tool-uses will trigger permission prompts. True for
+   * `default` and `auto` modes (both consult the MCP server for at least
+   * some tool-uses), false for `bypass`. Respects per-session overrides.
    */
   isSessionInteractive(threadId: string): boolean {
-    const botWideInteractive = this.permissionMode !== 'bypass';
     const session = this.findSessionByThreadId(threadId);
-    if (!session) return botWideInteractive;
-    if (botWideInteractive) return true;
-    return session.forceInteractivePermissions;
+    if (!session) return this.permissionMode !== 'bypass';
+    const effective = effectivePermissionMode({
+      override: session.permissionModeOverride,
+      sessionHasInteractiveOverride: session.forceInteractivePermissions,
+      botWideMode: this.permissionMode,
+    });
+    return effective !== 'bypass';
   }
 
   async requestMessageApproval(threadId: string, username: string, message: string): Promise<void> {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -287,6 +287,17 @@ export interface Session {
    */
   forceInteractivePermissions: boolean;
 
+  /**
+   * Current effective permission mode for THIS session when it differs from
+   * the bot-wide default. Set by `!permissions <mode>`. Not persisted —
+   * on bot restart, `auto` and `bypass` overrides revert to bot-wide mode
+   * (which is usually what operators want; see PR #343 doc). `default`
+   * overrides persist via `forceInteractivePermissions`.
+   *
+   * `undefined` means "inherit bot-wide mode from `SessionConfig`".
+   */
+  permissionModeOverride?: PermissionMode;
+
   // Display state
   sessionStartPostId: string | null;  // The header post we update with participants
 


### PR DESCRIPTION
Live smoke of PR #343/#344 surfaced three user-visible bugs.

## 1. `!permissions <mode>` right after session start aborts Claude

Claude CLI rejects `--resume <uuid>` with _"No conversation found with session ID"_ when the session has never completed a turn. The spawn path in `setSessionPermissionMode` (and plugin install/uninstall) hardcoded `resume: true`, producing a user-facing:

> ❌ Session cannot be resumed — The conversation history for this session no longer exists.

**Fix**: gate ` resume` on `session.lifecycle.hasClaudeResponded`. Early restarts start fresh under the same UUID; chat-thread continuity is preserved because it lives in the platform, not Claude.

Applied to both `setSessionPermissionMode` and `handlePluginInstall`/`handlePluginUninstall`.

## 2. `!help` listed stale `!permissions interactive\|skip`

The command registry was never updated when PR #343 added `auto`. Two problems in one cell:

- `args: 'interactive|skip'` is the old two-mode surface.
- The literal `|` is a column separator in markdown tables; the formatter's `escapeCell` produced `\|`, which Mattermost rendered verbatim.

**Fix**: `args: 'default / auto / bypass'` (no pipe → no escape issue) plus a new description matching the three-mode model.

## Verification

- [x] `bun test src/` — 2104 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] `bun run test:integration` — runs in CI
- [ ] Live smoke: `@bot hello` + immediate `!permissions auto` — Claude respawns without the "cannot be resumed" error
- [ ] Live smoke: `!help` shows `!permissions default / auto / bypass`

## Scope

Minimal fix for two bugs from a live test. No refactor, no type-level changes.