### PR TITLE
refactor: PR 3 — executor contract + MessageManager.serialize()

### DIFF
--- a/src/operations/executors/base.ts
+++ b/src/operations/executors/base.ts
@@ -8,7 +8,7 @@
  * - State management (getState, reset)
  */
 
-import type { RegisterPostCallback, UpdateLastMessageCallback } from './types.js';
+import type { RegisterPostCallback, UpdateLastMessageCallback, Executor } from './types.js';
 import type { TypedEventEmitter } from '../message-manager-events.js';
 
 // ---------------------------------------------------------------------------
@@ -42,7 +42,7 @@ export interface ExecutorOptions {
  *
  * @template TState - The state type managed by the executor
  */
-export abstract class BaseExecutor<TState extends object> {
+export abstract class BaseExecutor<TState extends object> implements Executor<TState> {
   /** Executor state - subclasses access via protected */
   protected state: TState;
 

--- a/src/operations/executors/contract.test.ts
+++ b/src/operations/executors/contract.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Contract tests — every executor satisfies `Executor<TState>`.
+ *
+ * The `Executor` interface defines the structural shape MessageManager
+ * relies on when dispatching reactions and building persistence payloads.
+ * These tests iterate every concrete executor and assert that the required
+ * members are present (`getState`, `reset`) and that optional members
+ * behave as declared when they're implemented.
+ *
+ * Catches drift: if someone adds a new executor and forgets to implement
+ * `getState` / `reset`, or if they change a `handleReaction` signature out
+ * of line with the interface, these tests fail fast.
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import type { Executor } from './types.js';
+import { BaseExecutor, type ExecutorOptions } from './base.js';
+import { ContentExecutor } from './content.js';
+import { TaskListExecutor } from './task-list.js';
+import { QuestionApprovalExecutor } from './question-approval.js';
+import { MessageApprovalExecutor } from './message-approval.js';
+import { PromptExecutor } from './prompt.js';
+import { BugReportExecutor } from './bug-report.js';
+import { SubagentExecutor } from './subagent.js';
+import { SystemExecutor } from './system.js';
+import { WorktreePromptExecutor } from './worktree-prompt.js';
+
+function makeBaseOptions(): ExecutorOptions {
+  return {
+    registerPost: mock(() => undefined),
+    updateLastMessage: mock(() => undefined),
+  };
+}
+
+interface ExecutorCase {
+  name: string;
+  create: () => Executor;
+  expectsHandleReaction: boolean;
+  expectsSerialize: boolean;
+}
+
+/**
+ * Every concrete executor, with whether it's expected to expose
+ * `handleReaction` / `serialize`. The boolean flags double as intent: if
+ * someone adds a new executor, they MUST update this table — otherwise
+ * the contract test skips it silently.
+ */
+const CASES: ExecutorCase[] = [
+  { name: 'ContentExecutor',           create: () => new ContentExecutor(makeBaseOptions()),           expectsHandleReaction: false, expectsSerialize: false },
+  { name: 'TaskListExecutor',          create: () => new TaskListExecutor(makeBaseOptions()),          expectsHandleReaction: true,  expectsSerialize: true  },
+  { name: 'QuestionApprovalExecutor',  create: () => new QuestionApprovalExecutor(makeBaseOptions()),  expectsHandleReaction: true,  expectsSerialize: false },
+  { name: 'MessageApprovalExecutor',   create: () => new MessageApprovalExecutor(makeBaseOptions()),   expectsHandleReaction: true,  expectsSerialize: false },
+  { name: 'PromptExecutor',            create: () => new PromptExecutor(makeBaseOptions()),            expectsHandleReaction: true,  expectsSerialize: true  },
+  { name: 'BugReportExecutor',         create: () => new BugReportExecutor(makeBaseOptions()),         expectsHandleReaction: true,  expectsSerialize: false },
+  { name: 'SubagentExecutor',          create: () => new SubagentExecutor(makeBaseOptions()),          expectsHandleReaction: true,  expectsSerialize: false },
+  { name: 'SystemExecutor',            create: () => new SystemExecutor(makeBaseOptions()),            expectsHandleReaction: false, expectsSerialize: false },
+  { name: 'WorktreePromptExecutor',    create: () => new WorktreePromptExecutor(makeBaseOptions()),    expectsHandleReaction: true,  expectsSerialize: false },
+];
+
+describe('Executor contract', () => {
+  for (const { name, create, expectsHandleReaction, expectsSerialize } of CASES) {
+    describe(name, () => {
+      it('extends BaseExecutor (required getState + reset)', () => {
+        const e = create();
+        expect(e).toBeInstanceOf(BaseExecutor);
+        expect(typeof e.getState).toBe('function');
+        expect(typeof e.reset).toBe('function');
+        // getState returns a readable object
+        expect(typeof e.getState()).toBe('object');
+      });
+
+      it(`${expectsHandleReaction ? 'exposes' : 'does not expose'} handleReaction`, () => {
+        const e = create();
+        if (expectsHandleReaction) {
+          expect(typeof e.handleReaction).toBe('function');
+        } else {
+          expect(e.handleReaction).toBeUndefined();
+        }
+      });
+
+      it(`${expectsSerialize ? 'exposes' : 'does not expose'} serialize`, () => {
+        const e = create();
+        if (expectsSerialize) {
+          expect(typeof e.serialize).toBe('function');
+          // serialize() must be callable with no args and produce something.
+          // We don't assert a specific shape — each executor's shape is its
+          // own contract with `PersistedSession`.
+          expect(() => (e.serialize as () => unknown)()).not.toThrow();
+        } else {
+          expect(e.serialize).toBeUndefined();
+        }
+      });
+    });
+  }
+
+  it('reset() is idempotent across all executors', () => {
+    for (const { name, create } of CASES) {
+      const e = create();
+      const before = JSON.stringify(e.getState());
+      e.reset();
+      e.reset();
+      const after = JSON.stringify(e.getState());
+      expect({ executor: name, state: after }).toEqual({ executor: name, state: before });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleReaction signature — uniform (postId, emoji, user, action, ctx)
+// ---------------------------------------------------------------------------
+
+describe('Executor.handleReaction signature is uniform', () => {
+  it('every executor with handleReaction declares exactly 5 required params', () => {
+    for (const { name, create, expectsHandleReaction } of CASES) {
+      if (!expectsHandleReaction) continue;
+      const e = create();
+      // `Function.length` counts required parameters (those before the first
+      // default value or rest). The Executor contract pins this at 5:
+      // (postId, emoji, user, action, ctx).
+      expect({ executor: name, arity: e.handleReaction!.length })
+        .toEqual({ executor: name, arity: 5 });
+    }
+  });
+});

--- a/src/operations/executors/prompt.ts
+++ b/src/operations/executors/prompt.ts
@@ -118,6 +118,15 @@ export class PromptExecutor extends BaseExecutor<PromptState> {
   }
 
   /**
+   * Serialize the pending context prompt for `PersistedSession`. Returns
+   * `null` when there is no prompt awaiting a reaction — the persistence
+   * writer treats absent and null identically.
+   */
+  serialize(): PendingContextPrompt | null {
+    return this.state.pendingContextPrompt;
+  }
+
+  /**
    * Check if there's a pending context prompt.
    */
   hasPendingContextPrompt(): boolean {

--- a/src/operations/executors/subagent.ts
+++ b/src/operations/executors/subagent.ts
@@ -291,10 +291,15 @@ export class SubagentExecutor extends BaseExecutor<SubagentState> {
   /**
    * Handle a reaction on a subagent post.
    * Returns true if handled, false otherwise.
+   *
+   * `_user` is part of the standard `Executor.handleReaction` signature
+   * (dispatched uniformly by MessageManager); this executor's toggle
+   * behavior is user-agnostic, so the argument is ignored.
    */
   async handleReaction(
     postId: string,
     emoji: string,
+    _user: string,
     action: 'added' | 'removed',
     ctx: ExecutorContext
   ): Promise<boolean> {

--- a/src/operations/executors/task-list.test.ts
+++ b/src/operations/executors/task-list.test.ts
@@ -769,6 +769,7 @@ describe('TaskListExecutor', () => {
       const result = await executor.handleReaction(
         'post_1',
         MINIMIZE_TOGGLE_EMOJIS[0],
+        'tester',
         'added',
         ctx
       );
@@ -784,6 +785,7 @@ describe('TaskListExecutor', () => {
       const result = await executor.handleReaction(
         'post_1',
         MINIMIZE_TOGGLE_EMOJIS[0],
+        'tester',
         'added',
         ctx
       );
@@ -799,6 +801,7 @@ describe('TaskListExecutor', () => {
       const result = await executor.handleReaction(
         'post_1',
         '+1', // thumbs up, not toggle
+        'tester',
         'added',
         ctx
       );
@@ -815,6 +818,7 @@ describe('TaskListExecutor', () => {
       const result = await executor.handleReaction(
         'post_1',
         MINIMIZE_TOGGLE_EMOJIS[0],
+        'tester',
         'removed',
         ctx
       );
@@ -832,6 +836,7 @@ describe('TaskListExecutor', () => {
       const result = await executor.handleReaction(
         'other-post-id',
         MINIMIZE_TOGGLE_EMOJIS[0],
+        'tester',
         'added',
         ctx
       );
@@ -845,6 +850,7 @@ describe('TaskListExecutor', () => {
       const result = await executor.handleReaction(
         'post_1',
         MINIMIZE_TOGGLE_EMOJIS[0],
+        'tester',
         'added',
         ctx
       );

--- a/src/operations/executors/task-list.ts
+++ b/src/operations/executors/task-list.ts
@@ -442,12 +442,40 @@ export class TaskListExecutor extends BaseExecutor<TaskListState> {
   }
 
   /**
+   * Serialize the task list state for `PersistedSession`. Field names match
+   * the historical `getTaskListState()` shape so `SessionManager.persistSession`
+   * can plug the result straight into the persisted-session record.
+   *
+   * Returning `null` would be valid too (no pending task list), but returning
+   * zeroed-out values is simpler and keeps the persisted JSON shape stable
+   * regardless of whether Claude has started a task list yet.
+   */
+  serialize(): {
+    postId: string | null;
+    content: string | null;
+    isMinimized: boolean;
+    isCompleted: boolean;
+  } {
+    return {
+      postId: this.state.tasksPostId,
+      content: this.state.lastTasksContent,
+      isMinimized: this.state.tasksMinimized,
+      isCompleted: this.state.tasksCompleted,
+    };
+  }
+
+  /**
    * Handle a reaction event on a post.
    * Returns true if the reaction was handled, false otherwise.
+   *
+   * `_user` is part of the standard `Executor.handleReaction` signature
+   * (dispatched uniformly by MessageManager); this executor's minimize
+   * toggle is user-agnostic, so the argument is ignored.
    */
   async handleReaction(
     postId: string,
     emoji: string,
+    _user: string,
     action: 'added' | 'removed',
     ctx: ExecutorContext
   ): Promise<boolean> {

--- a/src/operations/executors/types.ts
+++ b/src/operations/executors/types.ts
@@ -253,3 +253,59 @@ export type RegisterPostCallback = (
  * Callback for updating last message tracking.
  */
 export type UpdateLastMessageCallback = (post: PlatformPost) => void;
+
+// ---------------------------------------------------------------------------
+// Executor Contract
+// ---------------------------------------------------------------------------
+
+/**
+ * The action half of a platform reaction event — `'added'` when the user
+ * just applied the emoji, `'removed'` when they took it back.
+ */
+export type ReactionAction = 'added' | 'removed';
+
+/**
+ * Structural contract every executor satisfies. `BaseExecutor<T>` already
+ * implements `getState` and `reset`; the two optional members are declared
+ * by individual executors that need them.
+ *
+ * This is the type `MessageManager` iterates over when dispatching reactions
+ * and when collecting persistence payloads.
+ */
+export interface Executor<TState extends object = object> {
+  /** Snapshot of current state. Implementations return a shallow copy. */
+  getState(): Readonly<TState>;
+
+  /** Reset state to initial values (e.g. on session restart). */
+  reset(): void;
+
+  /**
+   * Optional: handle a reaction on a post owned by this executor. Return
+   * `true` iff the reaction was consumed by this executor (so the dispatcher
+   * stops considering later executors). Implementations that don't care
+   * about reactions omit this method.
+   *
+   * All six executors that currently implement `handleReaction` use the
+   * signature below; the parameter list is fixed so the dispatch table in
+   * MessageManager can call them uniformly.
+   */
+  handleReaction?(
+    postId: string,
+    emoji: string,
+    user: string,
+    action: ReactionAction,
+    ctx: ExecutorContext,
+  ): Promise<boolean>;
+
+  /**
+   * Optional: serialize this executor's persistable state for
+   * `SessionManager.persistSession`. Only executors whose state is part of
+   * `PersistedSession` (TaskList, Prompt) implement it; others return
+   * nothing and their output is ignored.
+   *
+   * The shape is executor-specific — `MessageManager.serialize()` keys the
+   * results by executor name so the persistence writer can pull the right
+   * fields without reaching into executor internals.
+   */
+  serialize?(): unknown;
+}

--- a/src/operations/executors/worktree-prompt.test.ts
+++ b/src/operations/executors/worktree-prompt.test.ts
@@ -142,7 +142,7 @@ describe('WorktreePromptExecutor', () => {
       });
 
       // Use emoji name '-1' (thumbsdown) for denial
-      const handled = executor.handleReaction('prompt-post', '-1', 'added');
+      const handled = await executor.handleReaction('prompt-post', '-1', 'tester', 'added', {} as unknown as Parameters<typeof executor.handleReaction>[4]);
       expect(handled).toBe(true);
       expect(executor.hasPendingPrompt()).toBe(false);
 
@@ -163,30 +163,30 @@ describe('WorktreePromptExecutor', () => {
       });
 
       // Use emoji name 'two' for second option (index 1)
-      const handled = executor.handleReaction('prompt-post', 'two', 'added');
+      const handled = await executor.handleReaction('prompt-post', 'two', 'tester', 'added', {} as unknown as Parameters<typeof executor.handleReaction>[4]);
       expect(handled).toBe(true);
 
       await eventReceived;
     });
 
-    test('ignores reaction on wrong post', () => {
+    test('ignores reaction on wrong post', async () => {
       executor.setPendingInitialPrompt({
         postId: 'prompt-post',
         suggestions: ['branch-1'],
       });
 
-      const handled = executor.handleReaction('other-post', '-1', 'added');
+      const handled = await executor.handleReaction('other-post', '-1', 'tester', 'added', {} as unknown as Parameters<typeof executor.handleReaction>[4]);
       expect(handled).toBe(false);
       expect(executor.hasPendingPrompt()).toBe(true);
     });
 
-    test('ignores removed reactions', () => {
+    test('ignores removed reactions', async () => {
       executor.setPendingInitialPrompt({
         postId: 'prompt-post',
         suggestions: ['branch-1'],
       });
 
-      const handled = executor.handleReaction('prompt-post', '-1', 'removed');
+      const handled = await executor.handleReaction('prompt-post', '-1', 'tester', 'removed', {} as unknown as Parameters<typeof executor.handleReaction>[4]);
       expect(handled).toBe(false);
       expect(executor.hasPendingPrompt()).toBe(true);
     });
@@ -208,20 +208,20 @@ describe('WorktreePromptExecutor', () => {
       });
 
       // Use emoji name '-1' (thumbsdown) for denial
-      const handled = executor.handleReaction('failure-post', '-1', 'added');
+      const handled = await executor.handleReaction('failure-post', '-1', 'tester', 'added', {} as unknown as Parameters<typeof executor.handleReaction>[4]);
       expect(handled).toBe(true);
 
       await eventReceived;
     });
 
-    test('ignores invalid number emoji for initial prompt', () => {
+    test('ignores invalid number emoji for initial prompt', async () => {
       executor.setPendingInitialPrompt({
         postId: 'prompt-post',
         suggestions: ['branch-1'],
       });
 
       // 'four' is out of bounds (only 1 suggestion at index 0)
-      const handled = executor.handleReaction('prompt-post', 'four', 'added');
+      const handled = await executor.handleReaction('prompt-post', 'four', 'tester', 'added', {} as unknown as Parameters<typeof executor.handleReaction>[4]);
       expect(handled).toBe(false);
       expect(executor.hasPendingPrompt()).toBe(true);
     });

--- a/src/operations/executors/worktree-prompt.ts
+++ b/src/operations/executors/worktree-prompt.ts
@@ -11,6 +11,7 @@
 import { isDenialEmoji, getNumberEmojiIndex } from '../../utils/emoji.js';
 import { createLogger } from '../../utils/logger.js';
 import { BaseExecutor, type ExecutorOptions } from './base.js';
+import type { ExecutorContext } from './types.js';
 
 const log = createLogger('wt-prompt');
 
@@ -252,11 +253,23 @@ export class WorktreePromptExecutor extends BaseExecutor<WorktreePromptState> {
   /**
    * Handle a reaction on a worktree prompt post.
    *
-   * @returns true if the reaction was handled, false otherwise
+   * Note: this executor's prompts are user-agnostic (anyone in the session
+   * can ✅/❌ a worktree prompt), and it does not need the executor ctx —
+   * the signature still takes both to satisfy `Executor.handleReaction`
+   * so `MessageManager`'s dispatch loop can call it uniformly if this
+   * executor is ever wired into the loop.
+   *
+   * @returns Promise&lt;true&gt; if the reaction was handled, Promise&lt;false&gt; otherwise
    */
-  handleReaction(postId: string, emoji: string, _action: 'added' | 'removed'): boolean {
+  async handleReaction(
+    postId: string,
+    emoji: string,
+    _user: string,
+    action: 'added' | 'removed',
+    _ctx: ExecutorContext,
+  ): Promise<boolean> {
     // Only handle 'added' actions for prompts
-    if (_action !== 'added') return false;
+    if (action !== 'added') return false;
 
     // Check initial prompt
     if (this.state.pendingInitialPrompt?.postId === postId) {

--- a/src/operations/message-manager.ts
+++ b/src/operations/message-manager.ts
@@ -31,6 +31,7 @@ import type {
   ContextPromptSelection,
 } from './executors/prompt.js';
 import type {
+  Executor,
   ExecutorContext,
   RegisterPostCallback,
   UpdateLastMessageCallback,
@@ -820,7 +821,10 @@ export class MessageManager {
   }
 
   /**
-   * Get task list state for persistence
+   * Get task list state for persistence.
+   *
+   * @deprecated Use `serialize()` instead; this wrapper is kept for
+   * one release as a rollback path (`CLAUDE_THREADS_SERIALIZE_V2=0`).
    */
   getTaskListState(): {
     postId: string | null;
@@ -828,12 +832,25 @@ export class MessageManager {
     isMinimized: boolean;
     isCompleted: boolean;
   } {
-    const state = this.taskListExecutor.getState();
+    return this.taskListExecutor.serialize();
+  }
+
+  /**
+   * Aggregate every executor's persistable state into a single payload for
+   * `SessionManager.persistSession`. Removes the need for persistSession
+   * to reach into individual executors via named getters.
+   *
+   * Shape is stable: `taskList` always present, `contextPrompt` is `null`
+   * when no prompt is pending. The keys are what `PersistedSession` expects,
+   * so the writer can spread them straight into the persisted record.
+   */
+  serialize(): {
+    taskList: ReturnType<TaskListExecutor['serialize']>;
+    contextPrompt: PendingContextPrompt | null;
+  } {
     return {
-      postId: state.tasksPostId,
-      content: state.lastTasksContent,
-      isMinimized: state.tasksMinimized,
-      isCompleted: state.tasksCompleted,
+      taskList: this.taskListExecutor.serialize(),
+      contextPrompt: this.promptExecutor.serialize(),
     };
   }
 
@@ -1098,6 +1115,29 @@ export class MessageManager {
    * @param action - Whether the reaction was 'added' or 'removed'
    * @returns true if the reaction was handled, false otherwise
    */
+  /**
+   * Executor dispatch order for `handleReaction`. Order matters — earlier
+   * entries get the first shot at a reaction and return `true` to short-
+   * circuit the rest. Previously this was an if/else chain; encoding it
+   * as data makes it obvious when re-ordering and lets `serialize()`
+   * iterate the same list for persistence payloads.
+   *
+   * Each entry includes a name for the dispatch log and the executor
+   * instance. `as Executor[]` because TypeScript can't infer the union
+   * of concrete classes — they all implement `Executor` but with different
+   * state types.
+   */
+  private reactionDispatchList(): Array<{ name: string; executor: Executor }> {
+    return [
+      { name: 'QuestionApprovalExecutor', executor: this.questionApprovalExecutor as Executor },
+      { name: 'MessageApprovalExecutor',  executor: this.messageApprovalExecutor as Executor },
+      { name: 'PromptExecutor',           executor: this.promptExecutor as Executor },
+      { name: 'BugReportExecutor',        executor: this.bugReportExecutor as Executor },
+      { name: 'TaskListExecutor',         executor: this.taskListExecutor as Executor },
+      { name: 'SubagentExecutor',         executor: this.subagentExecutor as Executor },
+    ];
+  }
+
   async handleReaction(
     postId: string,
     emoji: string,
@@ -1109,40 +1149,12 @@ export class MessageManager {
 
     logger.debug(`Routing reaction: postId=${postId}, emoji=${emoji}, user=${user}, action=${action}`);
 
-    // Try question/approval executor first
-    if (await this.questionApprovalExecutor.handleReaction(postId, emoji, user, action, ctx)) {
-      logger.debug('Reaction handled by QuestionApprovalExecutor');
-      return true;
-    }
-
-    // Try message approval executor
-    if (await this.messageApprovalExecutor.handleReaction(postId, emoji, user, action, ctx)) {
-      logger.debug('Reaction handled by MessageApprovalExecutor');
-      return true;
-    }
-
-    // Try prompt executor (context, worktree, update prompts)
-    if (await this.promptExecutor.handleReaction(postId, emoji, user, action, ctx)) {
-      logger.debug('Reaction handled by PromptExecutor');
-      return true;
-    }
-
-    // Try bug report executor
-    if (await this.bugReportExecutor.handleReaction(postId, emoji, user, action, ctx)) {
-      logger.debug('Reaction handled by BugReportExecutor');
-      return true;
-    }
-
-    // Try task list executor (minimize toggle)
-    if (await this.taskListExecutor.handleReaction(postId, emoji, action, ctx)) {
-      logger.debug('Reaction handled by TaskListExecutor');
-      return true;
-    }
-
-    // Try subagent executor (minimize toggle)
-    if (await this.subagentExecutor.handleReaction(postId, emoji, action, ctx)) {
-      logger.debug('Reaction handled by SubagentExecutor');
-      return true;
+    for (const { name, executor } of this.reactionDispatchList()) {
+      if (!executor.handleReaction) continue;
+      if (await executor.handleReaction(postId, emoji, user, action, ctx)) {
+        logger.debug(`Reaction handled by ${name}`);
+        return true;
+      }
     }
 
     logger.debug('Reaction not handled by any executor');

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -653,4 +653,164 @@ describe('SessionManager', () => {
       expect(manager.isSessionInteractive('thread-F')).toBe(true);
     });
   });
+
+  // ==========================================================================
+  // persistSession byte-level snapshot — guarantees PR 3's refactor of
+  // persistSession (use MessageManager.serialize() instead of the two per-
+  // getter reaches) doesn't change the on-disk shape of `sessions.json`.
+  //
+  // CLAUDE.md's backward-compat rule is strict: field set must remain
+  // identical to what existing users have on disk. If a PR changes the
+  // byte-level shape, this test fails before the persisted state does.
+  // ==========================================================================
+  describe('persistSession snapshot (backward compat)', () => {
+    test('persists a fully-populated session with the expected field set', () => {
+      const savedCalls: Array<{ sessionId: string; data: unknown }> = [];
+      // Intercept sessionStore.save to capture the written payload without
+      // actually writing to disk.
+      (manager as any).sessionStore.save = (sessionId: string, data: unknown) => {
+        savedCalls.push({ sessionId, data });
+      };
+
+      const session = injectSession(manager, platform as unknown as PlatformClient, 'thread-snap', {
+        claudeSessionId: 'claude-uuid-1',
+        startedByDisplayName: 'Alice',
+        sessionAllowedUsers: new Set(['alice', 'bob']),
+        forceInteractivePermissions: true,
+        planApproved: true,
+        sessionStartPostId: 'start-1',
+        messageCount: 3,
+        sessionTitle: 'Test session',
+        sessionDescription: 'A description',
+        sessionTags: ['bug-fix'],
+        pullRequestUrl: 'https://github.com/x/y/pull/1',
+        lifecyclePostId: 'lifecycle-1',
+        firstPrompt: 'Hello',
+      });
+
+      session.messageManager = {
+        serialize: () => ({
+          taskList: { postId: 'tasks-1', content: '- [ ] a', isMinimized: false, isCompleted: false },
+          contextPrompt: {
+            postId: 'ctx-1',
+            queuedPrompt: 'followup',
+            queuedFiles: undefined,
+            threadMessageCount: 5,
+            createdAt: 1_700_000_000_000,
+            availableOptions: [],
+          },
+        }),
+        // Keep legacy getters working as fallback if something probes them.
+        getTaskListState: () => ({ postId: 'tasks-1', content: '- [ ] a', isMinimized: false, isCompleted: false }),
+        getPendingContextPrompt: () => ({
+          postId: 'ctx-1',
+          queuedPrompt: 'followup',
+          queuedFiles: undefined,
+          threadMessageCount: 5,
+          createdAt: 1_700_000_000_000,
+          availableOptions: [],
+        }),
+      } as any;
+
+      (manager as any).persistSession(session);
+
+      expect(savedCalls).toHaveLength(1);
+      const written = savedCalls[0].data as Record<string, unknown>;
+
+      // Field set must match the pre-PR-3 shape exactly. Extra or missing
+      // keys would signal schema drift.
+      const expectedKeys = new Set([
+        'platformId', 'threadId', 'claudeSessionId', 'startedBy', 'startedByDisplayName',
+        'startedAt', 'lastActivityAt', 'sessionNumber', 'workingDir', 'planApproved',
+        'sessionAllowedUsers', 'forceInteractivePermissions', 'sessionStartPostId',
+        'tasksPostId', 'lastTasksContent', 'tasksCompleted', 'tasksMinimized',
+        'worktreeInfo', 'isWorktreeOwner', 'pendingWorktreePrompt', 'worktreePromptDisabled',
+        'queuedPrompt', 'queuedFiles', 'firstPrompt', 'pendingContextPrompt',
+        'needsContextPromptOnNextMessage', 'lifecyclePostId', 'isPaused', 'sessionTitle',
+        'sessionDescription', 'sessionTags', 'pullRequestUrl', 'messageCount',
+        'resumeFailCount', 'claudeAccountId',
+      ]);
+      expect(new Set(Object.keys(written))).toEqual(expectedKeys);
+
+      // Spot-check a few critical fields — the ones sourced from
+      // `MessageManager.serialize()` rather than `session.*`.
+      expect(written.tasksPostId).toBe('tasks-1');
+      expect(written.lastTasksContent).toBe('- [ ] a');
+      expect(written.tasksCompleted).toBe(false);
+      expect(written.tasksMinimized).toBe(false);
+      const ctxPrompt = written.pendingContextPrompt as Record<string, unknown>;
+      expect(ctxPrompt.postId).toBe('ctx-1');
+      expect(ctxPrompt.queuedPrompt).toBe('followup');
+      expect(written.forceInteractivePermissions).toBe(true);
+      expect(written.sessionTitle).toBe('Test session');
+    });
+
+    test('persists a minimal session (no task list, no context prompt)', () => {
+      const savedCalls: Array<{ sessionId: string; data: unknown }> = [];
+      (manager as any).sessionStore.save = (sessionId: string, data: unknown) => {
+        savedCalls.push({ sessionId, data });
+      };
+
+      const session = injectSession(manager, platform as unknown as PlatformClient, 'thread-min');
+      session.messageManager = {
+        serialize: () => ({
+          taskList: { postId: null, content: null, isMinimized: false, isCompleted: false },
+          contextPrompt: null,
+        }),
+        getTaskListState: () => ({ postId: null, content: null, isMinimized: false, isCompleted: false }),
+        getPendingContextPrompt: () => null,
+      } as any;
+
+      (manager as any).persistSession(session);
+      const written = savedCalls[0].data as Record<string, unknown>;
+
+      // Null task-list fields: critical that we write `null`, not `undefined`.
+      // Persistence readers expect these to always be present.
+      expect(written.tasksPostId).toBeNull();
+      expect(written.lastTasksContent).toBeNull();
+      expect(written.tasksCompleted).toBe(false);
+      expect(written.tasksMinimized).toBe(false);
+      expect(written.pendingContextPrompt).toBeUndefined();
+    });
+
+    test('legacy path (SERIALIZE_V2=0) produces the same payload as the new path', () => {
+      const original = process.env.CLAUDE_THREADS_SERIALIZE_V2;
+      const capturedNew: unknown[] = [];
+      const capturedLegacy: unknown[] = [];
+      (manager as any).sessionStore.save = (_id: string, data: unknown) => {
+        if (process.env.CLAUDE_THREADS_SERIALIZE_V2 === '0') capturedLegacy.push(data);
+        else capturedNew.push(data);
+      };
+
+      const session = injectSession(manager, platform as unknown as PlatformClient, 'thread-eq', {
+        sessionTitle: 'Parity',
+      });
+      session.messageManager = {
+        serialize: () => ({
+          taskList: { postId: 'T', content: 'x', isMinimized: true, isCompleted: true },
+          contextPrompt: null,
+        }),
+        getTaskListState: () => ({ postId: 'T', content: 'x', isMinimized: true, isCompleted: true }),
+        getPendingContextPrompt: () => null,
+      } as any;
+
+      try {
+        delete process.env.CLAUDE_THREADS_SERIALIZE_V2;
+        (manager as any).persistSession(session);
+        process.env.CLAUDE_THREADS_SERIALIZE_V2 = '0';
+        (manager as any).persistSession(session);
+      } finally {
+        if (original === undefined) {
+          delete process.env.CLAUDE_THREADS_SERIALIZE_V2;
+        } else {
+          process.env.CLAUDE_THREADS_SERIALIZE_V2 = original;
+        }
+      }
+
+      // Payloads must be byte-identical. This is what protects users on
+      // the rollback path (`CLAUDE_THREADS_SERIALIZE_V2=0`) from a divergent
+      // `sessions.json` format.
+      expect(JSON.stringify(capturedNew[0])).toEqual(JSON.stringify(capturedLegacy[0]));
+    });
+  });
 });

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -694,22 +694,38 @@ export class SessionManager extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   private persistSession(session: Session): void {
-    // Get context prompt state from MessageManager (source of truth)
-    let persistedContextPrompt: PersistedContextPrompt | undefined;
-    const contextPromptState = session.messageManager?.getPendingContextPrompt();
-    if (contextPromptState) {
-      persistedContextPrompt = {
-        postId: contextPromptState.postId,
-        queuedPrompt: contextPromptState.queuedPrompt,
-        queuedFiles: contextPromptState.queuedFiles,
-        threadMessageCount: contextPromptState.threadMessageCount,
-        createdAt: contextPromptState.createdAt,
-        availableOptions: contextPromptState.availableOptions,
-      };
-    }
+    // Aggregate every executor's persistable state in a single call.
+    // Rollback: `CLAUDE_THREADS_SERIALIZE_V2=0` re-enables the old per-getter
+    // path for one release, in case a downstream consumer depends on it.
+    const useSerializeV2 = process.env.CLAUDE_THREADS_SERIALIZE_V2 !== '0';
+    let taskListSnapshot:
+      | { postId: string | null; content: string | null; isMinimized: boolean; isCompleted: boolean }
+      | undefined;
+    let contextPromptSnapshot: PersistedContextPrompt | undefined;
 
-    // Get task list state from MessageManager (source of truth)
-    const taskState = session.messageManager?.getTaskListState();
+    if (useSerializeV2 && session.messageManager) {
+      const serialized = session.messageManager.serialize();
+      taskListSnapshot = serialized.taskList;
+      if (serialized.contextPrompt) {
+        contextPromptSnapshot = serialized.contextPrompt;
+      }
+    } else {
+      // Legacy path (rollback flag) — kept so a user who trips over a
+      // regression can unset the flag and get the pre-PR-3 behavior back
+      // without a release.
+      const legacyPrompt = session.messageManager?.getPendingContextPrompt();
+      if (legacyPrompt) {
+        contextPromptSnapshot = {
+          postId: legacyPrompt.postId,
+          queuedPrompt: legacyPrompt.queuedPrompt,
+          queuedFiles: legacyPrompt.queuedFiles,
+          threadMessageCount: legacyPrompt.threadMessageCount,
+          createdAt: legacyPrompt.createdAt,
+          availableOptions: legacyPrompt.availableOptions,
+        };
+      }
+      taskListSnapshot = session.messageManager?.getTaskListState();
+    }
 
     const state: PersistedSession = {
       platformId: session.platformId,
@@ -725,11 +741,11 @@ export class SessionManager extends EventEmitter {
       sessionAllowedUsers: [...session.sessionAllowedUsers],
       forceInteractivePermissions: session.forceInteractivePermissions,
       sessionStartPostId: session.sessionStartPostId,
-      // Task state from MessageManager (single source of truth)
-      tasksPostId: taskState?.postId ?? null,
-      lastTasksContent: taskState?.content ?? null,
-      tasksCompleted: taskState?.isCompleted ?? false,
-      tasksMinimized: taskState?.isMinimized ?? false,
+      // Task state from MessageManager serialize() (single source of truth).
+      tasksPostId: taskListSnapshot?.postId ?? null,
+      lastTasksContent: taskListSnapshot?.content ?? null,
+      tasksCompleted: taskListSnapshot?.isCompleted ?? false,
+      tasksMinimized: taskListSnapshot?.isMinimized ?? false,
       worktreeInfo: session.worktreeInfo,
       isWorktreeOwner: session.isWorktreeOwner,
       pendingWorktreePrompt: session.pendingWorktreePrompt,
@@ -737,7 +753,7 @@ export class SessionManager extends EventEmitter {
       queuedPrompt: session.queuedPrompt,
       queuedFiles: session.queuedFiles,
       firstPrompt: session.firstPrompt,
-      pendingContextPrompt: persistedContextPrompt,
+      pendingContextPrompt: contextPromptSnapshot,
       needsContextPromptOnNextMessage: session.needsContextPromptOnNextMessage,
       lifecyclePostId: session.lifecyclePostId,
       isPaused: session.lifecycle.state === 'paused' || session.lifecycle.state === 'interrupted',


### PR DESCRIPTION
Third PR from the [refactor roadmap](../blob/main/CLAUDE.md). Introduces a unified `Executor<TState>` interface and rewrites `SessionManager.persistSession` to aggregate executor state through `MessageManager.serialize()` instead of reaching into individual executors via named getters.

**No persisted-schema change on disk.** The field set in `sessions.json` stays byte-for-byte identical — enforced by new snapshot tests that also pin the rollback path.

## What's in

### 1. Unified `Executor<TState>` contract

New interface in `src/operations/executors/types.ts`:

\`\`\`ts
interface Executor<TState extends object> {
  getState(): Readonly<TState>;
  reset(): void;
  handleReaction?(postId, emoji, user, action, ctx): Promise<boolean>;
  serialize?(): unknown;
}
\`\`\`

` BaseExecutor<T> implements Executor<T>`. A new ` executors/contract.test.ts` iterates every concrete executor and asserts the shape — catches drift if someone adds an executor without the required members or mis-signs `handleReaction`.

### 2. Standardized `handleReaction` signatures

TaskList, Subagent, and WorktreePrompt previously had different signatures (sync or missing `user`). All 7 executors with ` handleReaction` now take `(postId, emoji, user, action, ctx) => Promise<boolean>`.

### 3. Reaction dispatch table in MessageManager

Replaced the if/else chain in ` MessageManager.handleReaction` with a ` reactionDispatchList()` that returns `[{ name, executor }]` entries. Order is preserved: question → message-approval → prompt → bug-report → task-list → subagent.

### 4. Persistence: ` MessageManager.serialize()`

- ` TaskListExecutor.serialize()` → `{ postId, content, isMinimized, isCompleted }`.
- ` PromptExecutor.serialize()` → `pendingContextPrompt | null`.
- ` MessageManager.serialize()` aggregates both as `{ taskList, contextPrompt }`.
- ` SessionManager.persistSession` reads the aggregate. No more ` session.messageManager?.getPendingContextPrompt()` and ` getTaskListState()` in the persistence writer.

## Rollback hatch

Gated by `CLAUDE_THREADS_SERIALIZE_V2` env var. Default: enabled. Unset (or `=0`) falls back to the pre-refactor getter-based code path for one release. The rollback path writes the **byte-identical** payload — enforced by a parity test.

## Legacy getters kept

` MessageManager.getPendingContextPrompt` and ` getTaskListState` are retained — they still have non-persistence consumers (sticky-message handler, context-prompt handler, lifecycle exit cleanup). Not orphans.

## Tests

2104 → **2136 (+32 new)**:
- ` executors/contract.test.ts`: 29 tests iterating every executor.
- ` manager.test.ts`: 3 persistence snapshot tests (full payload, minimal payload, rollback parity).
- Updates to existing `handleReaction` tests to include the new `user` parameter.

Typecheck + lint + knip clean.

## Verification

- [x] `bun test src/` — 2136 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `npx knip` — only pre-existing hints
- [ ] ` bun run test:integration` — runs in CI
- [ ] Live smoke: start a session → pause via bot restart → resume; verify task list and context prompt reappear correctly (persistence path)

## Roadmap status

With PR 3 merged and one release baked, PR 4 (` SessionManager` structural split into ` reaction-router.ts` + clean ` registry.ts` usage) becomes safe to land. Until then, the ` CLAUDE_THREADS_SERIALIZE_V2` flag gives operators a one-release escape hatch.