### PR TITLE
fix: dispose MessageManager on session cleanup (issue #351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Memory leak across session lifecycles.** `PostTracker` registered every post created during a session but its `clearSession(sessionId)` was only invoked on full bot shutdown. Across many sessions the in-memory map grew without bound and contributed to V8 mark-compact becoming ineffective and an eventual OOM abort (observed at ~14 h uptime). `MessageManager.dispose()` now clears its session's `PostTracker` bucket, and dispose is wired into all five session-removal paths in `src/session/lifecycle.ts`: normal exit, kill, idle timeout, pause, shutdown, early exit, resume-fail, plus the start-failure and resume-failure error branches that bypass the shared cleanup helpers. (#356, fixes #351)
+
 ## [1.9.3] - 2026-04-24
 
 ### Internals

--- a/src/operations/message-manager.test.ts
+++ b/src/operations/message-manager.test.ts
@@ -223,6 +223,24 @@ describe('MessageManager', () => {
       // Should not throw
       expect(manager.hasPendingQuestions()).toBe(false);
     });
+
+    it('clears its postTracker entries on dispose', () => {
+      // Register a few posts under this session and an unrelated session.
+      postTracker.register('post-a', 'thread-123', 'test:session-1', { type: 'content' });
+      postTracker.register('post-b', 'thread-123', 'test:session-1', { type: 'content' });
+      postTracker.register('post-c', 'thread-other', 'test:other-session', { type: 'content' });
+
+      expect(postTracker.getPostsForSession('test:session-1')).toHaveLength(2);
+      expect(postTracker.getPostsForSession('test:other-session')).toHaveLength(1);
+
+      manager.dispose();
+
+      // Without the dispose() fix, this leaked across sessions and contributed
+      // to OOM crashes after long uptimes (issue #351).
+      expect(postTracker.getPostsForSession('test:session-1')).toHaveLength(0);
+      // Other sessions must not be affected.
+      expect(postTracker.getPostsForSession('test:other-session')).toHaveLength(1);
+    });
   });
 
   describe('Event Handling', () => {

--- a/src/operations/message-manager.ts
+++ b/src/operations/message-manager.ts
@@ -1181,6 +1181,7 @@ export class MessageManager {
    */
   dispose(): void {
     this.cancelScheduledFlush();
+    this.postTracker.clearSession(this.sessionId);
     this.reset();
   }
 }

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -274,6 +274,19 @@ describe('Lifecycle Module', () => {
 
       expect(ctx.ops.stopTyping).toHaveBeenCalledWith(session);
     });
+
+    // Regression test for issue #351 (memory leak). Without dispose() in
+    // removeFromRegistry, PostTracker entries accumulated across every
+    // kill/exit, eventually causing V8 OOM after long uptimes.
+    it('disposes the message manager so post-tracker entries are released', async () => {
+      const session = createMockSession();
+      const sessions = new Map([['test-platform:thread-123', session]]);
+      const ctx = createMockSessionContext(sessions);
+
+      await lifecycle.killSession(session, true, ctx);
+
+      expect(session.messageManager?.dispose).toHaveBeenCalled();
+    });
   });
 
   describe('killAllSessions', () => {
@@ -992,6 +1005,19 @@ describe('handleExit', () => {
     await lifecycle.handleExit(session.sessionId, 1, ctx);
     expect(sessions.has(session.sessionId)).toBe(false);
     expect(ctx.ops.updateStickyMessage).toHaveBeenCalled();
+  });
+
+  // Regression test for issue #351 (memory leak). Without dispose() in
+  // cleanupSession, every early-exit/shutdown/resume-fail path leaked the
+  // MessageManager's PostTracker entries.
+  it('disposes the message manager on early exit', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: false });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 1, ctx);
+
+    expect(session.messageManager?.dispose).toHaveBeenCalled();
   });
 
   it('immediately unpersists on permanent failure for a resumed session', async () => {

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -168,6 +168,7 @@ async function cleanupSession(
   if (doCloseLogger) {
     await closeThreadLogger(session, action, details);
   }
+  session.messageManager?.dispose();
   ctx.ops.emitSessionRemove(session.sessionId);
   mutableSessions(ctx).delete(session.sessionId);
   if (doCleanupPostIndex) {
@@ -203,6 +204,7 @@ function releaseAccountIfHeld(session: Session, ctx: SessionContext): void {
  * @param ctx - Session context for state access
  */
 function removeFromRegistry(session: Session, ctx: SessionContext): void {
+  session.messageManager?.dispose();
   ctx.ops.emitSessionRemove(session.sessionId);
   mutableSessions(ctx).delete(session.sessionId);
   cleanupPostIndex(ctx, session.threadId);

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -966,6 +966,7 @@ export async function startSession(
   } catch (err) {
     await logAndNotify(err, { action: 'Start Claude', session });
     ctx.ops.stopTyping(session);
+    session.messageManager?.dispose();
     ctx.ops.emitSessionRemove(session.sessionId);
     mutableSessions(ctx).delete(session.sessionId);
     releaseAccountIfHeld(session, ctx);
@@ -1303,6 +1304,7 @@ export async function resumeSession(
     ctx.ops.persistSession(session);
   } catch (err) {
     log.error(`Failed to resume session ${shortId}`, err instanceof Error ? err : undefined);
+    session.messageManager?.dispose();
     ctx.ops.emitSessionRemove(sessionId);
     mutableSessions(ctx).delete(sessionId);
     ctx.state.sessionStore.remove(sessionId);


### PR DESCRIPTION
## Summary

Fixes #351 — long-running bot crashed with V8 OOM after every finished session leaked its `PostTracker` entries and `MessageManager` executor state.

`PostTracker.clearSession` was only invoked on full bot shutdown, so each session's post registrations stayed in the in-memory map forever. Across many sessions and tool calls this drove V8 into ineffective mark-compact cycles and ultimately `abort()`.

The fix wires `MessageManager.dispose()` into both session cleanup paths and has `dispose()` clear the session's `PostTracker` bucket:

- `MessageManager.dispose()` now calls `postTracker.clearSession(this.sessionId)` before `reset()`.
- `cleanupSession()` (shutdown / early-exit / resume-fail paths) calls `session.messageManager?.dispose()` before unregistering.
- `removeFromRegistry()` (normal exit / kill / pause paths) calls `session.messageManager?.dispose()` before unregistering.

The reporter on #351 already validated the fix in their own deployment: idle RSS dropped from 1.43 GB after 9 h to ~150 MB, with the daemon actively giving memory back to the OS during idle.

## Test plan

Three regression tests, all verified to be RED without the fix and GREEN with it (per the red-green requirement in `CLAUDE.md`):

- [x] `MessageManager > Lifecycle > clears its postTracker entries on dispose` — calls `register()` for two posts under the manager's session and one under another session, then asserts `dispose()` clears only the manager's session.
- [x] `Lifecycle Module > killSession > disposes the message manager so post-tracker entries are released` — covers `removeFromRegistry`.
- [x] `handleExit > disposes the message manager on early exit` — covers `cleanupSession`.
- [x] Full unit suite: 2289 pass, 0 fail.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean.