### PR TITLE
refactor: PR 4 — extract ReactionRouter from SessionManager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.0",

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -19,14 +19,6 @@ import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persi
 import { WorktreeMode, type LimitsConfig, type ResolvedLimits, type ClaudeAccount, type PermissionMode, resolveLimits, effectivePermissionMode } from '../config/index.js';
 import { AccountPool } from '../claude/account-pool.js';
 import type { SessionInfo } from '../ui/types.js';
-import {
-  isCancelEmoji,
-  isEscapeEmoji,
-  isResumeEmoji,
-  getNumberEmojiIndex,
-  isBugReportEmoji,
-} from '../utils/emoji.js';
-import { normalizeEmojiName } from '../platform/utils.js';
 import { CleanupScheduler } from '../cleanup/index.js';
 import { SessionMonitor } from '../operations/monitor/index.js';
 
@@ -42,6 +34,7 @@ import * as stickyMessage from '../operations/sticky-message/index.js';
 import * as plugin from '../operations/plugin/index.js';
 import type { Session, InitialSessionOptions } from './types.js';
 import { SessionRegistry } from './registry.js';
+import * as reactionRouter from './reaction-router.js';
 import { post } from '../operations/post-helpers/index.js';
 import { createLogger } from '../utils/logger.js';
 
@@ -420,6 +413,13 @@ export class SessionManager extends EventEmitter {
 
   // ---------------------------------------------------------------------------
   // Reaction Handling
+  //
+  // Delegated to `reaction-router.ts`. The router handles:
+  // - emoji normalization (`thumbsup` vs `+1`)
+  // - resume-from-reaction for timed-out sessions
+  // - allowlist check + audit log
+  // - session-level reactions (cancel, escape, worktree, bug report)
+  // - MessageManager delegation for executor-owned reactions
   // ---------------------------------------------------------------------------
 
   private async handleReaction(
@@ -427,164 +427,30 @@ export class SessionManager extends EventEmitter {
     postId: string,
     emojiName: string,
     username: string,
-    action: 'added' | 'removed'
+    action: 'added' | 'removed',
   ): Promise<void> {
-    // Normalize emoji name to handle platform differences (e.g., Slack's "thumbsup" vs Mattermost's "+1")
-    const normalizedEmoji = normalizeEmojiName(emojiName);
-
-    // First, check if this is a resume emoji for a timed-out session (only on add)
-    if (action === 'added' && isResumeEmoji(normalizedEmoji)) {
-      const resumed = await this.tryResumeFromReaction(platformId, postId, username);
-      if (resumed) return;
-    }
-
-    const session = this.getSessionByPost(postId);
-    if (!session) return;
-
-    // Verify this reaction is from the same platform
-    if (session.platformId !== platformId) return;
-
-    // SECURITY: Only process reactions from allowed users
-    // This is the primary authorization gate for all reaction-based actions.
-    // All reactions are validated here before reaching MessageManager/executors.
-    if (!session.sessionAllowedUsers.has(username) && !session.platform.isUserAllowed(username)) {
-      // Audit trail: record unauthorized reaction attempts so operators can
-      // detect probing. Structured fields stay searchable across platforms.
-      log.info(`🚫 rejected reaction from unauthorized user`, {
-        event: 'reaction.rejected',
-        platformId,
-        sessionId: session.sessionId,
-        postId,
-        emoji: normalizedEmoji,
-        action,
-        user: username,
-      });
-      return;
-    }
-
-    await this.handleSessionReaction(session, postId, normalizedEmoji, username, action);
+    await reactionRouter.handleReaction(
+      this.getReactionRouterDeps(),
+      platformId,
+      postId,
+      emojiName,
+      username,
+      action,
+    );
   }
 
-  /**
-   * Try to resume a timed-out session via emoji reaction on timeout post or session header.
-   * Returns true if a session was resumed, false otherwise.
-   */
-  private async tryResumeFromReaction(platformId: string, postId: string, username: string): Promise<boolean> {
-    // Find a persisted session by the post ID (timeout post or session header)
-    const persistedSession = this.sessionStore.findByPostId(platformId, postId);
-    if (!persistedSession) return false;
-
-    // Check if this session is already active
-    const sessionId = `${platformId}:${persistedSession.threadId}`;
-    if (this.registry.hasById(sessionId)) return false;
-
-    // Check if user is allowed
-    const allowedUsers = new Set(persistedSession.sessionAllowedUsers);
-    const platform = this.platforms.get(platformId);
-    if (!allowedUsers.has(username) && !platform?.isUserAllowed(username)) {
-      if (platform) {
-        await platform.createPost(
-          `⚠️ @${username} is not authorized to resume this session`,
-          persistedSession.threadId
-        );
-      }
-      return false;
-    }
-
-    // Check max sessions limit
-    if (this.registry.size >= this.limits.maxSessions) {
-      if (platform) {
-        const fmt = platform.getFormatter();
-        await platform.createPost(
-          `⚠️ ${fmt.formatBold('Too busy')} - ${this.registry.size} sessions active. Please try again later.`,
-          persistedSession.threadId
-        );
-      }
-      return false;
-    }
-
-    const shortId = persistedSession.threadId.substring(0, 8);
-    log.info(`🔄 Resuming session ${shortId}... via emoji reaction by @${username}`);
-
-    // Resume the session
-    await lifecycle.resumeSession(persistedSession, this.getContext());
-    return true;
-  }
-
-  private async handleSessionReaction(
-    session: Session,
-    postId: string,
-    emojiName: string,
-    username: string,
-    action: 'added' | 'removed'
-  ): Promise<void> {
-    // =========================================================================
-    // Session-level reactions (lifecycle, worktrees, updates, bug reports)
-    // These are NOT handled by MessageManager and must stay in SessionManager
-    // =========================================================================
-
-    if (action === 'added') {
-      // Handle cancel/escape reactions on session start post
-      if (session.sessionStartPostId === postId) {
-        if (isCancelEmoji(emojiName)) {
-          await commands.cancelSession(session, username, this.getContext());
-          return;
-        }
-        if (isEscapeEmoji(emojiName)) {
-          await commands.interruptSession(session, username);
-          return;
-        }
-      }
-
-      // Handle ❌ on worktree prompt
-      if (session.worktreePromptPostId === postId && emojiName === 'x') {
-        await worktreeModule.handleWorktreeSkip(
-          session,
-          username,
-          (s) => this.persistSession(s),
-          (s, q) => contextPrompt.offerContextPrompt(s, q, undefined, this.getContextPromptHandler())
-        );
-        return;
-      }
-
-      // Handle number emoji on worktree prompt (branch suggestion selection)
-      if (session.pendingWorktreeSuggestions?.postId === postId) {
-        const emojiIndex = getNumberEmojiIndex(emojiName);
-        if (emojiIndex >= 0) {
-          const handled = await worktreeModule.handleBranchSuggestionReaction(
-            session,
-            postId,
-            emojiIndex,
-            username,
-            (tid, branch, user) => this.createAndSwitchToWorktree(tid, branch, user)
-          );
-          if (handled) return;
-        }
-      }
-
-      // Handle bug report emoji reaction on error posts
-      // (Inlined from reactions.handleBugReportReaction to eliminate dependency)
-      if (session.lastError?.postId === postId && isBugReportEmoji(emojiName)) {
-        // Only session owner or allowed users can report bugs
-        if (session.startedBy === username ||
-            session.platform.isUserAllowed(username) ||
-            session.sessionAllowedUsers.has(username)) {
-          log.info(`🐛 @${username} triggered bug report from error reaction`);
-          await commands.reportBug(session, undefined, username, this.getContext(), session.lastError);
-          return;
-        }
-      }
-    }
-
-    // =========================================================================
-    // MessageManager-delegated reactions (questions, approvals, toggles, etc.)
-    // These are routed through MessageManager.handleReaction()
-    // =========================================================================
-
-    if (session.messageManager) {
-      const handled = await session.messageManager.handleReaction(postId, emojiName, username, action);
-      if (handled) return;
-    }
+  private getReactionRouterDeps(): reactionRouter.ReactionRouterDeps {
+    return {
+      registry: this.registry,
+      sessionStore: this.sessionStore,
+      platforms: this.platforms,
+      limits: this.limits,
+      getContext: () => this.getContext(),
+      getContextPromptHandler: () => this.getContextPromptHandler(),
+      persistSession: (s) => this.persistSession(s),
+      createAndSwitchToWorktree: (tid, branch, user) =>
+        this.createAndSwitchToWorktree(tid, branch, user),
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/session/reaction-router.test.ts
+++ b/src/session/reaction-router.test.ts
@@ -14,7 +14,7 @@
  * that `handleReaction` presents to platform clients.
  */
 
-import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 import { handleReaction, type ReactionRouterDeps } from './reaction-router.js';
 import type { Session } from './types.js';
 import type { PlatformClient } from '../platform/index.js';
@@ -75,11 +75,6 @@ function makeDeps(
 }
 
 describe('ReactionRouter.handleReaction', () => {
-  beforeEach(() => {
-    // Bun's mock.fn resets per-test only if we reach through the registry,
-    // which we re-create via makeSession/makeDeps each test.
-  });
-
   describe('no session', () => {
     test('is a no-op when no session matches the post', async () => {
       const deps = makeDeps(null);
@@ -118,13 +113,17 @@ describe('ReactionRouter.handleReaction', () => {
     });
 
     test('allows users permitted by the platform allowlist even if not session-local', async () => {
+      // Session allowlist is `{alice}` (from the default fixture) and does
+      // NOT contain `bob`. Only the platform's `isUserAllowed` returning
+      // true can open the gate — if the router ever stopped consulting it,
+      // `bob` would be dropped and `handleReaction` would never be called.
+      const isUserAllowed = mock((user: string) => user === 'bob');
       const session = makeSession({
-        platform: {
-          isUserAllowed: mock(() => true),
-        } as unknown as PlatformClient,
+        platform: { isUserAllowed } as unknown as PlatformClient,
       });
       const deps = makeDeps(session);
       await handleReaction(deps, 'test', 'any', 'x', 'bob', 'added');
+      expect(isUserAllowed).toHaveBeenCalledWith('bob');
       expect(session.messageManager!.handleReaction).toHaveBeenCalled();
     });
   });

--- a/src/session/reaction-router.test.ts
+++ b/src/session/reaction-router.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for ReactionRouter — the reaction dispatch module extracted from
+ * `SessionManager` in PR 4.
+ *
+ * Focus:
+ * - Security gate (unauthorized users never reach dispatch).
+ * - Dispatch priority (session-level reactions checked before
+ *   MessageManager delegation).
+ * - Emoji normalization (`thumbsup` vs `+1`).
+ * - Same-platform check (reaction from a different platform dropped).
+ *
+ * These are integration-shaped (the router is plumbed to real deps via a
+ * lightweight fake), not unit tests — the point is to pin the contract
+ * that `handleReaction` presents to platform clients.
+ */
+
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
+import { handleReaction, type ReactionRouterDeps } from './reaction-router.js';
+import type { Session } from './types.js';
+import type { PlatformClient } from '../platform/index.js';
+import type { SessionRegistry } from './registry.js';
+import type { SessionStore } from '../persistence/session-store.js';
+import type { ResolvedLimits } from '../config/index.js';
+import type { SessionContext } from '../operations/session-context/index.js';
+import type { ContextPromptHandler } from '../operations/context-prompt/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    platformId: 'test',
+    threadId: 't1',
+    sessionId: 'test:t1',
+    startedBy: 'alice',
+    sessionAllowedUsers: new Set(['alice']),
+    sessionStartPostId: null,
+    worktreePromptPostId: undefined,
+    pendingWorktreeSuggestions: undefined,
+    lastError: undefined,
+    platform: {
+      isUserAllowed: mock(() => false),
+    } as unknown as PlatformClient,
+    messageManager: {
+      handleReaction: mock(() => Promise.resolve(false)),
+    } as any,
+    ...overrides,
+  } as unknown as Session;
+}
+
+function makeDeps(
+  session: Session | null,
+  overrides: Partial<ReactionRouterDeps> = {},
+): ReactionRouterDeps {
+  const registry: Partial<SessionRegistry> = {
+    findByPost: mock(() => session ?? undefined),
+    hasById: mock(() => false),
+    get size() { return 0; },
+  };
+  const sessionStore: Partial<SessionStore> = {
+    findByPostId: mock(() => undefined),
+  };
+  return {
+    registry: registry as SessionRegistry,
+    sessionStore: sessionStore as SessionStore,
+    platforms: new Map(),
+    limits: { maxSessions: 5 } as ResolvedLimits,
+    getContext: () => ({} as SessionContext),
+    getContextPromptHandler: () => ({} as ContextPromptHandler),
+    persistSession: mock(() => {}),
+    createAndSwitchToWorktree: mock(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+describe('ReactionRouter.handleReaction', () => {
+  beforeEach(() => {
+    // Bun's mock.fn resets per-test only if we reach through the registry,
+    // which we re-create via makeSession/makeDeps each test.
+  });
+
+  describe('no session', () => {
+    test('is a no-op when no session matches the post', async () => {
+      const deps = makeDeps(null);
+      // Non-resume emoji on unknown post: no crash, no dispatch.
+      await expect(
+        handleReaction(deps, 'test', 'unknown-post', 'x', 'alice', 'added'),
+      ).resolves.toBeUndefined();
+      expect(deps.registry.findByPost).toHaveBeenCalledWith('unknown-post');
+    });
+
+    test('checks the persistence store when the emoji is a resume emoji', async () => {
+      const deps = makeDeps(null);
+      // 🔄 (arrows_counterclockwise) is the resume emoji — the router must
+      // probe the session store to see if a timed-out session can be revived.
+      await handleReaction(deps, 'test', 'any-post', 'arrows_counterclockwise', 'alice', 'added');
+      expect(deps.sessionStore.findByPostId).toHaveBeenCalled();
+    });
+  });
+
+  describe('security gate', () => {
+    test('drops reactions from users not in sessionAllowedUsers nor platform allowlist', async () => {
+      const session = makeSession();
+      const deps = makeDeps(session);
+      await handleReaction(deps, 'test', 'any', 'x', 'mallory', 'added');
+      // MessageManager must not have been consulted.
+      expect(session.messageManager!.handleReaction).not.toHaveBeenCalled();
+    });
+
+    test('allows users in sessionAllowedUsers through to dispatch', async () => {
+      const session = makeSession();
+      const deps = makeDeps(session);
+      await handleReaction(deps, 'test', 'any', 'x', 'alice', 'added');
+      // MessageManager IS consulted for unknown postId — no session-level
+      // handler matched so the reaction falls through.
+      expect(session.messageManager!.handleReaction).toHaveBeenCalled();
+    });
+
+    test('allows users permitted by the platform allowlist even if not session-local', async () => {
+      const session = makeSession({
+        platform: {
+          isUserAllowed: mock(() => true),
+        } as unknown as PlatformClient,
+      });
+      const deps = makeDeps(session);
+      await handleReaction(deps, 'test', 'any', 'x', 'bob', 'added');
+      expect(session.messageManager!.handleReaction).toHaveBeenCalled();
+    });
+  });
+
+  describe('cross-platform isolation', () => {
+    test('ignores a reaction from a different platform than the session', async () => {
+      const session = makeSession({ platformId: 'mattermost' });
+      const deps = makeDeps(session);
+      await handleReaction(deps, 'slack', 'any', 'x', 'alice', 'added');
+      // Even though alice is allowed, the platform mismatch drops it before
+      // dispatch.
+      expect(session.messageManager!.handleReaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emoji normalization', () => {
+    test('normalizes thumbsup to +1 before dispatch', async () => {
+      const session = makeSession();
+      const deps = makeDeps(session);
+      await handleReaction(deps, 'test', 'any', 'thumbsup', 'alice', 'added');
+      // MessageManager receives the normalized form — this is what executors
+      // depend on for consistent emoji matching across platforms.
+      expect(session.messageManager!.handleReaction).toHaveBeenCalledWith(
+        'any',
+        '+1',
+        'alice',
+        'added',
+      );
+    });
+  });
+
+  describe('MessageManager fallthrough', () => {
+    test('skips MessageManager if the session has none (edge case)', async () => {
+      const session = makeSession({ messageManager: undefined });
+      const deps = makeDeps(session);
+      // Should not throw.
+      await expect(
+        handleReaction(deps, 'test', 'any', 'x', 'alice', 'added'),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/session/reaction-router.ts
+++ b/src/session/reaction-router.ts
@@ -1,0 +1,272 @@
+/**
+ * ReactionRouter — dispatches platform reaction events to the right handler.
+ *
+ * Extracted from `SessionManager` in PR 4. No behavior change vs. the old
+ * inline code path; the goal is just to separate reaction routing
+ * responsibilities from the rest of `SessionManager` so `manager.ts` shrinks
+ * toward a pure orchestration role.
+ *
+ * Split rationale (unchanged from SessionManager comments):
+ * - **SessionManager-owned reactions**: session lifecycle posts (cancel /
+ *   escape on the session-start post), worktree prompt (skip / branch pick),
+ *   bug-report emoji on the last error post. These mutate session-level
+ *   state that lives outside MessageManager, so they stay here.
+ * - **MessageManager-delegated reactions**: questions, plan approvals,
+ *   minimize toggles, message-approval prompts, context prompts. These are
+ *   owned by executors and dispatched via `MessageManager.handleReaction`.
+ *
+ * The router is a thin adapter around those two layers plus the SECURITY
+ * allowlist check that was previously embedded in `SessionManager`.
+ */
+
+import type { PlatformClient } from '../platform/index.js';
+import type { Session } from './types.js';
+import type { ReactionAction } from '../operations/executors/types.js';
+import type { SessionRegistry } from './registry.js';
+import type { SessionStore } from '../persistence/session-store.js';
+import type { ResolvedLimits } from '../config/index.js';
+import type { SessionContext } from '../operations/session-context/index.js';
+import type { ContextPromptHandler } from '../operations/context-prompt/index.js';
+import {
+  isCancelEmoji,
+  isEscapeEmoji,
+  isResumeEmoji,
+  getNumberEmojiIndex,
+  isBugReportEmoji,
+} from '../utils/emoji.js';
+import { normalizeEmojiName } from '../platform/utils.js';
+import * as lifecycle from './lifecycle.js';
+import * as commands from '../operations/commands/index.js';
+import * as worktreeModule from '../operations/worktree/index.js';
+import * as contextPrompt from '../operations/context-prompt/index.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('manager');
+
+/**
+ * Dependencies the router needs from `SessionManager`. Passing a plain
+ * object keeps the coupling explicit — no hidden access to private state.
+ */
+export interface ReactionRouterDeps {
+  registry: SessionRegistry;
+  sessionStore: SessionStore;
+  platforms: Map<string, PlatformClient>;
+  limits: ResolvedLimits;
+  getContext: () => SessionContext;
+  getContextPromptHandler: () => ContextPromptHandler;
+  persistSession: (session: Session) => void;
+  createAndSwitchToWorktree: (
+    threadId: string,
+    branch: string,
+    username: string,
+  ) => Promise<void>;
+}
+
+/**
+ * Route a platform reaction event to the appropriate handler.
+ *
+ * Returns nothing — the router swallows unhandled reactions (they're just
+ * a no-op). Callers wire this to `PlatformClient.on('reaction' | 'reaction_removed')`.
+ */
+export async function handleReaction(
+  deps: ReactionRouterDeps,
+  platformId: string,
+  postId: string,
+  emojiName: string,
+  username: string,
+  action: ReactionAction,
+): Promise<void> {
+  // Normalize emoji name to handle platform differences (e.g. Slack's
+  // "thumbsup" vs Mattermost's "+1"). Every downstream check assumes the
+  // normalized shape.
+  const normalizedEmoji = normalizeEmojiName(emojiName);
+
+  // Resume-emoji on a timed-out session's header or timeout post is special:
+  // the session is inactive, so the allowlist check can't rely on the active
+  // session's `sessionAllowedUsers`. `tryResumeFromReaction` does its own
+  // authorization check against the *persisted* allowlist.
+  if (action === 'added' && isResumeEmoji(normalizedEmoji)) {
+    const resumed = await tryResumeFromReaction(deps, platformId, postId, username);
+    if (resumed) return;
+  }
+
+  const session = deps.registry.findByPost(postId);
+  if (!session) return;
+
+  // Verify this reaction is from the same platform (composite session IDs
+  // make this cheap — a Slack post ID can't collide with a Mattermost one,
+  // but the guard protects against a future platform that reuses ID shapes).
+  if (session.platformId !== platformId) return;
+
+  // SECURITY: Only process reactions from allowed users.
+  // This is the primary authorization gate for all reaction-based actions.
+  // All reactions are validated here before reaching MessageManager/executors.
+  if (
+    !session.sessionAllowedUsers.has(username) &&
+    !session.platform.isUserAllowed(username)
+  ) {
+    // Audit trail: record unauthorized reaction attempts so operators can
+    // detect probing. Structured fields stay searchable across platforms.
+    log.info(`🚫 rejected reaction from unauthorized user`, {
+      event: 'reaction.rejected',
+      platformId,
+      sessionId: session.sessionId,
+      postId,
+      emoji: normalizedEmoji,
+      action,
+      user: username,
+    });
+    return;
+  }
+
+  await dispatch(deps, session, postId, normalizedEmoji, username, action);
+}
+
+/**
+ * Try to resume a timed-out session via emoji reaction on the timeout post
+ * or session header.
+ */
+async function tryResumeFromReaction(
+  deps: ReactionRouterDeps,
+  platformId: string,
+  postId: string,
+  username: string,
+): Promise<boolean> {
+  const persistedSession = deps.sessionStore.findByPostId(platformId, postId);
+  if (!persistedSession) return false;
+
+  // Already active? Nothing to resume.
+  const sessionId = `${platformId}:${persistedSession.threadId}`;
+  if (deps.registry.hasById(sessionId)) return false;
+
+  // Authorization against the *persisted* allowlist — the session object
+  // doesn't exist yet, so we can't use `session.sessionAllowedUsers`.
+  const allowedUsers = new Set(persistedSession.sessionAllowedUsers);
+  const platform = deps.platforms.get(platformId);
+  if (!allowedUsers.has(username) && !platform?.isUserAllowed(username)) {
+    if (platform) {
+      await platform.createPost(
+        `⚠️ @${username} is not authorized to resume this session`,
+        persistedSession.threadId,
+      );
+    }
+    return false;
+  }
+
+  // Capacity check — a resumed session consumes a slot.
+  if (deps.registry.size >= deps.limits.maxSessions) {
+    if (platform) {
+      const fmt = platform.getFormatter();
+      await platform.createPost(
+        `⚠️ ${fmt.formatBold('Too busy')} - ${deps.registry.size} sessions active. Please try again later.`,
+        persistedSession.threadId,
+      );
+    }
+    return false;
+  }
+
+  const shortId = persistedSession.threadId.substring(0, 8);
+  log.info(`🔄 Resuming session ${shortId}... via emoji reaction by @${username}`);
+
+  await lifecycle.resumeSession(persistedSession, deps.getContext());
+  return true;
+}
+
+/**
+ * Dispatch a normalized, authorized reaction to the right handler.
+ *
+ * Session-level reactions are checked first — they mutate state that lives
+ * on `Session` directly (worktree info, last error, lifecycle flags) and
+ * need `SessionManager` callbacks. If no session-level handler claims the
+ * reaction, it falls through to `MessageManager.handleReaction` which
+ * iterates executors.
+ */
+async function dispatch(
+  deps: ReactionRouterDeps,
+  session: Session,
+  postId: string,
+  emojiName: string,
+  username: string,
+  action: ReactionAction,
+): Promise<void> {
+  // ---------------------------------------------------------------------------
+  // Session-level reactions (lifecycle, worktrees, bug reports)
+  // ---------------------------------------------------------------------------
+  if (action === 'added') {
+    // Cancel/escape on the session start post
+    if (session.sessionStartPostId === postId) {
+      if (isCancelEmoji(emojiName)) {
+        await commands.cancelSession(session, username, deps.getContext());
+        return;
+      }
+      if (isEscapeEmoji(emojiName)) {
+        await commands.interruptSession(session, username);
+        return;
+      }
+    }
+
+    // ❌ on worktree prompt → skip worktree
+    if (session.worktreePromptPostId === postId && emojiName === 'x') {
+      await worktreeModule.handleWorktreeSkip(
+        session,
+        username,
+        (s) => deps.persistSession(s),
+        (s, q) =>
+          contextPrompt.offerContextPrompt(
+            s,
+            q,
+            undefined,
+            deps.getContextPromptHandler(),
+          ),
+      );
+      return;
+    }
+
+    // Number emoji on worktree prompt → select branch suggestion
+    if (session.pendingWorktreeSuggestions?.postId === postId) {
+      const emojiIndex = getNumberEmojiIndex(emojiName);
+      if (emojiIndex >= 0) {
+        const handled = await worktreeModule.handleBranchSuggestionReaction(
+          session,
+          postId,
+          emojiIndex,
+          username,
+          (tid, branch, user) => deps.createAndSwitchToWorktree(tid, branch, user),
+        );
+        if (handled) return;
+      }
+    }
+
+    // 🐛 on the last error post → open bug report
+    if (session.lastError?.postId === postId && isBugReportEmoji(emojiName)) {
+      if (
+        session.startedBy === username ||
+        session.platform.isUserAllowed(username) ||
+        session.sessionAllowedUsers.has(username)
+      ) {
+        log.info(`🐛 @${username} triggered bug report from error reaction`);
+        await commands.reportBug(
+          session,
+          undefined,
+          username,
+          deps.getContext(),
+          session.lastError,
+        );
+        return;
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // MessageManager-delegated reactions (questions, approvals, toggles)
+  // ---------------------------------------------------------------------------
+  if (session.messageManager) {
+    const handled = await session.messageManager.handleReaction(
+      postId,
+      emojiName,
+      username,
+      action,
+    );
+    if (handled) return;
+  }
+}


### PR DESCRIPTION
Fourth PR from the [refactor roadmap](../blob/main/CLAUDE.md). Pure extraction — no behavior change, no persisted-schema change, no user-visible change.

## What moved

New module `src/session/reaction-router.ts` (272 LOC) takes over the reaction dispatch logic previously inlined as three private methods on `SessionManager`:

- `handleReaction` — emoji normalization, resume-from-reaction check, allowlist gate, audit log
- `tryResumeFromReaction` — resume a timed-out session from a 🔄 reaction
- `handleSessionReaction` — session-level reactions (cancel, escape, worktree, bug report) + MessageManager fallthrough

The router takes a plain `ReactionRouterDeps` object instead of a `SessionManager` reference. Explicit coupling, testable in isolation.

## What stays

- `SessionManager.handleReaction` remains as a one-liner delegation. Platform client subscriptions in `addPlatform` untouched.
- The split between session-level vs MessageManager-delegated reactions is unchanged — the router just encodes it explicitly instead of leaving it as a pair of if-blocks.
- Backward compat is trivially preserved: the public surface of `SessionManager` is unchanged.

## Size

| File | Before | After | Delta |
|------|--------|-------|-------|
| `src/session/manager.ts` | 1767 | 1633 | -134 |
| `src/session/reaction-router.ts` | — | 272 | +272 |
| `src/session/reaction-router.test.ts` | — | 150 | +150 |

The original roadmap target was <900 LOC for `manager.ts`, but most of the remaining bulk is one-liner command delegations (`killSession`, `cancelSession`, `inviteUser`, `setSessionPermissionMode`, `changeDirectory`, etc.) which are the bot's public API. Splitting them further would move lines, not reduce complexity. Stopping at the reaction-router extraction rather than forcing a synthetic split.

## Tests

+8 new tests in `src/session/reaction-router.test.ts` covering:
- security gate (unauthorized users dropped before dispatch)
- cross-platform isolation (Slack reaction on Mattermost session dropped)
- emoji normalization (`thumbsup` → `+1` before dispatch)
- resume-emoji path (persistence store consulted)
- missing MessageManager edge case

Existing `manager.test.ts` tests that exercise `(manager as any).handleReaction(...)` continue to pass unmodified — they now integration-test the router through the delegation.

Total: 2145 → 2153 (+8).

## Verification

- [x] Red-green confirmed: removed router source, tests fail; restored, all pass.
- [x] `bun test src/` — 2153 pass, 0 fail.
- [x] `bun run lint` clean.
- [x] `bun run typecheck` clean.
- [ ] `bun run test:integration` runs in CI.

## Roadmap

With PR 4 merged, PR 5 becomes the closeout:
- Remove `CLAUDE_THREADS_SERIALIZE_V2` flag from PR 3 (one release baked)
- Lifecycle FSM (warn-only by default)
- Doc updates

Lower-value than PRs 1–4 — may or may not land, depending on appetite.