### PR TITLE
fix: sticky-by-thread Claude account binding (multi-account)

### DIFF
--- a/src/claude/account-pool.test.ts
+++ b/src/claude/account-pool.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for AccountPool.
  */
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, setSystemTime } from 'bun:test';
 import { AccountPool } from './account-pool.js';
 
 describe('AccountPool', () => {
@@ -114,6 +114,114 @@ describe('AccountPool', () => {
       const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
       pool.markCooling('a', Date.now() - 1); // already expired
       expect(pool.acquire()?.id).toBe('a');
+    });
+  });
+
+  describe('sticky-by-thread binding', () => {
+    // Regression: in claude-threads <=1.8.2 the pool was strictly round-robin,
+    // and the claudeAccountId persisted to sessions.json could drift away from
+    // the $HOME Claude actually spawned under (race between multiple acquires
+    // and the writeAtomic of the whole sessions map). After a bot restart that
+    // mismatch produced "conversation history no longer exists" → soft-delete.
+    // Sticky binding by hash(threadId) closes the race deterministically.
+
+    it('always returns the same account for a given threadId', () => {
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+        { id: 'c', home: '/tmp/c' },
+      ]);
+      const first = pool.acquire(undefined, 'thread-xyz');
+      // Many subsequent acquires for the same thread must return the same id,
+      // independent of intervening calls from other threads.
+      pool.acquire(undefined, 'thread-other-1');
+      pool.acquire(undefined, 'thread-other-2');
+      pool.acquire(); // anonymous round-robin must not affect sticky binding
+      pool.acquire(undefined, 'thread-other-3');
+      for (let i = 0; i < 20; i++) {
+        expect(pool.acquire(undefined, 'thread-xyz')?.id).toBe(first?.id);
+      }
+    });
+
+    it('does not advance roundRobinIndex when sticky path serves the request', () => {
+      // Design invariant: sticky-bound threads must not perturb the cursor
+      // the anonymous round-robin path uses. Otherwise heavy use of one
+      // sticky thread silently shifts how anonymous acquires distribute,
+      // which is exactly the kind of subtle drift this fix is meant to
+      // eliminate.
+      //
+      // n=2 is required for RED-GREEN: with n=3 the cursor cycles back to 0
+      // after 3 RR calls "by luck" and the test passes either way. With n=2,
+      // 3 RR calls leave the cursor at index 1, so the anonymous acquire
+      // returns 'b' under the broken code path and 'a' under the fix.
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+      ]);
+      pool.acquire(undefined, 'sticky-1');
+      pool.acquire(undefined, 'sticky-2');
+      pool.acquire(undefined, 'sticky-3');
+      // Sticky path didn't touch the cursor → first anonymous acquire still
+      // starts at index 0.
+      expect(pool.acquire()?.id).toBe('a');
+    });
+
+    it('falls back to round-robin when sticky pick is cooling, then restores once cooldown lifts', () => {
+      // n=3 is required to make this test RED-GREEN — with n=2, plain
+      // round-robin happens to alternate back to the original account on the
+      // third call by sheer luck and the test would pass without the sticky
+      // branch. With n=3, plain round-robin walks 'a','b','c' regardless of
+      // threadId, so the third call returns 'c'; only sticky restores the
+      // original account after cooldown.
+      //
+      // setSystemTime advances the clock past the cooldown rather than
+      // re-calling markCooling — markCooling has a "never shortens" guard
+      // that makes a backwards-time call a no-op and silently breaks the
+      // assertion.
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+        { id: 'c', home: '/tmp/c' },
+      ]);
+      try {
+        const sticky = pool.acquire(undefined, 'pin-thread');
+        pool.release(sticky!.id);
+        const cooldownUntil = Date.now() + 60_000;
+        pool.markCooling(sticky!.id, cooldownUntil);
+
+        // Next acquire for the same thread must NOT return the cooling account.
+        const next = pool.acquire(undefined, 'pin-thread');
+        expect(next?.id).not.toBe(sticky?.id);
+        expect(next).not.toBeNull();
+
+        // Advance time past cooldown so the sticky binding can reassert
+        // itself. This is the property that distinguishes sticky from plain
+        // round-robin and makes the test RED without the sticky branch.
+        setSystemTime(new Date(cooldownUntil + 1));
+        expect(pool.acquire(undefined, 'pin-thread')?.id).toBe(sticky?.id);
+      } finally {
+        setSystemTime(); // restore real clock for sibling tests
+      }
+    });
+
+    it('preferredId still wins over threadId binding (resume invariant)', () => {
+      // Resume path: even if hash(threadId) would pick 'a', a persisted
+      // claudeAccountId of 'b' must still be honored — the conversation
+      // history lives under b's HOME.
+      const pool = new AccountPool([
+        { id: 'a', home: '/tmp/a' },
+        { id: 'b', home: '/tmp/b' },
+      ]);
+      const sticky = pool.acquire(undefined, 'thread-z');
+      pool.release(sticky!.id);
+      const other = sticky!.id === 'a' ? 'b' : 'a';
+      expect(pool.acquire(other, 'thread-z')?.id).toBe(other);
+    });
+
+    it('returns null when only account is cooling, even with threadId', () => {
+      const pool = new AccountPool([{ id: 'a', home: '/tmp/a' }]);
+      pool.markCooling('a', Date.now() + 60_000);
+      expect(pool.acquire(undefined, 'thread-q')).toBeNull();
     });
   });
 

--- a/src/claude/account-pool.ts
+++ b/src/claude/account-pool.ts
@@ -17,6 +17,21 @@ import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('account-pool');
 
+/**
+ * FNV-1a 32-bit hash. Pure, deterministic, dependency-free — chosen so the
+ * sticky-by-thread account binding picks the same account across bot restarts
+ * without leaning on Node's `crypto`. Avalanche is good enough for routing
+ * threads onto a handful of accounts.
+ */
+function hashThreadId(threadId: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < threadId.length; i++) {
+    h ^= threadId.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
 /** Snapshot of pool state for UI/debug. */
 export interface AccountPoolStatus {
   id: string;
@@ -67,16 +82,25 @@ export class AccountPool {
   }
 
   /**
-   * Acquire the next available account via round-robin, skipping cooling ones.
+   * Acquire an account for a session.
    *
-   * If `preferredId` is given and that account exists, it is returned as-is —
-   * even if it's currently cooling. This path is used when resuming an existing
-   * session whose conversation history lives under that account's HOME.
+   * Selection priority:
+   * 1. `preferredId` (if known) — returned as-is, even if cooling. Resume path:
+   *    OAuth history lives under that account's HOME and can't move.
+   * 2. `threadId` (if given) — deterministic sticky binding via
+   *    `accounts[hash(threadId) % n]`, so a thread always lands on the same
+   *    account across the session's lifetime. The `claudeAccountId` written
+   *    to `sessions.json` and the `$HOME` Claude actually spawned under can
+   *    no longer drift apart under multi-session race conditions (which
+   *    previously produced "conversation history no longer exists" failures
+   *    after a bot restart). If the sticky account is cooling, falls through
+   *    to round-robin.
+   * 3. Round-robin over non-cooling accounts.
    *
    * Returns `null` when the pool is empty, or when every account is cooling
    * and no `preferredId` was supplied.
    */
-  acquire(preferredId?: string): ClaudeAccount | null {
+  acquire(preferredId?: string, threadId?: string): ClaudeAccount | null {
     if (this.isEmpty) return null;
 
     if (preferredId) {
@@ -90,6 +114,20 @@ export class AccountPool {
 
     const now = Date.now();
     const n = this.accounts.length;
+
+    if (threadId) {
+      const sticky = this.accounts[hashThreadId(threadId) % n];
+      const cooling = this.coolingUntil.get(sticky.id) ?? 0;
+      if (cooling <= now) {
+        this.incrementActive(sticky.id);
+        return sticky;
+      }
+      // Sticky account is cooling — drop to round-robin so the session can
+      // still start. Resume of this thread will re-derive the same sticky id,
+      // but the sessions.json entry will record whatever round-robin picks
+      // here, which is fine because resume passes that id as preferredId.
+    }
+
     for (let i = 0; i < n; i++) {
       const idx = (this.roundRobinIndex + i) % n;
       const candidate = this.accounts[idx];

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -240,8 +240,15 @@ export interface SessionOperations {
    *
    * `preferredId` is honored even if the account is currently cooling — this
    * is required for resume, because OAuth history lives under a specific HOME.
+   *
+   * `threadId` enables sticky-by-thread distribution for new sessions: the
+   * pool deterministically picks `accounts[hash(threadId) % n]`, so a thread
+   * always lands on the same account regardless of multi-session ordering.
+   * This closes the race between round-robin selection and `sessions.json`
+   * persistence that previously caused `claudeAccountId` to drift away from
+   * the `$HOME` Claude actually spawned under.
    */
-  acquireClaudeAccount(preferredId?: string): ClaudeAccount | null;
+  acquireClaudeAccount(preferredId?: string, threadId?: string): ClaudeAccount | null;
 
   /**
    * Look up the Claude account metadata for a session that already holds one.

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -866,8 +866,14 @@ export async function startSession(
   // Create Claude CLI with options
   const platformMcpConfig = platform.getMcpConfig();
 
-  // Reserve a Claude account from the pool (null = single-account mode)
-  const claudeAccount = ctx.ops.acquireClaudeAccount();
+  // Reserve a Claude account from the pool (null = single-account mode).
+  // Pass threadId so the pool sticky-binds this thread to a deterministic
+  // account: the chosen $HOME at spawn time and the claudeAccountId persisted
+  // to sessions.json are derived from the same hash, so they can no longer
+  // drift apart under concurrent acquisitions (which previously left resumed
+  // sessions pointing at the wrong account's HOME → "conversation history no
+  // longer exists" failure on bot restart).
+  const claudeAccount = ctx.ops.acquireClaudeAccount(undefined, actualThreadId);
   if (claudeAccount) {
     log.info(`Session ${sessionId.substring(0, 20)} reserved Claude account "${claudeAccount.id}"`);
   }
@@ -1116,7 +1122,10 @@ export async function resumeSession(
   // Resume MUST re-use the same Claude account the session started on —
   // for OAuth accounts the conversation history lives under that HOME.
   // acquireClaudeAccount honors preferredId even if it is currently cooling.
-  const claudeAccount = ctx.ops.acquireClaudeAccount(state.claudeAccountId);
+  // threadId is passed as a fallback for legacy sessions persisted before
+  // sticky-by-thread binding existed: when state.claudeAccountId is missing,
+  // the pool can re-derive the same sticky account from the thread.
+  const claudeAccount = ctx.ops.acquireClaudeAccount(state.claudeAccountId, state.threadId);
   if (state.claudeAccountId && !claudeAccount) {
     log.warn(
       `Persisted session referenced Claude account "${state.claudeAccountId}" ` +

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -326,7 +326,7 @@ export class SessionManager extends EventEmitter {
       emitSessionRemove: (sid) => this.emitSessionRemove(sid),
 
       // Claude account pool (null when single-account mode)
-      acquireClaudeAccount: (preferredId) => this.accountPool.acquire(preferredId),
+      acquireClaudeAccount: (preferredId, threadId) => this.accountPool.acquire(preferredId, threadId),
       getClaudeAccount: (id) => this.accountPool.get(id),
       releaseClaudeAccount: (id) => this.accountPool.release(id),
       markClaudeAccountCooling: (id, untilMs) => this.accountPool.markCooling(id, untilMs),


### PR DESCRIPTION
## Problem

  In multi-account mode (`claudeAccounts:`), `AccountPool.acquire()` round-robins over accounts on session start. The chosen account's
  `$HOME` determines where the Claude CLI writes its conversation history (`<home>/.claude/projects/...`). The same id is also written
  to `sessions.json` so resume after a bot restart re-spawns Claude under the matching `$HOME`.

  These two writes happen on different code paths and aren't atomic together. In production, `sessions.json` ends up recording a
  different `claudeAccountId` than the `$HOME` Claude was actually spawned under. After a bot restart, resume picks the wrong `$HOME`,
  fails to find the JSONL, raises `Detected permanent failure: The conversation history for this session no longer exists`, and
  soft-deletes the session — users see `❌ Session cannot be resumed`.

  Real-world incident: 14 sessions soft-deleted in one restart cycle — 3 were genuine victims of this drift, the other 11 were normal
  `cleanStale`. The exact write-ordering that produces the drift was not localized; multiple paths can race on `claudeAccountId`. This
  PR removes the possibility of drift entirely rather than serializing the writes.

  ## Fix

  Sticky-by-thread account binding. `AccountPool.acquire(preferredId, threadId)` now picks `accounts[hash(threadId) % n]` when given a
  threadId. The `$HOME` chosen at spawn time and the `claudeAccountId` persisted to `sessions.json` are both derived from the same hash
   — they cannot drift apart under concurrent acquisitions.

  Selection priority:
  1. **preferredId** — honored even if cooling (resume invariant: OAuth history lives under that account's HOME and can't move)
  2. **threadId-sticky bucket** — round-robin fallback only if the sticky account is in rate-limit cooldown
  3. **round-robin** — unchanged

  Sticky-path acquires do **not** advance `roundRobinIndex`, so heavy use of one sticky thread does not silently shift how anonymous
  acquires distribute.

  Hash: FNV-1a 32-bit, pure, dependency-free.


  | File | Change |
  |---|---|
  | `src/claude/account-pool.ts` | sticky branch + `hashThreadId` helper |
  | `src/operations/session-context/types.ts` | extended ops signature `acquireClaudeAccount(preferredId?, threadId?)` |
  | `src/session/manager.ts` | pass threadId through to pool |
  | `src/session/lifecycle.ts` | `actualThreadId` on start, `state.threadId` on resume |
  | `src/claude/account-pool.test.ts` | 5 new tests (3 RED-GREEN regression defenders + 2 contract anchors) |

  ## Backward compatibility

  Pure addition. Existing `acquire(preferredId?)` callers continue to work. Resume path now also passes `state.threadId` so legacy
  sessions persisted before this fix re-derive the same sticky account when `state.claudeAccountId` is missing.

  ## Test plan

  - [x] `bun test src/` — 2171/2171 pass
  - [x] `bun run build` — clean
  - [x] `npx tsc --noEmit` — clean
  - [x] **RED-GREEN verified**: with the sticky branch disabled, 3 of 5 new tests fail (`always returns the same account for a given
  threadId`, `does not advance roundRobinIndex when sticky path serves the request`, `falls back to round-robin when sticky pick is
  cooling, then restores once cooldown lifts`). The other 2 lock pre-existing contract behavior (`preferredId still wins over threadId
  binding`, `returns null when only account is cooling, even with threadId`).