### PR TITLE
chore: sync lockfiles to match published versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,7 +476,7 @@ npm version minor --no-git-tag-version  # 0.47.0 → 0.48.0 (new features)
 npm version major --no-git-tag-version  # 0.47.0 → 1.0.0 (breaking changes)
 
 # 8. Commit and tag
-git add package.json && git commit -m "X.Y.Z" && git tag vX.Y.Z
+git add package.json package-lock.json && git commit -m "X.Y.Z" && git tag vX.Y.Z
 
 # 9. Push to GitHub with tags
 git push && git push --tags
@@ -505,7 +505,7 @@ git add CHANGELOG.md && git commit -m "Update CHANGELOG for vX.Y.Z"
 npm version patch --no-git-tag-version  # then commit and tag manually
 
 # 4. Commit and tag
-git add package.json && git commit -m "X.Y.Z" && git tag vX.Y.Z
+git add package.json package-lock.json && git commit -m "X.Y.Z" && git tag vX.Y.Z
 
 # 5. Push to GitHub with tags
 git push && git push --tags

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-threads",
       "dependencies": {
-        "@hono/node-server": "^1.19.11",
+        "@hono/node-server": "^2.0.0",
         "@inkjs/ui": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@redactpii/node": "^1.0.16",
@@ -48,7 +48,7 @@
     },
   },
   "overrides": {
-    "@hono/node-server": "^1.19.11",
+    "@hono/node-server": "^2.0.0",
     "express-rate-limit": "^8.3.0",
     "flatted": ">=3.4.0",
     "hono": "^4.12.5",
@@ -74,7 +74,7 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+    "@hono/node-server": ["@hono/node-server@2.0.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-n3GfHwwCvHCkGmOwKfxUPOlbfzuO64Sbc5XC4NGPIXxkuOnJrdgExdRKmHfF924r914WRJPT397GdqLvdYTeyQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.0",


### PR DESCRIPTION
## Summary

Two committed lockfiles had drifted from the actual released state:

- **`package-lock.json`** was still at `1.9.3` while `package.json` has shipped `1.9.4` and `1.10.0`. The release procedure in `CLAUDE.md` staged only `package.json` after `npm version`, so the lockfile bump never made it into the release commits and showed up as a permanent working-tree modification on every clone.
- **`bun.lock`** was missing the `@hono/node-server` 1.19.11 → 2.0.0 bump from #340. Caught by `bun install --frozen-lockfile`.

The release-flow docs in `CLAUDE.md` are also updated so the next release stages `package-lock.json` alongside `package.json` after `npm version` — preventing this drift from recurring.

No source changes. The committed npm tarballs published to the registry are unaffected (they were built from a clean `bun install` in CI).

## Test plan

- [x] `bun install --frozen-lockfile` clean
- [x] `bun test` — 2295 pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean