### PR TITLE
refactor: PR 5 — cleanup + lifecycle FSM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ Session is a thin container; most logic lives in `src/operations/`:
 | File | Purpose |
 |------|---------|
 | `src/session/manager.ts` | **Orchestrator** - creates sessions, routes messages/reactions |
+| `src/session/reaction-router.ts` | Reaction dispatch: allowlist gate, resume-from-reaction, session-level reactions, MessageManager fallthrough |
 | `src/session/lifecycle.ts` | Session start, resume, exit, cleanup |
 | `src/session/types.ts` | TypeScript types (Session interface) |
 | `src/session/registry.ts` | Session lookup and registration |

--- a/src/claude/cli.test.ts
+++ b/src/claude/cli.test.ts
@@ -310,26 +310,19 @@ describe('StatusLineData interface', () => {
 });
 
 // ============================================================================
-// materializeMcpConfig — default is tempfile (owner-only) so the platform
-// token does not appear in `ps`. The rollback flag keeps the inline path.
+// materializeMcpConfig — production always writes to an owner-only tempfile
+// so the platform token does not appear in `ps`. The `inline` opt is kept
+// for tests only.
 // ============================================================================
 describe('materializeMcpConfig', () => {
   let scratchDir: string;
-  let originalInlineEnv: string | undefined;
 
   beforeEach(() => {
     scratchDir = mkdtempSync(join(tmpdir(), 'mcp-config-test-'));
-    originalInlineEnv = process.env.CLAUDE_THREADS_MCP_CONFIG_INLINE;
-    delete process.env.CLAUDE_THREADS_MCP_CONFIG_INLINE;
   });
 
   afterEach(() => {
     rmSync(scratchDir, { recursive: true, force: true });
-    if (originalInlineEnv === undefined) {
-      delete process.env.CLAUDE_THREADS_MCP_CONFIG_INLINE;
-    } else {
-      process.env.CLAUDE_THREADS_MCP_CONFIG_INLINE = originalInlineEnv;
-    }
   });
 
   function makeConfig(): McpConfigBlob {
@@ -372,19 +365,13 @@ describe('materializeMcpConfig', () => {
     rmSync(result.path);
   });
 
-  it('returns inline JSON when CLAUDE_THREADS_MCP_CONFIG_INLINE=1 is set', () => {
-    process.env.CLAUDE_THREADS_MCP_CONFIG_INLINE = '1';
-    const result = materializeMcpConfig(makeConfig(), 'session-abc', { tmpDirOverride: scratchDir });
+  it('returns inline JSON when the opt-in is explicitly set (test-only)', () => {
+    const result = materializeMcpConfig(makeConfig(), 'session-abc', { inline: true, tmpDirOverride: scratchDir });
     expect(result.mode).toBe('inline');
     if (result.mode !== 'inline') return;
     expect(result.value).toContain('SECRET-TOKEN');
     // Critical: no stray file written when inline mode selected.
     expect(readdirOrEmpty(scratchDir)).toEqual([]);
-  });
-
-  it('honors the explicit inline opt-in even without env var', () => {
-    const result = materializeMcpConfig(makeConfig(), 'session-abc', { inline: true, tmpDirOverride: scratchDir });
-    expect(result.mode).toBe('inline');
   });
 });
 

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -221,9 +221,10 @@ export interface McpConfigBlob {
 }
 
 /**
- * Materialize an MCP config for handoff to Claude CLI. Either writes it to an
- * owner-only tempfile (default) and returns the path, or returns the inline
- * JSON string when the `CLAUDE_THREADS_MCP_CONFIG_INLINE=1` rollback env is set.
+ * Materialize an MCP config for handoff to Claude CLI. Writes it to an
+ * owner-only tempfile (mode 0600) and returns the path. The `inline` opt
+ * is for tests that want to keep Claude invocation off disk — production
+ * always goes via tempfile so the bot's platform token doesn't appear in `ps`.
  *
  * Exported so tests can assert file mode + contents without spawning Claude.
  */
@@ -232,7 +233,7 @@ export function materializeMcpConfig(
   sessionId: string | undefined,
   opts: { inline?: boolean; tmpDirOverride?: string } = {},
 ): { mode: 'inline'; value: string } | { mode: 'file'; path: string } {
-  if (opts.inline ?? process.env.CLAUDE_THREADS_MCP_CONFIG_INLINE === '1') {
+  if (opts.inline) {
     return { mode: 'inline', value: JSON.stringify(config) };
   }
   const dir = opts.tmpDirOverride ?? tmpdir();
@@ -455,8 +456,7 @@ export class ClaudeCli extends EventEmitter {
     // platform bot token. Passing it as an argv string would expose the
     // token in `ps`. `buildPermissionArgs` writes it to an owner-only
     // tempfile (mode 0600) and records the path on `this` for cleanup on
-    // exit. Set CLAUDE_THREADS_MCP_CONFIG_INLINE=1 to fall back to inline
-    // JSON as a one-release rollback hatch.
+    // exit.
     const permResult = buildPermissionArgs({
       permissionMode,
       mcpServerPath: this.getMcpServerPath(),

--- a/src/operations/message-manager.ts
+++ b/src/operations/message-manager.ts
@@ -821,10 +821,9 @@ export class MessageManager {
   }
 
   /**
-   * Get task list state for persistence.
-   *
-   * @deprecated Use `serialize()` instead; this wrapper is kept for
-   * one release as a rollback path (`CLAUDE_THREADS_SERIALIZE_V2=0`).
+   * Task list snapshot. Used by callers that read task state outside the
+   * persistence writer — sticky-message handler, lifecycle exit cleanup.
+   * Persistence itself goes through `serialize()`.
    */
   getTaskListState(): {
     postId: string | null;

--- a/src/session/lifecycle-fsm.test.ts
+++ b/src/session/lifecycle-fsm.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the lifecycle FSM.
+ *
+ * Two modes:
+ * - warn-only (default): illegal transitions log but don't throw.
+ * - strict (`CLAUDE_THREADS_FSM_STRICT=1`): illegal transitions throw.
+ *
+ * The allowed-transition table is the contract. These tests pin it so that
+ * changing an entry requires thinking about *why* — the warn logs in
+ * production are only useful if the allowed set is honest.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  checkTransition,
+  allowedTargetsFrom,
+  ALL_STATES,
+} from './lifecycle-fsm.js';
+import type { SessionLifecycleState } from './types.js';
+import { setLogHandler } from '../utils/logger.js';
+
+describe('lifecycle FSM', () => {
+  describe('allowed transitions', () => {
+    // Each state's legal target set. Kept verbose so a diff against the
+    // FSM module is readable — if a transition is added/removed here,
+    // the change is deliberate.
+    const cases: Array<[SessionLifecycleState, SessionLifecycleState[]]> = [
+      ['starting', ['active', 'paused', 'interrupted', 'cancelling', 'restarting']],
+      ['active', ['active', 'processing', 'paused', 'interrupted', 'restarting', 'cancelling', 'ending']],
+      ['processing', ['active', 'paused', 'interrupted', 'restarting', 'cancelling']],
+      ['paused', ['active', 'cancelling', 'restarting']],
+      ['interrupted', ['active', 'cancelling', 'restarting', 'paused']],
+      ['restarting', ['active', 'paused', 'cancelling']],
+      ['cancelling', ['ending']],
+      ['ending', []],
+    ];
+
+    for (const [from, legalTargets] of cases) {
+      test(`${from} → {${legalTargets.join(', ')}}`, () => {
+        const allowed = allowedTargetsFrom(from);
+        expect([...allowed].sort()).toEqual([...legalTargets].sort());
+      });
+    }
+  });
+
+  describe('warn mode (default)', () => {
+    const captured: Array<{ level: string; msg: string }> = [];
+
+    beforeEach(() => {
+      captured.length = 0;
+      setLogHandler((level, _component, msg) => {
+        captured.push({ level, msg });
+      });
+    });
+
+    afterEach(() => {
+      setLogHandler(null);
+    });
+
+    test('legal transition: silent, no log', () => {
+      checkTransition('active', 'paused', 'test:t1');
+      expect(captured.filter(e => e.msg.includes('illegal'))).toEqual([]);
+    });
+
+    test('illegal transition: warn, does not throw', () => {
+      // `cancelling` is terminal for everything but ending — ending is the
+      // only legal target and paused is illegal.
+      expect(() => checkTransition('cancelling', 'paused', 'test:t1')).not.toThrow();
+      const warns = captured.filter(e => e.msg.includes('illegal lifecycle transition'));
+      expect(warns).toHaveLength(1);
+      expect(warns[0].level).toBe('warn');
+      expect(warns[0].msg).toContain('cancelling -> paused');
+    });
+
+    test('illegal transition log includes the sessionId', () => {
+      checkTransition('ending', 'active', 'slack:thread-xyz');
+      const warn = captured.find(e => e.msg.includes('illegal'));
+      // sessionId lands in the structured payload (rendered as JSON in the log).
+      // The message itself pins the from → to pair; the payload is separate.
+      expect(warn?.msg).toContain('ending -> active');
+    });
+  });
+
+  describe('strict mode', () => {
+    let original: string | undefined;
+
+    beforeEach(() => {
+      original = process.env.CLAUDE_THREADS_FSM_STRICT;
+      process.env.CLAUDE_THREADS_FSM_STRICT = '1';
+    });
+
+    afterEach(() => {
+      if (original === undefined) {
+        delete process.env.CLAUDE_THREADS_FSM_STRICT;
+      } else {
+        process.env.CLAUDE_THREADS_FSM_STRICT = original;
+      }
+    });
+
+    test('legal transition: no throw', () => {
+      expect(() => checkTransition('active', 'paused', 'test:t1')).not.toThrow();
+    });
+
+    test('illegal transition: throws with informative message', () => {
+      expect(() => checkTransition('cancelling', 'active', 'test:t1')).toThrow(
+        /cancelling -> active/,
+      );
+    });
+
+    test('thrown error carries sessionId', () => {
+      let err: unknown;
+      try {
+        checkTransition('ending', 'starting', 'mattermost:t42');
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain('mattermost:t42');
+    });
+  });
+
+  describe('exhaustiveness', () => {
+    test('ALL_STATES covers every SessionLifecycleState the FSM recognises', () => {
+      // If a new state is added to SessionLifecycleState but not to the FSM
+      // table, `allowedTargetsFrom` will throw or return undefined. This
+      // test catches the mismatch.
+      for (const state of ALL_STATES) {
+        expect(() => allowedTargetsFrom(state)).not.toThrow();
+        const targets = allowedTargetsFrom(state);
+        expect(targets).toBeInstanceOf(Set);
+      }
+    });
+  });
+});

--- a/src/session/lifecycle-fsm.ts
+++ b/src/session/lifecycle-fsm.ts
@@ -1,0 +1,179 @@
+/**
+ * Session lifecycle finite-state machine.
+ *
+ * Defines the legal transitions between `SessionLifecycleState` values and
+ * provides a `check()` helper that `transitionTo()` calls before mutating
+ * state. By default, illegal transitions are logged at `warn` level with a
+ * structured payload — the transition still happens, so this is purely
+ * observability. Set `CLAUDE_THREADS_FSM_STRICT=1` to throw instead; useful
+ * for catching bugs in tests, not recommended for production until we've
+ * observed a few weeks of real traffic without warnings.
+ *
+ * ## Current states
+ *
+ * | State        | What it means                                                |
+ * |--------------|--------------------------------------------------------------|
+ * | `starting`   | Initial state. Session is being created.                     |
+ * | `active`     | Normal operation. Claude is idle or streaming.               |
+ * | `processing` | Reserved — never transitioned to in current code.            |
+ * | `paused`     | Timed out. Waiting for resume reaction or user message.      |
+ * | `interrupted`| User pressed escape / ⏸️. Claude stopped mid-turn.            |
+ * | `restarting` | `!cd` / `!permissions` / worktree switch — Claude respawns.  |
+ * | `cancelling` | `!stop` / ❌ — session is being torn down.                   |
+ * | `ending`     | Reserved — never transitioned to in current code.            |
+ *
+ * `processing` and `ending` are declared in the type but no call site
+ * currently transitions to them. They're permitted as targets from `active`
+ * for forward compatibility, but the warn logs will reveal if something
+ * actually hits those paths.
+ *
+ * ## Transitions (source-of-truth)
+ *
+ * Keep this table in sync with `ALLOWED_TRANSITIONS` below. When adding a
+ * transition, update both the code and this comment.
+ *
+ * ```
+ * starting   -> active                 (markClaudeResponded)
+ * starting   -> paused                 (idle timeout before first response)
+ * starting   -> interrupted            (escape before first response)
+ * starting   -> cancelling             (cancel during startup)
+ * starting   -> restarting             (!cd / !permissions before first response, e.g. on a just-resumed session)
+ * active     -> active                 (idempotent no-op, e.g. post-reply)
+ * active     -> processing             (reserved)
+ * active     -> paused                 (idle timeout)
+ * active     -> interrupted            (!escape)
+ * active     -> restarting             (!cd, !permissions, worktree)
+ * active     -> cancelling             (!stop)
+ * active     -> ending                 (reserved)
+ * processing -> active                 (request complete)
+ * processing -> paused                 (idle timeout mid-processing)
+ * processing -> interrupted            (!escape mid-processing)
+ * processing -> restarting             (!cd mid-processing)
+ * processing -> cancelling             (!stop mid-processing)
+ * paused     -> active                 (resumed)
+ * paused     -> cancelling             (cancel while paused)
+ * paused     -> restarting             (!cd on a just-resumed session)
+ * interrupted-> active                 (next message continues the session)
+ * interrupted-> cancelling             (!stop while interrupted)
+ * interrupted-> restarting             (!cd while interrupted)
+ * interrupted-> paused                 (idle timeout after escape)
+ * restarting -> active                 (respawn succeeded)
+ * restarting -> paused                 (respawn failed, persisted)
+ * restarting -> cancelling             (cancel during restart)
+ * cancelling -> ending                 (terminal)
+ * ```
+ *
+ * Everything not listed is illegal.
+ */
+
+import type { SessionLifecycleState } from './types.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('fsm');
+
+// ---------------------------------------------------------------------------
+// Transition table
+// ---------------------------------------------------------------------------
+
+/**
+ * Allowed `from -> to` transitions. `Set` membership is the check.
+ *
+ * Self-transitions (e.g. `active -> active`) are allowed for states where
+ * idempotent re-entry is common — they're no-ops and should not log.
+ * Other self-transitions are listed explicitly only when observed in the
+ * real code.
+ */
+const ALLOWED_TRANSITIONS: Record<SessionLifecycleState, ReadonlySet<SessionLifecycleState>> = {
+  // starting → paused: idle timeout fires before first Claude response
+  // starting → interrupted: user presses escape during startup
+  // starting → restarting: `!cd`/`!permissions` on a just-resumed session
+  starting: new Set(['active', 'paused', 'interrupted', 'cancelling', 'restarting']),
+
+  active: new Set([
+    'active',      // idempotent; many post-helpers call transitionTo('active') defensively
+    'processing',
+    'paused',
+    'interrupted',
+    'restarting',
+    'cancelling',
+    'ending',
+  ]),
+
+  processing: new Set([
+    'active',
+    'paused',
+    'interrupted',
+    'restarting',
+    'cancelling',
+  ]),
+
+  // paused → restarting: resumed session goes straight into a respawn path
+  paused: new Set(['active', 'cancelling', 'restarting']),
+
+  // interrupted → paused: idle timeout after escape
+  interrupted: new Set(['active', 'cancelling', 'restarting', 'paused']),
+
+  restarting: new Set(['active', 'paused', 'cancelling']),
+  cancelling: new Set(['ending']),
+  ending: new Set(), // terminal
+};
+
+// ---------------------------------------------------------------------------
+// Check
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a `from -> to` transition against the FSM.
+ *
+ * - Legal transition: no-op.
+ * - Illegal transition + `CLAUDE_THREADS_FSM_STRICT=1`: throws `Error`.
+ * - Illegal transition otherwise: logs `warn` with structured payload.
+ *
+ * The structured log fields are stable (matched by ops tooling): `event`,
+ * `from`, `to`, `sessionId`.
+ */
+export function checkTransition(
+  from: SessionLifecycleState,
+  to: SessionLifecycleState,
+  sessionId: string,
+): void {
+  const allowed = ALLOWED_TRANSITIONS[from];
+  if (allowed.has(to)) return;
+
+  const msg = `illegal lifecycle transition ${from} -> ${to}`;
+  const payload = {
+    event: 'fsm.illegal_transition',
+    from,
+    to,
+    sessionId,
+  };
+
+  if (process.env.CLAUDE_THREADS_FSM_STRICT === '1') {
+    throw new Error(`${msg} (sessionId=${sessionId})`);
+  }
+
+  log.warn(msg, payload);
+}
+
+// ---------------------------------------------------------------------------
+// Introspection (exposed for tests)
+// ---------------------------------------------------------------------------
+
+/** All states declared by the FSM. Useful for exhaustive tests. */
+export const ALL_STATES: readonly SessionLifecycleState[] = [
+  'starting',
+  'active',
+  'processing',
+  'paused',
+  'interrupted',
+  'restarting',
+  'cancelling',
+  'ending',
+];
+
+/** Read-only view of the transition table (for tests and diagnostics). */
+export function allowedTargetsFrom(
+  from: SessionLifecycleState,
+): ReadonlySet<SessionLifecycleState> {
+  return ALLOWED_TRANSITIONS[from];
+}

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -772,45 +772,5 @@ describe('SessionManager', () => {
       expect(written.tasksMinimized).toBe(false);
       expect(written.pendingContextPrompt).toBeUndefined();
     });
-
-    test('legacy path (SERIALIZE_V2=0) produces the same payload as the new path', () => {
-      const original = process.env.CLAUDE_THREADS_SERIALIZE_V2;
-      const capturedNew: unknown[] = [];
-      const capturedLegacy: unknown[] = [];
-      (manager as any).sessionStore.save = (_id: string, data: unknown) => {
-        if (process.env.CLAUDE_THREADS_SERIALIZE_V2 === '0') capturedLegacy.push(data);
-        else capturedNew.push(data);
-      };
-
-      const session = injectSession(manager, platform as unknown as PlatformClient, 'thread-eq', {
-        sessionTitle: 'Parity',
-      });
-      session.messageManager = {
-        serialize: () => ({
-          taskList: { postId: 'T', content: 'x', isMinimized: true, isCompleted: true },
-          contextPrompt: null,
-        }),
-        getTaskListState: () => ({ postId: 'T', content: 'x', isMinimized: true, isCompleted: true }),
-        getPendingContextPrompt: () => null,
-      } as any;
-
-      try {
-        delete process.env.CLAUDE_THREADS_SERIALIZE_V2;
-        (manager as any).persistSession(session);
-        process.env.CLAUDE_THREADS_SERIALIZE_V2 = '0';
-        (manager as any).persistSession(session);
-      } finally {
-        if (original === undefined) {
-          delete process.env.CLAUDE_THREADS_SERIALIZE_V2;
-        } else {
-          process.env.CLAUDE_THREADS_SERIALIZE_V2 = original;
-        }
-      }
-
-      // Payloads must be byte-identical. This is what protects users on
-      // the rollback path (`CLAUDE_THREADS_SERIALIZE_V2=0`) from a divergent
-      // `sessions.json` format.
-      expect(JSON.stringify(capturedNew[0])).toEqual(JSON.stringify(capturedLegacy[0]));
-    });
   });
 });

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -560,37 +560,21 @@ export class SessionManager extends EventEmitter {
   // ---------------------------------------------------------------------------
 
   private persistSession(session: Session): void {
-    // Aggregate every executor's persistable state in a single call.
-    // Rollback: `CLAUDE_THREADS_SERIALIZE_V2=0` re-enables the old per-getter
-    // path for one release, in case a downstream consumer depends on it.
-    const useSerializeV2 = process.env.CLAUDE_THREADS_SERIALIZE_V2 !== '0';
+    // Aggregate every executor's persistable state in one call. Byte-parity
+    // with the pre-PR-3 writer is guarded by the snapshot tests in
+    // `manager.test.ts` — adding a field here without updating the snapshot
+    // expected-keys set will fail CI.
     let taskListSnapshot:
       | { postId: string | null; content: string | null; isMinimized: boolean; isCompleted: boolean }
       | undefined;
     let contextPromptSnapshot: PersistedContextPrompt | undefined;
 
-    if (useSerializeV2 && session.messageManager) {
+    if (session.messageManager) {
       const serialized = session.messageManager.serialize();
       taskListSnapshot = serialized.taskList;
       if (serialized.contextPrompt) {
         contextPromptSnapshot = serialized.contextPrompt;
       }
-    } else {
-      // Legacy path (rollback flag) — kept so a user who trips over a
-      // regression can unset the flag and get the pre-PR-3 behavior back
-      // without a release.
-      const legacyPrompt = session.messageManager?.getPendingContextPrompt();
-      if (legacyPrompt) {
-        contextPromptSnapshot = {
-          postId: legacyPrompt.postId,
-          queuedPrompt: legacyPrompt.queuedPrompt,
-          queuedFiles: legacyPrompt.queuedFiles,
-          threadMessageCount: legacyPrompt.threadMessageCount,
-          createdAt: legacyPrompt.createdAt,
-          availableOptions: legacyPrompt.availableOptions,
-        };
-      }
-      taskListSnapshot = session.messageManager?.getTaskListState();
     }
 
     const state: PersistedSession = {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -12,6 +12,7 @@ import type { ThreadLogger } from '../persistence/thread-logger.js';
 import type { MessageManager } from '../operations/message-manager.js';
 import type { QuestionOption } from '../operations/types.js';
 import type { SessionTimers } from './timer-manager.js';
+import { checkTransition } from './lifecycle-fsm.js';
 
 // Re-export timer types
 export type { SessionTimers };
@@ -216,8 +217,14 @@ export function isSessionCancelled(session: Session): boolean {
 
 /**
  * Transition session to a new lifecycle state.
+ *
+ * Routes through the FSM in `lifecycle-fsm.ts` — illegal transitions are
+ * logged at `warn` level by default, and throw when
+ * `CLAUDE_THREADS_FSM_STRICT=1` is set. The state assignment still happens
+ * either way (warn mode is observational, not enforcing).
  */
 export function transitionTo(session: Session, newState: SessionLifecycleState): void {
+  checkTransition(session.lifecycle.state, newState, session.sessionId);
   session.lifecycle.state = newState;
 }
 


### PR DESCRIPTION
Fifth and final PR from the [refactor roadmap](../blob/main/CLAUDE.md). Two rollback flags removed (both baked) plus a new lifecycle FSM (warn-only default).

## Legacy rollback flags removed

**\`CLAUDE_THREADS_SERIALIZE_V2\`** (from PR 3 / v1.9.1). \`persistSession\` now unconditionally goes through \`MessageManager.serialize()\`. The parity test that guarded byte-identity across the two paths is removed; the snapshot tests in \`manager.test.ts\` remain as the on-disk-shape guard.

**\`CLAUDE_THREADS_MCP_CONFIG_INLINE\`** (from PR 2 / v1.9.0). Production always writes the MCP config to an owner-only tempfile (mode 0600). The \`inline\` opt on \`materializeMcpConfig\` is kept for tests that want to keep Claude invocation off disk — that's a separate, test-only concern from the user-facing rollback.

The previously \`@deprecated\` \`getTaskListState\` / \`getPendingContextPrompt\` wrappers on \`MessageManager\` stay. They have real non-persistence callers (context-prompt handler, sticky-message handler, lifecycle exit), so they're not orphans. Deprecation comment updated to reflect that role.

## Lifecycle FSM (warn-only default)

New \`src/session/lifecycle-fsm.ts\`. \`transitionTo()\` routes through \`checkTransition()\` which validates \`from → to\` against an allowed-transition table.

**Default (warn-only):** illegal transitions log at \`warn\` with a structured payload (\`event: 'fsm.illegal_transition'\`, \`from\`, \`to\`, \`sessionId\`) and the state assignment proceeds. Observational, not enforcing.

**\`CLAUDE_THREADS_FSM_STRICT=1\`:** illegal transitions throw. Useful for tests/CI/staging where you actively want to hunt bugs.

**Why not strict by default:** the transition table is derived from *observed* transitions in the current codebase, not an idealised graph. The tests don't cover every production path (daemon restarts, platform disconnects mid-worktree, etc.), so strict-by-default risks crashing on a legitimate rare transition nobody thought of. Warn-first, then tighten once we've seen a release or two of real traffic.

**What the FSM surfaced:** wiring it up ran the existing test suite through a real validator and flagged five transitions the original lifecycle comment block didn't mention. All legitimate — the table now documents them:

- \`starting → paused\` (idle timeout before first Claude response)
- \`starting → interrupted\` (escape before first response)
- \`starting → restarting\` (\`!cd\` on a just-resumed session)
- \`paused → restarting\` (same path from a paused start)
- \`interrupted → paused\` (idle timeout after escape)

## Docs

\`CLAUDE.md\`'s Session Management source-files table gets the new \`reaction-router.ts\` entry from PR 4.

## Tests

| | Before | After |
|---|---|---|
| \`lifecycle-fsm.test.ts\` (new) | — | 15 |
| SERIALIZE_V2 parity test | 1 | — |
| MCP_CONFIG_INLINE env test | 1 | — |
| **Total** | **2153** | **2166** |

The FSM tests pin the allowed-transition table: if you change an entry in the code, the matching test fails and forces you to think about why.

## Not in this PR

**\`skipPermissions\` stays.** It lives in users' \`config.yaml\` files on disk. Removing it without a config migration would silently break existing permission settings. If we ever remove it, it needs:

- A \`skipPermissions → permissionMode\` migration that reads the legacy field, writes the equivalent \`permissionMode\`, and removes the legacy field from the file
- A major version bump (v2.0.0)
- A changelog entry loud enough that users reconfigure before upgrading

Out of scope for a pure refactor PR.

## Verification

- [x] Red-green confirmed: removed \`lifecycle-fsm.ts\`, tests failed; restored, all passed.
- [x] \`bun test src/\` — 2166 pass, 0 fail
- [x] \`bun run lint\` clean
- [x] \`bun run typecheck\` clean
- [ ] \`bun run test:integration\` — runs in CI

## Roadmap status

PR 5 of 5. Roadmap complete.