### PR TITLE
fix: readable WebSocket error logs + nested-branch worktree error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,8 @@ function wirePlatformEvents(
     ui.setPlatformStatus(platformId, { reconnecting: true, reconnectAttempts: attempt });
   });
   client.on('error', (e) => {
-    ui.addLog({ level: 'error', component: platformId, message: String(e) });
+    const message = e instanceof Error ? e.message : String(e);
+    ui.addLog({ level: 'error', component: platformId, message });
   });
 }
 

--- a/src/operations/worktree/handler.test.ts
+++ b/src/operations/worktree/handler.test.ts
@@ -994,3 +994,32 @@ describe('Worktree Module', () => {
     });
   });
 });
+
+describe('parseWorktreeError', () => {
+  it('matches the "parent branch blocks nested branch" git error', () => {
+    // Real error git produces when a user requests `test/add-unit-coverage`
+    // but a flat branch named `test` already exists. Without this match
+    // the error fell through to the generic fallback and the user got no
+    // actionable hint.
+    const err = new Error(
+      "Command failed: git worktree add -b test/add-unit-coverage /tmp/x\n" +
+      "Preparing worktree (new branch 'test/add-unit-coverage')\n" +
+      "fatal: 'refs/heads/test' exists; cannot create 'refs/heads/test/add-unit-coverage'\n",
+    );
+    const { summary, suggestion } = worktree.parseWorktreeError(err);
+    expect(summary).toBe('Branch test already exists and blocks test/add-unit-coverage');
+    expect(suggestion).toContain('Pick a name that does not start with test/');
+  });
+
+  it('falls back to generic message for unrecognized errors', () => {
+    const err = new Error('some weird failure we have not seen before');
+    const { summary } = worktree.parseWorktreeError(err);
+    expect(summary).toBe('Failed to create worktree');
+  });
+
+  it('still recognizes the generic "already exists" shape', () => {
+    const err = new Error('fatal: A branch named "foo" already exists.');
+    const { summary } = worktree.parseWorktreeError(err);
+    expect(summary).toBe('A worktree or branch with this name already exists');
+  });
+});

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -53,7 +53,7 @@ const sessionLog = createSessionLog(log);
  * - Permission denied
  * - Disk space issues
  */
-function parseWorktreeError(error: unknown): { summary: string; suggestion: string } {
+export function parseWorktreeError(error: unknown): { summary: string; suggestion: string } {
   const message = error instanceof Error ? error.message : String(error);
   const lowerMessage = message.toLowerCase();
 
@@ -62,6 +62,22 @@ function parseWorktreeError(error: unknown): { summary: string; suggestion: stri
     return {
       summary: 'Branch is already checked out in another worktree',
       suggestion: 'Try a different branch name, or use `!worktree list` to see existing worktrees',
+    };
+  }
+
+  // Parent branch blocks nested branch — git refuses when a flat branch
+  // (e.g. `test`) exists and a nested name (e.g. `test/add-unit-coverage`)
+  // is requested. Message shape:
+  //   fatal: 'refs/heads/<parent>' exists; cannot create '<nested>'
+  const parentBlocksMatch = message.match(
+    /'refs\/heads\/([^']+)' exists; cannot create '(?:refs\/heads\/)?([^']+)'/i,
+  );
+  if (parentBlocksMatch) {
+    const parent = parentBlocksMatch[1];
+    const nested = parentBlocksMatch[2];
+    return {
+      summary: `Branch ${parent} already exists and blocks ${nested}`,
+      suggestion: `Pick a name that does not start with ${parent}/, or delete the existing ${parent} branch first.`,
     };
   }
 

--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -2,7 +2,7 @@ import { WebSocket } from '../../utils/websocket.js';
 import type { MattermostPlatformConfig } from '../../config/index.js';
 import { wsLogger, createLogger } from '../../utils/logger.js';
 import { formatShortId } from '../../utils/format.js';
-import { escapeRegExp } from '../utils.js';
+import { escapeRegExp, formatWebSocketError } from '../utils.js';
 import { BasePlatformClient } from '../base-client.js';
 
 const log = createLogger('mattermost');
@@ -520,9 +520,10 @@ export class MattermostClient extends BasePlatformClient {
       };
 
       this.ws.onerror = (event) => {
-        wsLogger.warn(`WebSocket error: ${event}`);
-        this.emit('error', event);
-        reject(event);
+        const msg = formatWebSocketError(event);
+        wsLogger.warn(`WebSocket error: ${msg}`);
+        this.emit('error', new Error(`WebSocket error: ${msg}`));
+        reject(new Error(`WebSocket error: ${msg}`));
       };
     });
   }

--- a/src/platform/mattermost/permission-api.ts
+++ b/src/platform/mattermost/permission-api.ts
@@ -13,6 +13,7 @@ import type { PlatformFormatter } from '../formatter.js';
 import { MattermostFormatter } from './formatter.js';
 import { createLogger, mcpLogger } from '../../utils/logger.js';
 import { formatShortId } from '../../utils/format.js';
+import { formatWebSocketError } from '../utils.js';
 
 // =============================================================================
 // Mattermost REST API helpers (internal)
@@ -308,7 +309,7 @@ class MattermostPermissionApi implements PermissionApi {
       };
 
       ws.onerror = (event) => {
-        mcpLogger.error(`WebSocket error: ${event}`);
+        mcpLogger.error(`WebSocket error: ${formatWebSocketError(event)}`);
         if (!resolved) {
           resolved = true;
           clearTimeout(timeout);

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -1,7 +1,7 @@
 import { WebSocket } from '../../utils/websocket.js';
 import type { SlackPlatformConfig } from '../../config/index.js';
 import { wsLogger, createLogger } from '../../utils/logger.js';
-import { truncateMessageSafely, escapeRegExp, getEmojiName } from '../utils.js';
+import { truncateMessageSafely, escapeRegExp, getEmojiName, formatWebSocketError } from '../utils.js';
 import { BasePlatformClient } from '../base-client.js';
 
 const log = createLogger('slack');
@@ -381,14 +381,15 @@ export class SlackClient extends BasePlatformClient {
 
       this.ws.onerror = (event) => {
         clearTimeout(connectionTimeout);
-        wsLogger.warn(`Socket Mode: WebSocket error: ${event}`);
+        const msg = formatWebSocketError(event);
+        wsLogger.warn(`Socket Mode: WebSocket error: ${msg}`);
         // Only emit error event if this is not an intentional disconnect and not a reconnection attempt.
         // During reconnection, errors are already handled by the .catch() in scheduleReconnect().
         // This avoids unhandled error events during test cleanup when mock server is shut down.
         if (!this.isIntentionalDisconnect && !this.isReconnecting) {
-          this.emit('error', new Error('Socket Mode WebSocket error'));
+          this.emit('error', new Error(`Socket Mode WebSocket error: ${msg}`));
         }
-        doReject(new Error('Socket Mode WebSocket error'));
+        doReject(new Error(`Socket Mode WebSocket error: ${msg}`));
       };
     });
   }

--- a/src/platform/slack/permission-api.ts
+++ b/src/platform/slack/permission-api.ts
@@ -27,6 +27,7 @@ import type {
 } from './types.js';
 import { mcpLogger } from '../../utils/logger.js';
 import { SlackFormatter } from './formatter.js';
+import { formatWebSocketError } from '../utils.js';
 
 // =============================================================================
 // Slack Permission API Configuration
@@ -324,7 +325,7 @@ class SlackPermissionApi implements PermissionApi {
           };
 
           ws.onerror = (event) => {
-            mcpLogger.error(`Socket Mode WebSocket error: ${event}`);
+            mcpLogger.error(`Socket Mode WebSocket error: ${formatWebSocketError(event)}`);
             if (!resolved) {
               resolved = true;
               clearTimeout(timeout);

--- a/src/platform/utils.test.ts
+++ b/src/platform/utils.test.ts
@@ -6,6 +6,7 @@ import {
   getEmojiName,
   convertMarkdownTablesToSlack,
   convertMarkdownToSlack,
+  formatWebSocketError,
 } from './utils.js';
 
 describe('getPlatformIcon', () => {
@@ -347,5 +348,51 @@ Check out [the docs](https://example.com) for more info.`;
       const input = '- First item\n- Second item\n- Third item';
       expect(convertMarkdownToSlack(input)).toBe(input);
     });
+  });
+});
+
+describe('formatWebSocketError', () => {
+  it('returns message from plain Error', () => {
+    expect(formatWebSocketError(new Error('connection refused'))).toBe('connection refused');
+  });
+
+  it('extracts message from browser-style ErrorEvent-shaped object', () => {
+    // This is the shape recent Node/undici pass to ws.onerror — a template
+    // literal on this object produces the useless `[object ErrorEvent]`.
+    const event = { type: 'error', message: 'socket hang up', error: new Error('socket hang up') };
+    expect(formatWebSocketError(event)).toBe('socket hang up');
+  });
+
+  it('falls back to nested .error.message when .message is absent', () => {
+    const event = { type: 'error', error: new Error('ECONNRESET') };
+    expect(formatWebSocketError(event)).toBe('ECONNRESET');
+  });
+
+  it('uses .type with .code when only the wrapper is populated', () => {
+    const event = { type: 'error', code: 1006 };
+    expect(formatWebSocketError(event)).toBe('error (code: 1006)');
+  });
+
+  it('falls back to String() for truly opaque values', () => {
+    expect(formatWebSocketError('raw string')).toBe('raw string');
+    expect(formatWebSocketError(42)).toBe('42');
+    expect(formatWebSocketError(null)).toBe('null');
+  });
+
+  it('never produces the [object ErrorEvent] sentinel', () => {
+    // Regression guard: the bug was that `${event}` on a browser-style
+    // ErrorEvent stringified to `[object ErrorEvent]`. Any shape we feed
+    // the formatter must produce something that is not that literal.
+    const shapes: unknown[] = [
+      new Error('x'),
+      { type: 'error', message: 'y' },
+      { type: 'error', error: new Error('z') },
+      { type: 'error', code: 1006 },
+      'raw',
+      null,
+    ];
+    for (const s of shapes) {
+      expect(formatWebSocketError(s)).not.toContain('[object');
+    }
   });
 });

--- a/src/platform/utils.ts
+++ b/src/platform/utils.ts
@@ -24,6 +24,31 @@ export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Format a WebSocket error event into a readable string.
+ *
+ * Node's `ws` library and `undici` deliver two different shapes to `onerror`:
+ * a plain `Error` (older) and a browser-style `ErrorEvent` wrapper with a
+ * `.error` / `.message` field (newer). A template literal on the latter
+ * produces the useless `[object ErrorEvent]`. Pull the first field that
+ * carries signal and fall back to `String(x)`.
+ */
+export function formatWebSocketError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === 'object') {
+    const e = err as { message?: unknown; error?: unknown; type?: unknown; code?: unknown };
+    if (typeof e.message === 'string' && e.message) return e.message;
+    if (e.error instanceof Error) return e.error.message;
+    if (typeof e.error === 'string' && e.error) return e.error;
+    if (typeof e.type === 'string' && e.type) {
+      return typeof e.code === 'string' || typeof e.code === 'number'
+        ? `${e.type} (code: ${e.code})`
+        : e.type;
+    }
+  }
+  return String(err);
+}
+
 // =============================================================================
 // Platform Icons
 // =============================================================================


### PR DESCRIPTION
Two user-visible bugs noticed during live use.

## 1. `[object ErrorEvent]` in WebSocket error logs

Recent Node / undici deliver a browser-style `ErrorEvent` (not a plain `Error`) to `ws.onerror`. `` `${event}` `` on that wrapper stringifies to the useless `[object ErrorEvent]` sentinel, so the logs lost all signal about what the underlying failure was.

**Fix:** new `formatWebSocketError(err)` helper in `src/platform/utils.ts` that extracts `.message`, then `.error.message`, then `.type (code: .code)`, and falls back to `String(err)`. Wired into all five WebSocket error sites:

- `src/platform/mattermost/client.ts` (main bot)
- `src/platform/slack/client.ts` (main bot)
- `src/platform/mattermost/permission-api.ts` (MCP permission server)
- `src/platform/slack/permission-api.ts` (MCP permission server)
- `src/index.ts` (UI re-emitted-error log — now reads `.message` on the `Error` re-emission instead of stringifying whatever the platform forwards)

The Slack and Mattermost clients already re-emit an `Error` on `'error'`; I just made the Slack one carry the underlying message like Mattermost's does and preserve it across the `reject()` call sites.

## 2. `git worktree add -b test/add-unit-coverage` fell through to a generic error

When a flat branch `test` already exists and the user requests `test/add-unit-coverage`, git refuses with `fatal: 'refs/heads/test' exists; cannot create 'refs/heads/test/add-unit-coverage'`. `parseWorktreeError` didn't match this shape, so the bot responded with a generic "Failed to create worktree" with no actionable hint.

**Fix:** specific match extracts the parent and nested branch names and returns `Branch <parent> already exists and blocks <nested>` with the suggestion to pick a non-nested name or delete the existing parent branch first.

`parseWorktreeError` is now `export`ed so the regression tests hit it directly instead of going through the full worktree flow.

## Verification

- [x] Red-green: reverted each fix, confirmed tests fail, restored, confirmed they pass.
- [x] `bun test src/` — 2145 pass (+9 new), 0 fail.
- [x] `bun run lint` clean.
- [x] `bun run typecheck` clean.