### PR TITLE
feat: include thread permalink in Claude session context

### DIFF
--- a/src/commands/system-prompt-generator.test.ts
+++ b/src/commands/system-prompt-generator.test.ts
@@ -77,11 +77,20 @@ describe('generateChatPlatformPrompt', () => {
 });
 
 describe('buildSessionContext', () => {
+  const mattermostPlatform = {
+    platformType: 'mattermost',
+    displayName: 'Test Server',
+    getThreadLink: (threadId: string) => `https://chat.example.com/_redirect/pl/${threadId}`,
+  };
+
+  const slackPlatform = {
+    platformType: 'slack',
+    displayName: 'Workspace',
+    getThreadLink: (threadId: string) => `https://slack.example.com/archives/C123/p${threadId}`,
+  };
+
   it('formats platform and working directory', () => {
-    const context = buildSessionContext(
-      { platformType: 'mattermost', displayName: 'Test Server' },
-      '/home/user/project'
-    );
+    const context = buildSessionContext(mattermostPlatform, '/home/user/project', 'thread-1');
 
     expect(context).toContain('Platform:');
     expect(context).toContain('Mattermost');
@@ -91,13 +100,37 @@ describe('buildSessionContext', () => {
   });
 
   it('capitalizes platform type', () => {
-    const context = buildSessionContext(
-      { platformType: 'slack', displayName: 'Workspace' },
-      '/path'
-    );
+    const context = buildSessionContext(slackPlatform, '/path', 'thread-1');
 
     expect(context).toContain('Slack');
-    expect(context).not.toContain('slack');
+    // The full string still contains lowercase 'slack' inside the URL —
+    // assert that the *capitalized* form precedes the URL segment so the
+    // intent of the assertion (label, not URL) is preserved.
+    const labelSegment = context.split('|')[0];
+    expect(labelSegment).toContain('Slack');
+    expect(labelSegment).not.toMatch(/\bslack\b/);
+  });
+
+  it('includes the Thread permalink so Claude can reference the conversation', () => {
+    // Regression-defender: the chat link is what lets Claude paste a
+    // back-reference into MR/ticket descriptions it generates. Without
+    // this segment that affordance is gone — Claude has no way to know
+    // the thread URL.
+    const captured: string[] = [];
+    const platform = {
+      platformType: 'mattermost',
+      displayName: 'Team',
+      getThreadLink: (threadId: string) => {
+        captured.push(threadId);
+        return `https://chat.example.com/_redirect/pl/${threadId}`;
+      },
+    };
+
+    const context = buildSessionContext(platform, '/repo', 'thread-abc');
+
+    expect(captured).toEqual(['thread-abc']);
+    expect(context).toContain('**Thread:**');
+    expect(context).toContain('https://chat.example.com/_redirect/pl/thread-abc');
   });
 });
 

--- a/src/commands/system-prompt-generator.ts
+++ b/src/commands/system-prompt-generator.ts
@@ -56,13 +56,24 @@ function formatClaudeCommand(cmd: CommandDefinition): string {
 
 /**
  * Build session context line for the system prompt.
+ *
+ * The `**Thread:**` URL gives Claude a stable handle for the conversation it
+ * is running inside. It is included so Claude can reference the chat from
+ * artifacts it produces — e.g. paste it into the description of a merge
+ * request or ticket so reviewers can trace the work back to the discussion.
  */
 export function buildSessionContext(
-  platform: { platformType: string; displayName: string },
-  workingDir: string
+  platform: {
+    platformType: string;
+    displayName: string;
+    getThreadLink(threadId: string): string;
+  },
+  workingDir: string,
+  threadId: string,
 ): string {
   const platformName = platform.platformType.charAt(0).toUpperCase() + platform.platformType.slice(1);
-  return `**Platform:** ${platformName} (${platform.displayName}) | **Working Directory:** ${workingDir}`;
+  const threadUrl = platform.getThreadLink(threadId);
+  return `**Platform:** ${platformName} (${platform.displayName}) | **Working Directory:** ${workingDir} | **Thread:** ${threadUrl}`;
 }
 
 /**

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -379,7 +379,7 @@ export async function changeDirectory(
   session.claudeSessionId = newSessionId;
 
   // Build system prompt with platform context for the new directory
-  const sessionContext = buildSessionContext(session.platform, absoluteDir);
+  const sessionContext = buildSessionContext(session.platform, absoluteDir, session.threadId);
   const appendSystemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
 
   const cliOptions: ClaudeCliOptions = {

--- a/src/operations/worktree/handler.test.ts
+++ b/src/operations/worktree/handler.test.ts
@@ -61,6 +61,8 @@ const mockFormatContextForClaude = mock((messages: unknown[], summary?: string) 
 function createMockPlatform(overrides?: Partial<PlatformClient>): PlatformClient {
   return {
     platformId: 'test-platform',
+    platformType: 'mattermost',
+    displayName: 'Test Platform',
     createPost: mock(() => Promise.resolve({ id: 'post-1', message: '', userId: 'bot' })),
     updatePost: mock(() => Promise.resolve({ id: 'post-1', message: '', userId: 'bot' })),
     deletePost: mock(() => Promise.resolve()),
@@ -82,6 +84,7 @@ function createMockPlatform(overrides?: Partial<PlatformClient>): PlatformClient
     getPinnedPosts: mock(() => Promise.resolve([])),
     getPost: mock(() => Promise.resolve(null)),
     getFormatter: mock(() => createMockFormatter()),
+    getThreadLink: mock((threadId: string) => `https://test.example.com/_redirect/pl/${threadId}`),
     ...overrides,
   } as unknown as PlatformClient;
 }

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -25,6 +25,7 @@ import {
 } from '../../git/worktree.js';
 import type { ClaudeCliOptions, ClaudeEvent } from '../../claude/cli.js';
 import { ClaudeCli } from '../../claude/cli.js';
+import { buildSessionContext } from '../../commands/system-prompt-generator.js';
 import { postSkippedFilesFeedback, type BuiltMessageContent } from '../streaming/handler.js';
 import { randomUUID } from 'crypto';
 import { logAndNotify } from '../../utils/error-handler/index.js';
@@ -487,6 +488,9 @@ export async function createAndSwitchToWorktree(
 
         // Create new CLI with new working directory
         const needsTitlePrompt = !session.sessionTitle;
+        const sessionContext = needsTitlePrompt
+          ? buildSessionContext(session.platform, existing.path, session.threadId)
+          : null;
         const cliOptions: ClaudeCliOptions = {
           workingDir: existing.path,
           threadId: session.threadId,
@@ -499,7 +503,7 @@ export async function createAndSwitchToWorktree(
           resume: false,
           chrome: options.chromeEnabled,
           platformConfig: session.platform.getMcpConfig(),
-          appendSystemPrompt: needsTitlePrompt ? options.appendSystemPrompt : undefined,
+          appendSystemPrompt: sessionContext ? `${sessionContext}\n\n${options.appendSystemPrompt}` : undefined,
           logSessionId: session.sessionId,
           permissionTimeoutMs: options.permissionTimeoutMs,
         };
@@ -636,6 +640,9 @@ export async function createAndSwitchToWorktree(
       // Include system prompt if session doesn't have a title yet
       // This ensures Claude will generate a title on its next response
       const needsTitlePrompt = !session.sessionTitle;
+      const sessionContext = needsTitlePrompt
+        ? buildSessionContext(session.platform, worktreePath, session.threadId)
+        : null;
 
       const cliOptions: ClaudeCliOptions = {
         workingDir: worktreePath,
@@ -649,7 +656,7 @@ export async function createAndSwitchToWorktree(
         resume: false,  // Fresh start - can't resume across directories
         chrome: options.chromeEnabled,
         platformConfig: session.platform.getMcpConfig(),
-        appendSystemPrompt: needsTitlePrompt ? options.appendSystemPrompt : undefined,
+        appendSystemPrompt: sessionContext ? `${sessionContext}\n\n${options.appendSystemPrompt}` : undefined,
         logSessionId: session.sessionId,  // Route logs to session panel
         permissionTimeoutMs: options.permissionTimeoutMs,
       };

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -860,7 +860,7 @@ export async function startSession(
   }
 
   // Build system prompt with session context
-  const sessionContext = buildSessionContext(platform, workingDir);
+  const sessionContext = buildSessionContext(platform, workingDir, actualThreadId);
   const systemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
 
   // Create Claude CLI with options
@@ -1110,7 +1110,7 @@ export async function resumeSession(
   const platformMcpConfig = platform.getMcpConfig();
 
   // Include system prompt for resumed sessions (provides platform context and command info)
-  const sessionContext = buildSessionContext(platform, state.workingDir);
+  const sessionContext = buildSessionContext(platform, state.workingDir, state.threadId);
   const appendSystemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
 
   // Resume MUST re-use the same Claude account the session started on —


### PR DESCRIPTION
## Why

  The bot already gives Claude platform context (`**Platform:** … | **Working Directory:** …`) at the top of every session's system
  prompt, but never tells Claude the URL of the thread it is running inside. As a result, when Claude opens a merge request, files a
  ticket, or otherwise produces an artifact for someone to review later, it cannot link back to the conversation that led to the
  change. Reviewers have to find the thread by hand.

  ## What

  Extend `buildSessionContext()` to append `**Thread:** <permalink>`. Both platform clients already expose `getThreadLink()`, so this
  is a pure plumbing change with no new external dependencies.

  Resulting prompt segment:

  ```
  **Platform:** Mattermost (Team) | **Working Directory:** /repo | **Thread:** https://chat.example.com/_redirect/pl/<threadId>
  ```

  URL formats (unchanged, already in production):
  - Mattermost: `${url}/_redirect/pl/${threadId}`
  - Slack: `${teamUrl}/archives/${channelId}/p${threadId}` (root permalink — Slack threadIds are the root `thread_ts`)

  ## Files

  | File | Change |
  |---|---|
  | `src/commands/system-prompt-generator.ts` | `buildSessionContext` now requires `threadId` and accepts a platform with
  `getThreadLink` |
  | `src/operations/commands/handler.ts` | pass `session.threadId` on `!cd` respawn |
  | `src/operations/worktree/handler.ts` | build session context locally on `!worktree` restart (also restores Platform/WorkingDir,
  which had been silently dropped on this path pre-existing) |
  | `src/commands/system-prompt-generator.test.ts` | 1 new RED-GREEN test + 2 existing tests updated |
  | `src/operations/worktree/handler.test.ts` | mock platform exposes `platformType`/`displayName`/`getThreadLink` |

  ## Backward compatibility

  - No persisted-data shape changes.
  - No config changes.
  - `buildSessionContext` signature is breaking for any out-of-tree caller that passes only 2 args. All in-tree callers updated; tests
  cover the full call-site set.

  ## Test plan

  - [x] `bun test src/` — 2167/2167 pass
  - [x] `npx tsc --noEmit` — clean
  - [x] `bun run build` — clean
  - [x] **RED-GREEN verified**: with the `**Thread:**` segment removed from `buildSessionContext`, the new test (`includes the Thread
  permalink so Claude can reference the conversation`) fails on both the `getThreadLink` call assertion and the URL substring
  assertion.