### PR TITLE
Add session collaborators as Co-Authored-By on commits

### DIFF
--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -163,6 +163,20 @@ const handleKick: CommandHandler = async (ctx, args) => {
 };
 
 /**
+ * Handle !github-email command — self-only, no isAllowed gate. Anyone in the
+ * thread (including unauthorized senders) can register their address; this is
+ * what makes the !invite onboarding flow practical. The handler itself only
+ * mutates the caller's own entry so there's no privilege-escalation surface.
+ */
+const handleGitHubEmail: CommandHandler = async (ctx, args) => {
+  if (ctx.commandContext === 'first-message') {
+    return { handled: false };
+  }
+  await ctx.sessionManager.setGitHubEmail(ctx.threadId, ctx.username, args);
+  return { handled: true };
+};
+
+/**
  * Handle !cd command.
  */
 const handleCd: CommandHandler = async (ctx, args) => {
@@ -438,6 +452,7 @@ handlers.set('escape', handleEscape);
 handlers.set('approve', handleApprove);
 handlers.set('invite', handleInvite);
 handlers.set('kick', handleKick);
+handlers.set('github-email', handleGitHubEmail);
 handlers.set('cd', handleCd);
 handlers.set('permissions', handlePermissions);
 handlers.set('worktree', handleWorktree);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -53,4 +53,9 @@ export { generateHelpMessage } from './help-generator.js';
 export {
   generateChatPlatformPrompt,
   buildSessionContext,
+  buildCollaboratorContext,
+  resolveCollaborators,
+  formatCollaboratorListForChat,
+  buildAppendSystemPrompt,
+  type ResolvedCollaborator,
 } from './system-prompt-generator.js';

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -192,6 +192,14 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
     audience: 'user',
     claudeNotes: 'User decisions, not yours',
   },
+  {
+    command: 'github-email',
+    description: 'Register your GitHub noreply email so you can be added as a Co-Authored-By on commits (find yours at https://github.com/settings/emails)',
+    args: '<email> | reset',
+    category: 'collaboration',
+    audience: 'user',
+    claudeNotes: 'User decisions, not yours',
+  },
 
   // ---------------------------------------------------------------------------
   // Settings

--- a/src/commands/system-prompt-generator.test.ts
+++ b/src/commands/system-prompt-generator.test.ts
@@ -6,8 +6,14 @@ import { describe, it, expect } from 'bun:test';
 import {
   generateChatPlatformPrompt,
   buildSessionContext,
+  buildCollaboratorContext,
+  resolveCollaborators,
+  formatCollaboratorListForChat,
+  buildAppendSystemPrompt,
+  type ResolvedCollaborator,
 } from './system-prompt-generator.js';
 import { VERSION } from '../version.js';
+import type { PlatformUser } from '../platform/types.js';
 
 describe('generateChatPlatformPrompt', () => {
   it('generates a non-empty prompt', () => {
@@ -131,6 +137,203 @@ describe('buildSessionContext', () => {
     expect(captured).toEqual(['thread-abc']);
     expect(context).toContain('**Thread:**');
     expect(context).toContain('https://chat.example.com/_redirect/pl/thread-abc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collaborator co-author attribution
+// ---------------------------------------------------------------------------
+
+function fakePlatform(users: Record<string, PlatformUser | null>) {
+  return {
+    platformType: 'mattermost',
+    displayName: 'Test',
+    getThreadLink: (id: string) => `https://example.com/${id}`,
+    async getUserByUsername(username: string): Promise<PlatformUser | null> {
+      return users[username] ?? null;
+    },
+  };
+}
+
+describe('resolveCollaborators', () => {
+  it('returns empty when only the owner is in the set', async () => {
+    const platform = fakePlatform({});
+    const result = await resolveCollaborators(platform, 'alice', ['alice']);
+    expect(result).toEqual([]);
+  });
+
+  it('skips the owner', async () => {
+    const platform = fakePlatform({
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B', email: 'bob@example.com' },
+    });
+    const result = await resolveCollaborators(platform, 'alice', ['alice', 'bob']);
+    expect(result).toEqual([{ username: 'bob', name: 'Bob B', email: 'bob@example.com' }]);
+  });
+
+  it('skips collaborators with no email (cannot form co-author trailer)', async () => {
+    const platform = fakePlatform({
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B' }, // no email
+      carol: { id: 'c', username: 'carol', email: 'carol@example.com' }, // no displayName
+    });
+    const result = await resolveCollaborators(platform, 'alice', ['alice', 'bob', 'carol']);
+    expect(result).toEqual([
+      { username: 'carol', name: 'carol', email: 'carol@example.com' },
+    ]);
+  });
+
+  it('skips users that the platform does not know about', async () => {
+    const platform = fakePlatform({}); // returns null for everyone
+    const result = await resolveCollaborators(platform, 'alice', ['alice', 'ghost']);
+    expect(result).toEqual([]);
+  });
+
+  it('survives a thrown lookup error and continues with the rest', async () => {
+    const platform = {
+      platformType: 'mattermost',
+      displayName: 'Test',
+      getThreadLink: (id: string) => `https://example.com/${id}`,
+      async getUserByUsername(username: string): Promise<PlatformUser | null> {
+        if (username === 'broken') throw new Error('flaky API');
+        return { id: 'c', username, displayName: username, email: `${username}@x.com` };
+      },
+    };
+    const result = await resolveCollaborators(platform, 'alice', ['alice', 'broken', 'carol']);
+    expect(result).toEqual([{ username: 'carol', name: 'carol', email: 'carol@x.com' }]);
+  });
+});
+
+describe('buildCollaboratorContext', () => {
+  it('falls back to a single-line standby instruction when there are no collaborators', () => {
+    // Solo sessions don't need the full rule yet — but the system prompt still
+    // has to teach Claude the "Collaborators updated" thread convention,
+    // otherwise a later !invite would post a notice Claude doesn't recognize.
+    const section = buildCollaboratorContext([]);
+    expect(section).toContain('"Collaborators updated"');
+    expect(section).toContain('Co-Authored-By:');
+    // Compactness: a few lines, not a full section with header.
+    expect(section).not.toContain('## Git commit attribution');
+    expect(section.split('\n').length).toBeLessThanOrEqual(2);
+  });
+
+  it('lists current collaborators in the Co-Authored-By format', () => {
+    const collaborators: ResolvedCollaborator[] = [
+      { username: 'bob', name: 'Bob B', email: 'bob@example.com' },
+      { username: 'carol', name: 'Carol C', email: 'carol@example.com' },
+    ];
+    const section = buildCollaboratorContext(collaborators);
+    expect(section).toContain('- Bob B <bob@example.com>');
+    expect(section).toContain('- Carol C <carol@example.com>');
+    expect(section).toContain('supersedes this one');
+  });
+
+  it('disambiguates who Claude must not co-author (owner is author, no bot, no AI) — full form', () => {
+    // "yourself" was ambiguous — Claude could read it as the bot or as the
+    // owner. Spell out both: owner is the implicit author; no bot/AI trailers.
+    const section = buildCollaboratorContext([
+      { username: 'bob', name: 'Bob', email: 'bob@example.com' },
+    ]);
+    expect(section).toMatch(/session\s+owner/);
+    expect(section).toMatch(/implicit\s+author/);
+    expect(section).toContain('the bot');
+    expect(section).toContain('AI assistant');
+  });
+
+  it('disambiguates the standby one-liner too (same exclusion list)', () => {
+    // The empty-state form is shown to solo sessions — it must give the
+    // same exclusion guidance, not fall back to ambiguous "yourself".
+    const section = buildCollaboratorContext([]);
+    expect(section).toMatch(/session\s+owner/);
+    expect(section).toMatch(/implicit\s+author/);
+    expect(section).toContain('AI assistant');
+    expect(section).not.toMatch(/\byourself\b/);
+  });
+});
+
+describe('formatCollaboratorListForChat', () => {
+  it('returns empty string for empty list (caller produces the "no co-authors" sentence)', () => {
+    expect(formatCollaboratorListForChat([])).toBe('');
+  });
+
+  it('joins names + emails with comma+space', () => {
+    const out = formatCollaboratorListForChat([
+      { username: 'bob', name: 'Bob B', email: 'bob@x.com' },
+      { username: 'carol', name: 'Carol', email: 'c@x.com' },
+    ]);
+    expect(out).toBe('Bob B <bob@x.com>, Carol <c@x.com>');
+  });
+});
+
+describe('buildAppendSystemPrompt', () => {
+  it('still teaches the "Collaborators updated" convention in solo sessions', async () => {
+    // Even when there are no collaborators, Claude must know the convention —
+    // otherwise a later !invite during this same session won't be honored.
+    const platform = fakePlatform({});
+    const prompt = await buildAppendSystemPrompt(
+      platform,
+      '/repo',
+      't1',
+      'alice',
+      ['alice'],
+      'STATIC_PROMPT_BODY',
+    );
+    expect(prompt).toContain('STATIC_PROMPT_BODY');
+    expect(prompt).toContain('"Collaborators updated"');
+    expect(prompt).toContain('Co-Authored-By:');
+    // Don't dump the heavy section header in solo sessions.
+    expect(prompt).not.toContain('## Git commit attribution');
+  });
+
+  it('includes resolved collaborators when there are any', async () => {
+    const platform = fakePlatform({
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B', email: 'bob@x.com' },
+    });
+    const prompt = await buildAppendSystemPrompt(
+      platform,
+      '/repo',
+      't1',
+      'alice',
+      ['alice', 'bob'],
+      'STATIC',
+    );
+    expect(prompt).toContain('- Bob B <bob@x.com>');
+  });
+
+  it('omits the session-context line when omitSessionContext is set (worktree respawn case)', async () => {
+    // Worktree respawn after Claude already has a title: the session-context
+    // preamble is dropped to keep the prompt small, but the chat-platform
+    // prompt and collaborator section MUST still be there.
+    const platform = fakePlatform({});
+    const prompt = await buildAppendSystemPrompt(
+      platform,
+      '/repo',
+      't1',
+      'alice',
+      ['alice'],
+      'STATIC',
+      { omitSessionContext: true },
+    );
+    expect(prompt).not.toContain('**Platform:**');
+    expect(prompt).not.toContain('**Working Directory:**');
+    expect(prompt).toContain('STATIC');
+    expect(prompt).toContain('"Collaborators updated"');
+  });
+
+  it('survives a legacy persisted session that lacks sessionAllowedUsers entries', async () => {
+    // Backward-compat: lifecycle.resumeSession defaults to `[startedBy]` when
+    // the persisted set is missing. Verify that the helper degrades gracefully
+    // when called with just the owner (which is what that fallback yields).
+    const platform = fakePlatform({});
+    const prompt = await buildAppendSystemPrompt(
+      platform,
+      '/repo',
+      't1',
+      'alice',
+      ['alice'], // legacy fallback shape: only the owner
+      'STATIC',
+    );
+    expect(prompt).toContain('STATIC');
+    // No exception, falls to the standby one-liner.
+    expect(prompt).toContain('"Collaborators updated"');
   });
 });
 

--- a/src/commands/system-prompt-generator.test.ts
+++ b/src/commands/system-prompt-generator.test.ts
@@ -155,50 +155,73 @@ function fakePlatform(users: Record<string, PlatformUser | null>) {
   };
 }
 
+function fakeStore(emails: Record<string, Record<string, string>>) {
+  return {
+    get(platformId: string, username: string): string | undefined {
+      return emails[platformId]?.[username];
+    },
+  };
+}
+
 describe('resolveCollaborators', () => {
   it('returns empty when only the owner is in the set', async () => {
     const platform = fakePlatform({});
-    const result = await resolveCollaborators(platform, 'alice', ['alice']);
+    const store = fakeStore({});
+    const result = await resolveCollaborators(platform, 'mm', 'alice', ['alice'], store);
     expect(result).toEqual([]);
   });
 
   it('skips the owner', async () => {
     const platform = fakePlatform({
-      bob: { id: 'b', username: 'bob', displayName: 'Bob B', email: 'bob@example.com' },
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B' },
     });
-    const result = await resolveCollaborators(platform, 'alice', ['alice', 'bob']);
-    expect(result).toEqual([{ username: 'bob', name: 'Bob B', email: 'bob@example.com' }]);
+    const store = fakeStore({ mm: { bob: '111+bob@users.noreply.github.com' } });
+    const result = await resolveCollaborators(platform, 'mm', 'alice', ['alice', 'bob'], store);
+    expect(result).toEqual([{ username: 'bob', name: 'Bob B', email: '111+bob@users.noreply.github.com' }]);
   });
 
-  it('skips collaborators with no email (cannot form co-author trailer)', async () => {
+  it('skips collaborators without a registered noreply email (privacy)', async () => {
+    // We never read the platform email — it would leak to the chat thread
+    // and the local Claude history. Bob has no registration → no co-author.
     const platform = fakePlatform({
-      bob: { id: 'b', username: 'bob', displayName: 'Bob B' }, // no email
-      carol: { id: 'c', username: 'carol', email: 'carol@example.com' }, // no displayName
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B', email: 'bob@example.com' },
+      carol: { id: 'c', username: 'carol' },
     });
-    const result = await resolveCollaborators(platform, 'alice', ['alice', 'bob', 'carol']);
+    const store = fakeStore({ mm: { carol: '222+carol@users.noreply.github.com' } });
+    const result = await resolveCollaborators(platform, 'mm', 'alice', ['alice', 'bob', 'carol'], store);
     expect(result).toEqual([
-      { username: 'carol', name: 'carol', email: 'carol@example.com' },
+      { username: 'carol', name: 'carol', email: '222+carol@users.noreply.github.com' },
     ]);
   });
 
-  it('skips users that the platform does not know about', async () => {
-    const platform = fakePlatform({}); // returns null for everyone
-    const result = await resolveCollaborators(platform, 'alice', ['alice', 'ghost']);
-    expect(result).toEqual([]);
-  });
-
-  it('survives a thrown lookup error and continues with the rest', async () => {
+  it('keeps the user even when the platform display-name lookup fails', async () => {
+    // Display name lookup failures are best-effort: we still tag the
+    // co-author, falling back to username for the human-readable part.
     const platform = {
       platformType: 'mattermost',
       displayName: 'Test',
       getThreadLink: (id: string) => `https://example.com/${id}`,
-      async getUserByUsername(username: string): Promise<PlatformUser | null> {
-        if (username === 'broken') throw new Error('flaky API');
-        return { id: 'c', username, displayName: username, email: `${username}@x.com` };
+      async getUserByUsername(_: string): Promise<PlatformUser | null> {
+        throw new Error('flaky API');
       },
     };
-    const result = await resolveCollaborators(platform, 'alice', ['alice', 'broken', 'carol']);
-    expect(result).toEqual([{ username: 'carol', name: 'carol', email: 'carol@x.com' }]);
+    const store = fakeStore({ mm: { carol: '222+carol@users.noreply.github.com' } });
+    const result = await resolveCollaborators(platform, 'mm', 'alice', ['alice', 'carol'], store);
+    expect(result).toEqual([{ username: 'carol', name: 'carol', email: '222+carol@users.noreply.github.com' }]);
+  });
+
+  it('isolates registrations per platform (same username on two platforms)', async () => {
+    const platform = fakePlatform({
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B' },
+    });
+    const store = fakeStore({
+      mm: { bob: '111+bob@users.noreply.github.com' },
+      slack: { bob: '999+bob@users.noreply.github.com' },
+    });
+    const onMm = await resolveCollaborators(platform, 'mm', 'alice', ['alice', 'bob'], store);
+    const onSlack = await resolveCollaborators(platform, 'slack', 'alice', ['alice', 'bob'], store);
+    expect(onMm[0].email).toBe('111+bob@users.noreply.github.com');
+    expect(onSlack[0].email).toBe('999+bob@users.noreply.github.com');
   });
 });
 
@@ -265,51 +288,51 @@ describe('formatCollaboratorListForChat', () => {
 
 describe('buildAppendSystemPrompt', () => {
   it('still teaches the "Collaborators updated" convention in solo sessions', async () => {
-    // Even when there are no collaborators, Claude must know the convention —
-    // otherwise a later !invite during this same session won't be honored.
     const platform = fakePlatform({});
     const prompt = await buildAppendSystemPrompt(
       platform,
+      'mm',
       '/repo',
       't1',
       'alice',
       ['alice'],
       'STATIC_PROMPT_BODY',
+      fakeStore({}),
     );
     expect(prompt).toContain('STATIC_PROMPT_BODY');
     expect(prompt).toContain('"Collaborators updated"');
     expect(prompt).toContain('Co-Authored-By:');
-    // Don't dump the heavy section header in solo sessions.
     expect(prompt).not.toContain('## Git commit attribution');
   });
 
-  it('includes resolved collaborators when there are any', async () => {
+  it('includes resolved collaborators when registered in the store', async () => {
     const platform = fakePlatform({
-      bob: { id: 'b', username: 'bob', displayName: 'Bob B', email: 'bob@x.com' },
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B' },
     });
     const prompt = await buildAppendSystemPrompt(
       platform,
+      'mm',
       '/repo',
       't1',
       'alice',
       ['alice', 'bob'],
       'STATIC',
+      fakeStore({ mm: { bob: '111+bob@users.noreply.github.com' } }),
     );
-    expect(prompt).toContain('- Bob B <bob@x.com>');
+    expect(prompt).toContain('- Bob B <111+bob@users.noreply.github.com>');
   });
 
   it('omits the session-context line when omitSessionContext is set (worktree respawn case)', async () => {
-    // Worktree respawn after Claude already has a title: the session-context
-    // preamble is dropped to keep the prompt small, but the chat-platform
-    // prompt and collaborator section MUST still be there.
     const platform = fakePlatform({});
     const prompt = await buildAppendSystemPrompt(
       platform,
+      'mm',
       '/repo',
       't1',
       'alice',
       ['alice'],
       'STATIC',
+      fakeStore({}),
       { omitSessionContext: true },
     );
     expect(prompt).not.toContain('**Platform:**');
@@ -319,21 +342,42 @@ describe('buildAppendSystemPrompt', () => {
   });
 
   it('survives a legacy persisted session that lacks sessionAllowedUsers entries', async () => {
-    // Backward-compat: lifecycle.resumeSession defaults to `[startedBy]` when
-    // the persisted set is missing. Verify that the helper degrades gracefully
-    // when called with just the owner (which is what that fallback yields).
     const platform = fakePlatform({});
     const prompt = await buildAppendSystemPrompt(
       platform,
+      'mm',
       '/repo',
       't1',
       'alice',
-      ['alice'], // legacy fallback shape: only the owner
+      ['alice'],
       'STATIC',
+      fakeStore({}),
     );
     expect(prompt).toContain('STATIC');
-    // No exception, falls to the standby one-liner.
     expect(prompt).toContain('"Collaborators updated"');
+  });
+
+  it('does not leak platform email even when the platform exposes one (privacy)', async () => {
+    // Regression-defender: an earlier version read `user.email` from the
+    // platform API and put it into Co-Authored-By trailers. That leaked
+    // private addresses into the chat thread and into the local Claude
+    // conversation history. The store-only path must NEVER tag a user
+    // whose entry is absent, regardless of the platform reply.
+    const platform = fakePlatform({
+      bob: { id: 'b', username: 'bob', displayName: 'Bob B', email: 'bob@private.example.com' },
+    });
+    const prompt = await buildAppendSystemPrompt(
+      platform,
+      'mm',
+      '/repo',
+      't1',
+      'alice',
+      ['alice', 'bob'],
+      'STATIC',
+      fakeStore({}), // bob has not registered
+    );
+    expect(prompt).not.toContain('bob@private.example.com');
+    expect(prompt).not.toContain('- Bob B');
   });
 });
 

--- a/src/commands/system-prompt-generator.ts
+++ b/src/commands/system-prompt-generator.ts
@@ -12,6 +12,10 @@ import {
   getClaudeAvoidCommands,
   type CommandDefinition,
 } from './registry.js';
+import type { PlatformClient } from '../platform/client.js';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('system-prompt');
 
 /**
  * Format a command for the user commands section of the system prompt.
@@ -74,6 +78,134 @@ export function buildSessionContext(
   const platformName = platform.platformType.charAt(0).toUpperCase() + platform.platformType.slice(1);
   const threadUrl = platform.getThreadLink(threadId);
   return `**Platform:** ${platformName} (${platform.displayName}) | **Working Directory:** ${workingDir} | **Thread:** ${threadUrl}`;
+}
+
+/**
+ * Resolved collaborator with the data we need for a Co-Authored-By trailer.
+ * `name` falls back to username when displayName is missing; `email` is required
+ * (collaborators without an email cannot be tagged as co-author).
+ */
+export interface ResolvedCollaborator {
+  username: string;
+  name: string;
+  email: string;
+}
+
+/**
+ * Resolve the co-authorable collaborators for a session.
+ *
+ * Looks up each non-owner username in `sessionAllowedUsers` via the platform
+ * and keeps the ones with an email. Owner is excluded — the owner is the
+ * implicit author, not a co-author. Users without email are skipped silently
+ * (debug-logged) because we can't form a valid Co-Authored-By trailer for them.
+ */
+export async function resolveCollaborators(
+  platform: Pick<PlatformClient, 'getUserByUsername'>,
+  ownerUsername: string,
+  allowedUsers: Iterable<string>,
+): Promise<ResolvedCollaborator[]> {
+  const resolved: ResolvedCollaborator[] = [];
+  for (const username of allowedUsers) {
+    if (username === ownerUsername) continue;
+    try {
+      const user = await platform.getUserByUsername(username);
+      if (!user) {
+        log.debug(`Collaborator @${username} not found on platform — skipping`);
+        continue;
+      }
+      if (!user.email) {
+        log.debug(`Collaborator @${username} has no email — skipping co-author tag`);
+        continue;
+      }
+      resolved.push({
+        username,
+        name: user.displayName || user.username,
+        email: user.email,
+      });
+    } catch (err) {
+      log.debug(`Lookup failed for collaborator @${username}: ${(err as Error).message}`);
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Build the "Git commit attribution" section of the system prompt.
+ *
+ * Two shapes:
+ * - No collaborators: a one-liner that only kicks in if a "Collaborators
+ *   updated" notice appears later in the thread. Solo sessions stay quiet.
+ * - With collaborators: the full rule plus the current list and a pointer
+ *   to the thread for later updates.
+ */
+export function buildCollaboratorContext(collaborators: ResolvedCollaborator[]): string {
+  if (collaborators.length === 0) {
+    return `If a "Collaborators updated" notice appears in this thread, add each listed person as a \`Co-Authored-By: Name <email>\` trailer on subsequent git commits. Do not add the session owner (they are the implicit author), the bot, or any AI assistant.`;
+  }
+
+  const lines = collaborators.map(c => `- ${c.name} <${c.email}>`).join('\n');
+  return `## Git commit attribution
+
+When you create a git commit in this session, add every current collaborator
+listed below as a \`Co-Authored-By:\` trailer at the end of the commit
+message, each on its own line, after a blank line separating them from the
+body. Use the format \`Co-Authored-By: Name <email>\`. Do not add the session
+owner (they are the implicit author), the bot, or any AI assistant.
+
+Current collaborators:
+${lines}
+
+If a "Collaborators updated" notice appears later in this thread, use the
+list from the most recent such notice instead — it supersedes this one.`;
+}
+
+/**
+ * Format the collaborator list for an in-thread "collaborators updated" notice.
+ * Returns an empty string when there is nothing co-authorable; the caller
+ * is expected to produce a "no co-authors" sentence in that case.
+ */
+export function formatCollaboratorListForChat(collaborators: ResolvedCollaborator[]): string {
+  return collaborators.map(c => `${c.name} <${c.email}>`).join(', ');
+}
+
+/**
+ * Compose the full `appendSystemPrompt` for a Claude session.
+ *
+ * Layers (in order, blank-line-separated):
+ *   1. session context line — included unless `omitSessionContext` is set,
+ *      which is the worktree-respawn case where Claude already has a title
+ *      and the bestaande spawn-pad omits it to keep prompt-rebuilds cheap.
+ *   2. static chat-platform prompt (commands, send_file, etc.)
+ *   3. collaborator co-author section — always included so the rule can't
+ *      silently disappear across `!cd` / worktree / resume.
+ *
+ * Centralizing every spawn-site through this helper guarantees they all
+ * teach Claude the same conventions; adding a layer in one place but not
+ * another previously caused `!cd` to silently strip attribution.
+ */
+export async function buildAppendSystemPrompt(
+  platform: Pick<PlatformClient, 'getUserByUsername'> & {
+    platformType: string;
+    displayName: string;
+    getThreadLink(threadId: string): string;
+  },
+  workingDir: string,
+  threadId: string,
+  ownerUsername: string,
+  allowedUsers: Iterable<string>,
+  staticChatPlatformPrompt: string,
+  options?: { omitSessionContext?: boolean },
+): Promise<string> {
+  const collaborators = await resolveCollaborators(platform, ownerUsername, allowedUsers);
+  const collaboratorSection = buildCollaboratorContext(collaborators);
+
+  const parts: string[] = [];
+  if (!options?.omitSessionContext) {
+    parts.push(buildSessionContext(platform, workingDir, threadId));
+  }
+  parts.push(staticChatPlatformPrompt);
+  parts.push(collaboratorSection);
+  return parts.join('\n\n');
 }
 
 /**

--- a/src/commands/system-prompt-generator.ts
+++ b/src/commands/system-prompt-generator.ts
@@ -13,6 +13,7 @@ import {
   type CommandDefinition,
 } from './registry.js';
 import type { PlatformClient } from '../platform/client.js';
+import type { GitHubEmailsStore } from '../persistence/github-emails-store.js';
 import { createLogger } from '../utils/logger.js';
 
 const log = createLogger('system-prompt');
@@ -94,37 +95,41 @@ export interface ResolvedCollaborator {
 /**
  * Resolve the co-authorable collaborators for a session.
  *
- * Looks up each non-owner username in `sessionAllowedUsers` via the platform
- * and keeps the ones with an email. Owner is excluded — the owner is the
- * implicit author, not a co-author. Users without email are skipped silently
- * (debug-logged) because we can't form a valid Co-Authored-By trailer for them.
+ * For each non-owner username in `sessionAllowedUsers`, look up:
+ *   - the GitHub noreply email from the local store (self-registered via
+ *     `!github-email`). This is the address used in the `Co-Authored-By:`
+ *     trailer. We do **not** read platform emails: those are private (real
+ *     mail addresses) and would leak to the chat thread / Claude history.
+ *   - a human display name from the platform (best-effort) for the trailer's
+ *     `Name <email>` segment. Falls back to the username when unavailable.
+ *
+ * Owner is excluded — the owner is the implicit author. Collaborators without
+ * a registered noreply email are skipped silently (debug-logged); the caller
+ * is responsible for nudging them to register.
  */
 export async function resolveCollaborators(
   platform: Pick<PlatformClient, 'getUserByUsername'>,
+  platformId: string,
   ownerUsername: string,
   allowedUsers: Iterable<string>,
+  githubEmailsStore: Pick<GitHubEmailsStore, 'get'>,
 ): Promise<ResolvedCollaborator[]> {
   const resolved: ResolvedCollaborator[] = [];
   for (const username of allowedUsers) {
     if (username === ownerUsername) continue;
+    const email = githubEmailsStore.get(platformId, username);
+    if (!email) {
+      log.debug(`Collaborator @${username} has no registered GitHub noreply email — skipping`);
+      continue;
+    }
+    let name = username;
     try {
       const user = await platform.getUserByUsername(username);
-      if (!user) {
-        log.debug(`Collaborator @${username} not found on platform — skipping`);
-        continue;
-      }
-      if (!user.email) {
-        log.debug(`Collaborator @${username} has no email — skipping co-author tag`);
-        continue;
-      }
-      resolved.push({
-        username,
-        name: user.displayName || user.username,
-        email: user.email,
-      });
+      if (user) name = user.displayName || user.username;
     } catch (err) {
-      log.debug(`Lookup failed for collaborator @${username}: ${(err as Error).message}`);
+      log.debug(`Display name lookup failed for @${username}: ${(err as Error).message}`);
     }
+    resolved.push({ username, name, email });
   }
   return resolved;
 }
@@ -189,14 +194,22 @@ export async function buildAppendSystemPrompt(
     displayName: string;
     getThreadLink(threadId: string): string;
   },
+  platformId: string,
   workingDir: string,
   threadId: string,
   ownerUsername: string,
   allowedUsers: Iterable<string>,
   staticChatPlatformPrompt: string,
+  githubEmailsStore: Pick<GitHubEmailsStore, 'get'>,
   options?: { omitSessionContext?: boolean },
 ): Promise<string> {
-  const collaborators = await resolveCollaborators(platform, ownerUsername, allowedUsers);
+  const collaborators = await resolveCollaborators(
+    platform,
+    platformId,
+    ownerUsername,
+    allowedUsers,
+    githubEmailsStore,
+  );
   const collaboratorSection = buildCollaboratorContext(collaborators);
 
   const parts: string[] = [];

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -441,6 +441,39 @@ describe('kickUser', () => {
     );
   });
 
+  it('persists the session BEFORE the in-thread chat notices run', async () => {
+    // Mirror of the invite test: a network failure on the chat-side notice
+    // must not roll back the kick. Without this, the kicked user comes back
+    // alive on bot restart because disk still has them in sessionAllowedUsers.
+    const callOrder: string[] = [];
+    const mockPlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({ id: 'user-2', username: 'inviteduser' })),
+      createPost: mock((message: string) => {
+        callOrder.push(`createPost:${message.substring(0, 30)}`);
+        return Promise.resolve({
+          id: 'post-x',
+          platformId: 'test-platform',
+          channelId: 'test-channel',
+          userId: 'bot',
+          message,
+        });
+      }),
+    });
+    const session = createMockSession({ platform: mockPlatform });
+    session.sessionAllowedUsers.add('inviteduser');
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+    (ctx.ops.persistSession as any).mockImplementation(() => callOrder.push('persistSession'));
+
+    await commands.kickUser(session, 'inviteduser', 'testuser', ctx);
+
+    const persistIdx = callOrder.indexOf('persistSession');
+    const noticeIdx = callOrder.findIndex(s => s.startsWith('createPost:📝'));
+    expect(persistIdx).toBeGreaterThan(-1);
+    expect(noticeIdx).toBeGreaterThan(-1);
+    expect(persistIdx).toBeLessThan(noticeIdx);
+  });
+
   it('posts a "Collaborators updated" notice after a successful kick so Claude drops the kicked co-author', async () => {
     // Regression-defender: without this, the previous "Collaborators updated"
     // notice (with the now-kicked user) would keep applying to future commits.

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -136,6 +136,11 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
         load: mock(() => new Map()),
         findByPostId: mock(() => undefined),
       } as any,
+      githubEmailsStore: {
+        get: mock(() => undefined),
+        set: mock(() => {}),
+        delete: mock(() => false),
+      } as any,
       isShuttingDown: false,
     },
     ops: {
@@ -232,32 +237,33 @@ describe('inviteUser', () => {
     );
   });
 
-  it('posts a "Collaborators updated" notice with the new co-author when the invitee has an email', async () => {
+  it('posts a "Collaborators updated" notice listing the invitee when they have a registered noreply email', async () => {
     // Regression-defender: this notice is the contract that lets Claude pick
-    // up the current co-author list mid-session. Without it, an !invite is
-    // invisible to Claude until the next system-prompt rebuild (resume/!cd).
+    // up the current co-author list mid-session. The email comes from the
+    // local store (self-registered via !github-email), NOT from the platform.
     const mockPlatform = createMockPlatform({
       getUserByUsername: mock(() => Promise.resolve({
-        id: 'user-2', username: 'newuser', displayName: 'New User', email: 'new@example.com',
+        id: 'user-2', username: 'newuser', displayName: 'New User',
       })),
     });
     const session = createMockSession({ platform: mockPlatform });
     const sessions = new Map([['test-platform:thread-123', session]]);
     const ctx = createMockSessionContext(sessions);
+    (ctx.state.githubEmailsStore.get as any).mockImplementation(
+      (_: string, u: string) => u === 'newuser' ? '111+newuser@users.noreply.github.com' : undefined,
+    );
 
     await commands.inviteUser(session, 'newuser', 'testuser', ctx);
 
     const calls = (mockPlatform.createPost as any).mock.calls.map((c: any[]) => c[0]);
     const notice = calls.find((m: string) => m.includes('Collaborators updated'));
     expect(notice).toBeTruthy();
-    expect(notice).toContain('New User <new@example.com>');
+    expect(notice).toContain('New User <111+newuser@users.noreply.github.com>');
   });
 
-  it('still posts a notice (with empty list) so an older notice does not keep applying — but only if collaborators with email exist', async () => {
-    // When the invitee has no email we can't add them as co-author, so the
-    // co-author list is still empty after the invite. The notice must reflect
-    // that — otherwise an older notice could keep claiming this invitee is a
-    // co-author. Owner is excluded so no email anywhere → "no co-authors".
+  it('posts a "no co-authors" notice when the invitee has not registered a noreply email yet', async () => {
+    // No registration → not co-authorable. The notice must be posted anyway
+    // so an older notice (from a previous invite) does not keep applying.
     const mockPlatform = createMockPlatform({
       getUserByUsername: mock(() => Promise.resolve({ id: 'user-2', username: 'newuser' })),
     });
@@ -271,6 +277,81 @@ describe('inviteUser', () => {
     const notice = calls.find((m: string) => m.includes('Collaborators updated'));
     expect(notice).toBeTruthy();
     expect(notice).toContain('no co-authors');
+  });
+
+  it('posts the !github-email onboarding nudge when the invitee has not registered yet', async () => {
+    // Regression-defender: without this nudge, the new collaborator has no
+    // visible signal that they need to register, and silently never gets
+    // co-author credit. The link to settings + the !github-email command
+    // give them a clear, in-thread path forward.
+    const mockPlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({ id: 'user-2', username: 'newuser' })),
+    });
+    const session = createMockSession({ platform: mockPlatform });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await commands.inviteUser(session, 'newuser', 'testuser', ctx);
+
+    const calls = (mockPlatform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    const nudge = calls.find((m: string) => m.includes('!github-email'));
+    expect(nudge).toBeTruthy();
+    expect(nudge).toContain('https://github.com/settings/emails');
+    expect(nudge).toContain('@newuser');
+  });
+
+  it('does not nudge an invitee who has already registered a noreply email', async () => {
+    // Quietness matters: a thread with a long-running collaboration shouldn't
+    // re-paste the registration instructions for someone who has self-registered.
+    const mockPlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({ id: 'user-2', username: 'newuser' })),
+    });
+    const session = createMockSession({ platform: mockPlatform });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+    (ctx.state.githubEmailsStore.get as any).mockImplementation(
+      (_: string, u: string) => u === 'newuser' ? '111+newuser@users.noreply.github.com' : undefined,
+    );
+
+    await commands.inviteUser(session, 'newuser', 'testuser', ctx);
+
+    const calls = (mockPlatform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    const nudge = calls.find((m: string) => m.includes('!github-email'));
+    expect(nudge).toBeFalsy();
+  });
+
+  it('persists the session BEFORE the in-thread chat notices run', async () => {
+    // Regression-defender: in an earlier draft, the chat-side notice ran
+    // before persistSession. If that post threw (network error), the invitee
+    // was added to the in-memory set but never written to disk — so a bot
+    // restart would silently drop them. Verifies call ordering, not failure
+    // semantics, by tracking the call sequence.
+    const callOrder: string[] = [];
+    const mockPlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({ id: 'user-2', username: 'newuser' })),
+      createPost: mock((message: string) => {
+        callOrder.push(`createPost:${message.substring(0, 30)}`);
+        return Promise.resolve({
+          id: 'post-x',
+          platformId: 'test-platform',
+          channelId: 'test-channel',
+          userId: 'bot',
+          message,
+        });
+      }),
+    });
+    const session = createMockSession({ platform: mockPlatform });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+    (ctx.ops.persistSession as any).mockImplementation(() => callOrder.push('persistSession'));
+
+    await commands.inviteUser(session, 'newuser', 'testuser', ctx);
+
+    const persistIdx = callOrder.indexOf('persistSession');
+    const noticeIdx = callOrder.findIndex(s => s.startsWith('createPost:🔑') || s.startsWith('createPost:📝'));
+    expect(persistIdx).toBeGreaterThan(-1);
+    expect(noticeIdx).toBeGreaterThan(-1);
+    expect(persistIdx).toBeLessThan(noticeIdx);
   });
 });
 
@@ -379,6 +460,111 @@ describe('kickUser', () => {
     const notice = calls.find((m: string) => m.includes('Collaborators updated'));
     expect(notice).toBeTruthy();
     expect(notice).toContain('no co-authors');
+  });
+});
+
+describe('setGitHubEmail', () => {
+  function makeCtx() {
+    const session = createMockSession();
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+    return { session, ctx, platform: session.platform };
+  }
+
+  it('shows current registration when called without args', async () => {
+    const { session, ctx, platform } = makeCtx();
+    (ctx.state.githubEmailsStore.get as any).mockReturnValue('111+testuser@users.noreply.github.com');
+
+    await commands.setGitHubEmail(session, 'testuser', undefined, ctx);
+
+    const calls = (platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls.find((m: string) => m.includes('111+testuser@users.noreply.github.com'))).toBeTruthy();
+  });
+
+  it('shows the registration instructions when not registered yet', async () => {
+    const { session, ctx, platform } = makeCtx();
+    (ctx.state.githubEmailsStore.get as any).mockReturnValue(undefined);
+
+    await commands.setGitHubEmail(session, 'testuser', undefined, ctx);
+
+    const calls = (platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls.find((m: string) =>
+      m.includes('!github-email') && m.includes('https://github.com/settings/emails'),
+    )).toBeTruthy();
+  });
+
+  it('rejects an obviously-not-a-noreply address with a clear message', async () => {
+    const { session, ctx, platform } = makeCtx();
+
+    await commands.setGitHubEmail(session, 'testuser', 'testuser@example.com', ctx);
+
+    expect(ctx.state.githubEmailsStore.set).not.toHaveBeenCalled();
+    const calls = (platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls.find((m: string) =>
+      m.includes("doesn't look like") || m.includes('does not look like'),
+    )).toBeTruthy();
+  });
+
+  it('persists a valid noreply email and confirms', async () => {
+    const { session, ctx, platform } = makeCtx();
+
+    await commands.setGitHubEmail(
+      session,
+      'testuser',
+      '12345+testuser@users.noreply.github.com',
+      ctx,
+    );
+
+    expect(ctx.state.githubEmailsStore.set).toHaveBeenCalledWith(
+      'test-platform',
+      'testuser',
+      '12345+testuser@users.noreply.github.com',
+    );
+    const calls = (platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls.find((m: string) =>
+      m.includes('registered') && m.includes('12345+testuser@users.noreply.github.com'),
+    )).toBeTruthy();
+  });
+
+  it('removes the registration on `reset`', async () => {
+    const { session, ctx, platform } = makeCtx();
+    (ctx.state.githubEmailsStore.delete as any).mockReturnValue(true);
+
+    await commands.setGitHubEmail(session, 'testuser', 'reset', ctx);
+
+    expect(ctx.state.githubEmailsStore.delete).toHaveBeenCalledWith('test-platform', 'testuser');
+    const calls = (platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls.find((m: string) => m.includes('removed'))).toBeTruthy();
+  });
+
+  it('also accepts `clear` as alias for reset', async () => {
+    const { session, ctx } = makeCtx();
+    (ctx.state.githubEmailsStore.delete as any).mockReturnValue(true);
+
+    await commands.setGitHubEmail(session, 'testuser', 'clear', ctx);
+
+    expect(ctx.state.githubEmailsStore.delete).toHaveBeenCalledWith('test-platform', 'testuser');
+  });
+
+  it('isolates registrations per platform (uses session.platformId, not a global key)', async () => {
+    // Regression-defender: same username on different platforms must store
+    // independently. Verifies the call passes the session's platformId, not
+    // (e.g.) a hard-coded 'default' or the username alone.
+    const { session, ctx } = makeCtx();
+    session.platformId = 'slack-workspace';
+
+    await commands.setGitHubEmail(
+      session,
+      'testuser',
+      '12345+testuser@users.noreply.github.com',
+      ctx,
+    );
+
+    expect(ctx.state.githubEmailsStore.set).toHaveBeenCalledWith(
+      'slack-workspace',
+      'testuser',
+      '12345+testuser@users.noreply.github.com',
+    );
   });
 });
 

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -231,6 +231,47 @@ describe('inviteUser', () => {
       session.threadId
     );
   });
+
+  it('posts a "Collaborators updated" notice with the new co-author when the invitee has an email', async () => {
+    // Regression-defender: this notice is the contract that lets Claude pick
+    // up the current co-author list mid-session. Without it, an !invite is
+    // invisible to Claude until the next system-prompt rebuild (resume/!cd).
+    const mockPlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({
+        id: 'user-2', username: 'newuser', displayName: 'New User', email: 'new@example.com',
+      })),
+    });
+    const session = createMockSession({ platform: mockPlatform });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await commands.inviteUser(session, 'newuser', 'testuser', ctx);
+
+    const calls = (mockPlatform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    const notice = calls.find((m: string) => m.includes('Collaborators updated'));
+    expect(notice).toBeTruthy();
+    expect(notice).toContain('New User <new@example.com>');
+  });
+
+  it('still posts a notice (with empty list) so an older notice does not keep applying — but only if collaborators with email exist', async () => {
+    // When the invitee has no email we can't add them as co-author, so the
+    // co-author list is still empty after the invite. The notice must reflect
+    // that — otherwise an older notice could keep claiming this invitee is a
+    // co-author. Owner is excluded so no email anywhere → "no co-authors".
+    const mockPlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({ id: 'user-2', username: 'newuser' })),
+    });
+    const session = createMockSession({ platform: mockPlatform });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await commands.inviteUser(session, 'newuser', 'testuser', ctx);
+
+    const calls = (mockPlatform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    const notice = calls.find((m: string) => m.includes('Collaborators updated'));
+    expect(notice).toBeTruthy();
+    expect(notice).toContain('no co-authors');
+  });
 });
 
 describe('kickUser', () => {
@@ -317,6 +358,27 @@ describe('kickUser', () => {
       expect.stringContaining('was not in this session'),
       session.threadId
     );
+  });
+
+  it('posts a "Collaborators updated" notice after a successful kick so Claude drops the kicked co-author', async () => {
+    // Regression-defender: without this, the previous "Collaborators updated"
+    // notice (with the now-kicked user) would keep applying to future commits.
+    const inviteePlatform = createMockPlatform({
+      getUserByUsername: mock(() => Promise.resolve({
+        id: 'user-2', username: 'inviteduser', displayName: 'Invited', email: 'inv@example.com',
+      })),
+    });
+    const session = createMockSession({ platform: inviteePlatform });
+    session.sessionAllowedUsers.add('inviteduser');
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await commands.kickUser(session, 'inviteduser', 'testuser', ctx);
+
+    const calls = (inviteePlatform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    const notice = calls.find((m: string) => m.includes('Collaborators updated'));
+    expect(notice).toBeTruthy();
+    expect(notice).toContain('no co-authors');
   });
 });
 

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -65,6 +65,7 @@ import {
   formatCollaboratorListForChat,
   resolveCollaborators,
 } from '../../commands/system-prompt-generator.js';
+import { isValidGitHubNoreplyEmail } from '../../persistence/github-emails-store.js';
 
 const log = createLogger('commands');
 const sessionLog = createSessionLog(log);
@@ -399,11 +400,13 @@ export async function changeDirectory(
   // doesn't silently drop on `!cd`.
   const appendSystemPrompt = await buildAppendSystemPrompt(
     session.platform,
+    session.platformId,
     absoluteDir,
     session.threadId,
     session.startedBy,
     session.sessionAllowedUsers,
     CHAT_PLATFORM_PROMPT,
+    ctx.state.githubEmailsStore,
   );
 
   const cliOptions: ClaudeCliOptions = {
@@ -461,11 +464,63 @@ export async function changeDirectory(
  * Posts even when the list is now empty (e.g. after the last !kick) so an
  * older notice in the thread doesn't keep applying.
  */
-async function postCollaboratorUpdatedNotice(session: Session): Promise<void> {
+/**
+ * Onboarding nudge: when a freshly-invited collaborator has no GitHub noreply
+ * email registered yet, point them at the `!github-email` command and the
+ * GitHub settings URL. Quiet no-op if they already registered (e.g. they were
+ * invited to a previous session and set it then).
+ */
+async function postOnboardingReminderIfNeeded(
+  session: Session,
+  invitedUser: string,
+  ctx: SessionContext,
+): Promise<void> {
+  if (ctx.state.githubEmailsStore.get(session.platformId, invitedUser)) return;
+  const formatter = session.platform.getFormatter();
+  await post(
+    session,
+    'info',
+    `🔑 ${formatter.formatUserMention(invitedUser)}, to be added as a co-author on git commits in this session, share your GitHub noreply email: send ${formatter.formatCode('!github-email <addr>')} in this thread. Find yours at https://github.com/settings/emails (under "Keep my email addresses private" — toggle does not need to be on; the address is shown right below it). Until then, commits won't credit you.`,
+  );
+}
+
+/**
+ * On session resume, list the still-unregistered collaborators in one
+ * combined nudge so each user can self-register without re-inviting them.
+ * No-ops when every collaborator (or the lone owner) is already accounted for.
+ */
+export async function postResumeCoAuthorOnboarding(
+  session: Session,
+  ctx: SessionContext,
+): Promise<void> {
+  const unregistered: string[] = [];
+  for (const username of session.sessionAllowedUsers) {
+    if (username === session.startedBy) continue;
+    if (!ctx.state.githubEmailsStore.get(session.platformId, username)) {
+      unregistered.push(username);
+    }
+  }
+  if (unregistered.length === 0) return;
+
+  const formatter = session.platform.getFormatter();
+  const mentions = unregistered.map(u => formatter.formatUserMention(u)).join(', ');
+  await post(
+    session,
+    'info',
+    `🔑 ${mentions} — to be added as co-authors on git commits, share your GitHub noreply email with ${formatter.formatCode('!github-email <addr>')}. Find yours at https://github.com/settings/emails.`,
+  );
+}
+
+async function postCollaboratorUpdatedNotice(
+  session: Session,
+  ctx: SessionContext,
+): Promise<void> {
   const collaborators = await resolveCollaborators(
     session.platform,
+    session.platformId,
     session.startedBy,
     session.sessionAllowedUsers,
+    ctx.state.githubEmailsStore,
   );
   const body = collaborators.length === 0
     ? `📝 Collaborators updated — no co-authors for new commits.`
@@ -501,8 +556,13 @@ export async function inviteUser(
   sessionLog(session).info(`👋 @${invitedUser} invited by @${invitedBy}`);
   session.threadLogger?.logCommand('invite', invitedUser, invitedBy);
   await updateSessionHeader(session, ctx);
-  await postCollaboratorUpdatedNotice(session);
+  // Persist FIRST so a failure in the chat-side notices below doesn't leave
+  // the session in memory-only state (the invitee would vanish on bot restart).
   ctx.ops.persistSession(session);
+  // Onboard for co-author attribution: nudge the invitee to register their
+  // GitHub noreply email if they haven't already, so Claude can tag them.
+  await postOnboardingReminderIfNeeded(session, invitedUser, ctx);
+  await postCollaboratorUpdatedNotice(session, ctx);
 }
 
 /**
@@ -547,11 +607,102 @@ export async function kickUser(
     sessionLog(session).info(`🚫 @${kickedUser} kicked by @${kickedBy}`);
     session.threadLogger?.logCommand('kick', kickedUser, kickedBy);
     await updateSessionHeader(session, ctx);
-    await postCollaboratorUpdatedNotice(session);
+    await postCollaboratorUpdatedNotice(session, ctx);
     ctx.ops.persistSession(session);
   } else {
     await post(session, 'warning', `${formatter.formatUserMention(kickedUser)} was not in this session`);
     sessionLog(session).warn(`🚫 @${kickedUser} was not in session`);
+  }
+}
+
+/**
+ * Handle `!github-email` — register/show/reset the caller's GitHub noreply email.
+ *
+ * Always self-scoped: a user can only register their own address. Owners
+ * cannot register on behalf of someone else, by design — the noreply mapping
+ * tells GitHub which account a commit is co-authored by, and only the user
+ * themselves can authoritatively name that.
+ *
+ * Subcommands:
+ * - `!github-email <addr>` — register or replace
+ * - `!github-email`        — show currently registered address (or "none")
+ * - `!github-email reset`  — clear registration
+ */
+export async function setGitHubEmail(
+  session: Session,
+  username: string,
+  arg: string | undefined,
+  ctx: SessionContext,
+): Promise<void> {
+  const formatter = session.platform.getFormatter();
+  const trimmed = arg?.trim();
+  const platformId = session.platformId;
+
+  // Show current registration.
+  if (!trimmed) {
+    const current = ctx.state.githubEmailsStore.get(platformId, username);
+    if (current) {
+      await post(
+        session,
+        'info',
+        `🔑 ${formatter.formatUserMention(username)}, your registered GitHub noreply email is ${formatter.formatCode(current)}. Use ${formatter.formatCode('!github-email reset')} to remove it.`,
+      );
+    } else {
+      await post(
+        session,
+        'info',
+        `🔑 ${formatter.formatUserMention(username)}, you have not registered a GitHub noreply email. Find yours at https://github.com/settings/emails (under "Keep my email addresses private" — toggle does not need to be on; the address is shown right below it). Then send ${formatter.formatCode('!github-email <addr>')} in this thread.`,
+      );
+    }
+    return;
+  }
+
+  // Reset.
+  if (trimmed.toLowerCase() === 'reset' || trimmed.toLowerCase() === 'clear') {
+    const removed = ctx.state.githubEmailsStore.delete(platformId, username);
+    if (removed) {
+      await post(
+        session,
+        'success',
+        `🔑 ${formatter.formatUserMention(username)}, your GitHub noreply email registration was removed. You will no longer be added as a co-author on commits.`,
+      );
+      sessionLog(session).info(`🔑 @${username} reset GitHub noreply email`);
+      // Refresh Claude's view in the thread so the now-removed user is dropped.
+      await postCollaboratorUpdatedNotice(session, ctx);
+    } else {
+      await post(
+        session,
+        'info',
+        `🔑 ${formatter.formatUserMention(username)}, you had no GitHub noreply email registered.`,
+      );
+    }
+    return;
+  }
+
+  // Register or replace.
+  if (!isValidGitHubNoreplyEmail(trimmed)) {
+    await post(
+      session,
+      'warning',
+      `🔑 That doesn't look like a GitHub noreply email. Expected the form ${formatter.formatCode('<id>+<username>@users.noreply.github.com')} (e.g. ${formatter.formatCode('12345+alice@users.noreply.github.com')}). Find yours at https://github.com/settings/emails.`,
+    );
+    sessionLog(session).warn(`🔑 @${username} provided invalid GitHub noreply email`);
+    return;
+  }
+
+  ctx.state.githubEmailsStore.set(platformId, username, trimmed);
+  await post(
+    session,
+    'success',
+    `🔑 ${formatter.formatUserMention(username)}, registered ${formatter.formatCode(trimmed)} as your GitHub noreply email. You will be added as a co-author on commits made in sessions you participate in.`,
+  );
+  sessionLog(session).info(`🔑 @${username} registered GitHub noreply email`);
+  session.threadLogger?.logCommand('github-email', 'set', username);
+
+  // If this user is in the current session as a collaborator, immediately
+  // refresh the thread notice so Claude picks up the trailer next turn.
+  if (session.sessionAllowedUsers.has(username) && username !== session.startedBy) {
+    await postCollaboratorUpdatedNotice(session, ctx);
   }
 }
 

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -607,8 +607,11 @@ export async function kickUser(
     sessionLog(session).info(`🚫 @${kickedUser} kicked by @${kickedBy}`);
     session.threadLogger?.logCommand('kick', kickedUser, kickedBy);
     await updateSessionHeader(session, ctx);
-    await postCollaboratorUpdatedNotice(session, ctx);
+    // Persist FIRST, mirror of inviteUser: a network failure on the
+    // collaborator-update notice must not roll back the kick to disk.
+    // Without this, a bot restart would resurrect the kicked user.
     ctx.ops.persistSession(session);
+    await postCollaboratorUpdatedNotice(session, ctx);
   } else {
     await post(session, 'warning', `${formatter.formatUserMention(kickedUser)} was not in this session`);
     sessionLog(session).warn(`🚫 @${kickedUser} was not in session`);

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -60,7 +60,11 @@ import { shortenPath } from '../index.js';
 import { getLogFilePath } from '../../persistence/thread-logger.js';
 import { quickQuery } from '../../claude/quick-query.js';
 import { CHAT_PLATFORM_PROMPT } from '../../session/lifecycle.js';
-import { buildSessionContext } from '../../commands/system-prompt-generator.js';
+import {
+  buildAppendSystemPrompt,
+  formatCollaboratorListForChat,
+  resolveCollaborators,
+} from '../../commands/system-prompt-generator.js';
 
 const log = createLogger('commands');
 const sessionLog = createSessionLog(log);
@@ -390,9 +394,17 @@ export async function changeDirectory(
   const newSessionId = randomUUID();
   session.claudeSessionId = newSessionId;
 
-  // Build system prompt with platform context for the new directory
-  const sessionContext = buildSessionContext(session.platform, absoluteDir, session.threadId);
-  const appendSystemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
+  // Build system prompt with platform context for the new directory.
+  // Carry collaborator co-author tags across the respawn so attribution
+  // doesn't silently drop on `!cd`.
+  const appendSystemPrompt = await buildAppendSystemPrompt(
+    session.platform,
+    absoluteDir,
+    session.threadId,
+    session.startedBy,
+    session.sessionAllowedUsers,
+    CHAT_PLATFORM_PROMPT,
+  );
 
   const cliOptions: ClaudeCliOptions = {
     ...commonRestartCliOptions(session, ctx),
@@ -441,6 +453,27 @@ export async function changeDirectory(
 // ---------------------------------------------------------------------------
 
 /**
+ * Post a "Collaborators updated" notice in the thread so Claude can read the
+ * current co-author list on the next turn.
+ *
+ * The literal phrase "Collaborators updated" is the convention promised by
+ * `buildCollaboratorContext()` — it's how Claude finds the most-recent list.
+ * Posts even when the list is now empty (e.g. after the last !kick) so an
+ * older notice in the thread doesn't keep applying.
+ */
+async function postCollaboratorUpdatedNotice(session: Session): Promise<void> {
+  const collaborators = await resolveCollaborators(
+    session.platform,
+    session.startedBy,
+    session.sessionAllowedUsers,
+  );
+  const body = collaborators.length === 0
+    ? `📝 Collaborators updated — no co-authors for new commits.`
+    : `📝 Collaborators updated — co-authors for new commits: ${formatCollaboratorListForChat(collaborators)}`;
+  await post(session, 'info', body);
+}
+
+/**
  * Invite a user to participate in a session.
  */
 export async function inviteUser(
@@ -468,6 +501,7 @@ export async function inviteUser(
   sessionLog(session).info(`👋 @${invitedUser} invited by @${invitedBy}`);
   session.threadLogger?.logCommand('invite', invitedUser, invitedBy);
   await updateSessionHeader(session, ctx);
+  await postCollaboratorUpdatedNotice(session);
   ctx.ops.persistSession(session);
 }
 
@@ -513,6 +547,7 @@ export async function kickUser(
     sessionLog(session).info(`🚫 @${kickedUser} kicked by @${kickedBy}`);
     session.threadLogger?.logCommand('kick', kickedUser, kickedBy);
     await updateSessionHeader(session, ctx);
+    await postCollaboratorUpdatedNotice(session);
     ctx.ops.persistSession(session);
   } else {
     await post(session, 'warning', `${formatter.formatUserMention(kickedUser)} was not in this session`);

--- a/src/operations/commands/index.ts
+++ b/src/operations/commands/index.ts
@@ -18,6 +18,7 @@ export {
   // User collaboration
   inviteUser,
   kickUser,
+  setGitHubEmail,
 
   // Permission management
   setSessionPermissionMode,

--- a/src/operations/events/handler.test.ts
+++ b/src/operations/events/handler.test.ts
@@ -128,6 +128,7 @@ function createSessionContext(): SessionContext {
       postIndex: new Map(),
       platforms: new Map(),
       sessionStore: { save: () => {}, remove: () => {}, load: () => new Map(), findByPostId: () => undefined, cleanStale: () => [] } as any,
+      githubEmailsStore: { get: () => undefined, set: () => {}, delete: () => false } as any,
       isShuttingDown: false,
     },
     ops: {

--- a/src/operations/monitor/handler.test.ts
+++ b/src/operations/monitor/handler.test.ts
@@ -10,6 +10,7 @@ function createMockContext(): SessionContext {
       platforms: new Map(),
       postIndex: new Map(),
       sessionStore: {} as never,
+      githubEmailsStore: {} as never,
       isShuttingDown: false,
     },
     config: {

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -15,6 +15,7 @@ import type { Session } from '../../session/types.js';
 import type { ClaudeEvent } from '../../claude/cli.js';
 import type { PlatformClient, PlatformFile } from '../../platform/index.js';
 import type { SessionStore } from '../../persistence/session-store.js';
+import type { GitHubEmailsStore } from '../../persistence/github-emails-store.js';
 import type { SessionInfo } from '../../ui/types.js';
 import type { BuiltMessageContent } from '../streaming/handler.js';
 import type { ClaudeAccount, PermissionMode } from '../../config/index.js';
@@ -64,6 +65,8 @@ export interface SessionState {
   readonly platforms: ReadonlyMap<string, PlatformClient>;
   /** Session persistence store */
   readonly sessionStore: SessionStore;
+  /** GitHub noreply email registrations (for commit co-author attribution) */
+  readonly githubEmailsStore: GitHubEmailsStore;
   /** Whether the manager is shutting down */
   readonly isShuttingDown: boolean;
 }

--- a/src/operations/worktree/handler.test.ts
+++ b/src/operations/worktree/handler.test.ts
@@ -173,6 +173,7 @@ function createMockOptions() {
     formatContextForClaude: mockFormatContextForClaude,
     registerPost: mock(() => {}),
     updateStickyMessage: mock(() => Promise.resolve()),
+    githubEmailsStore: { get: mock(() => undefined) },
   };
 }
 

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -412,6 +412,7 @@ export async function createAndSwitchToWorktree(
     getThreadMessagesForContext: (session: Session, limit: number, excludePostId?: string) => Promise<ThreadMessage[]>;
     formatContextForClaude: (messages: ThreadMessage[], previousWorkSummary?: string) => string;
     appendSystemPrompt?: string;
+    githubEmailsStore: { get(platformId: string, username: string): string | undefined };
     registerPost: (postId: string, threadId: string) => void;
     updateStickyMessage: () => Promise<void>;
     registerWorktreeUser?: (worktreePath: string, sessionId: string) => void;
@@ -508,11 +509,13 @@ export async function createAndSwitchToWorktree(
           resume: false,
           appendSystemPrompt: await buildAppendSystemPrompt(
             session.platform,
+            session.platformId,
             existing.path,
             session.threadId,
             session.startedBy,
             session.sessionAllowedUsers,
             options.appendSystemPrompt ?? '',
+            options.githubEmailsStore,
             { omitSessionContext: !needsTitlePrompt },
           ),
         };
@@ -666,11 +669,13 @@ export async function createAndSwitchToWorktree(
         resume: false,  // Fresh start - can't resume across directories
         appendSystemPrompt: await buildAppendSystemPrompt(
           session.platform,
+          session.platformId,
           worktreePath,
           session.threadId,
           session.startedBy,
           session.sessionAllowedUsers,
           options.appendSystemPrompt ?? '',
+          options.githubEmailsStore,
           { omitSessionContext: !needsTitlePrompt },
         ),
       };

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -26,7 +26,7 @@ import {
 import type { ClaudeCliOptions, ClaudeEvent } from '../../claude/cli.js';
 import { ClaudeCli } from '../../claude/cli.js';
 import { buildRestartCliOptions } from '../../claude/restart-options.js';
-import { buildSessionContext } from '../../commands/system-prompt-generator.js';
+import { buildAppendSystemPrompt } from '../../commands/system-prompt-generator.js';
 import { postSkippedFilesFeedback, type BuiltMessageContent } from '../streaming/handler.js';
 import { randomUUID } from 'crypto';
 import { logAndNotify } from '../../utils/error-handler/index.js';
@@ -487,11 +487,12 @@ export async function createAndSwitchToWorktree(
         const newSessionId = randomUUID();
         session.claudeSessionId = newSessionId;
 
-        // Create new CLI with new working directory
+        // Create new CLI with new working directory.
+        // Always include the chat-platform prompt + collaborator section so
+        // attribution rules and other conventions don't drop on respawn.
+        // The session-context line is only re-included when Claude still needs
+        // to generate a title (preserves the existing optimization).
         const needsTitlePrompt = !session.sessionTitle;
-        const sessionContext = needsTitlePrompt
-          ? buildSessionContext(session.platform, existing.path, session.threadId)
-          : null;
         const cliOptions: ClaudeCliOptions = {
           ...buildRestartCliOptions(session, {
             chromeEnabled: options.chromeEnabled,
@@ -505,7 +506,15 @@ export async function createAndSwitchToWorktree(
           }),
           sessionId: newSessionId,
           resume: false,
-          appendSystemPrompt: sessionContext ? `${sessionContext}\n\n${options.appendSystemPrompt}` : undefined,
+          appendSystemPrompt: await buildAppendSystemPrompt(
+            session.platform,
+            existing.path,
+            session.threadId,
+            session.startedBy,
+            session.sessionAllowedUsers,
+            options.appendSystemPrompt ?? '',
+            { omitSessionContext: !needsTitlePrompt },
+          ),
         };
         session.claude = new ClaudeCli(cliOptions);
 
@@ -636,13 +645,11 @@ export async function createAndSwitchToWorktree(
       const newSessionId = randomUUID();
       session.claudeSessionId = newSessionId;
 
-      // Create new CLI with new working directory
-      // Include system prompt if session doesn't have a title yet
-      // This ensures Claude will generate a title on its next response
+      // Create new CLI with new working directory.
+      // Always include the chat-platform prompt + collaborator section so
+      // attribution rules and other conventions don't drop on respawn.
+      // Session-context preamble re-included only when Claude still owes a title.
       const needsTitlePrompt = !session.sessionTitle;
-      const sessionContext = needsTitlePrompt
-        ? buildSessionContext(session.platform, worktreePath, session.threadId)
-        : null;
 
       const cliOptions: ClaudeCliOptions = {
         ...buildRestartCliOptions(session, {
@@ -657,7 +664,15 @@ export async function createAndSwitchToWorktree(
         }),
         sessionId: newSessionId,
         resume: false,  // Fresh start - can't resume across directories
-        appendSystemPrompt: sessionContext ? `${sessionContext}\n\n${options.appendSystemPrompt}` : undefined,
+        appendSystemPrompt: await buildAppendSystemPrompt(
+          session.platform,
+          worktreePath,
+          session.threadId,
+          session.startedBy,
+          session.sessionAllowedUsers,
+          options.appendSystemPrompt ?? '',
+          { omitSessionContext: !needsTitlePrompt },
+        ),
       };
       session.claude = new ClaudeCli(cliOptions);
 

--- a/src/persistence/github-emails-store.test.ts
+++ b/src/persistence/github-emails-store.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { writeFileSync, existsSync, unlinkSync, statSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { GitHubEmailsStore, isValidGitHubNoreplyEmail } from './github-emails-store.js';
+
+function uniquePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gh-emails-'));
+  return join(dir, 'github-emails.yaml');
+}
+
+describe('isValidGitHubNoreplyEmail', () => {
+  it('accepts the canonical ID-prefix form', () => {
+    expect(isValidGitHubNoreplyEmail('12345678+anne@users.noreply.github.com')).toBe(true);
+    expect(isValidGitHubNoreplyEmail('1+a@users.noreply.github.com')).toBe(true);
+  });
+
+  it('rejects the legacy username-only form (account creation date dependent)', () => {
+    // Refusing this avoids supporting two formats with subtle account-age semantics.
+    expect(isValidGitHubNoreplyEmail('anne@users.noreply.github.com')).toBe(false);
+  });
+
+  it('rejects real emails and other domains', () => {
+    expect(isValidGitHubNoreplyEmail('anne@example.com')).toBe(false);
+    expect(isValidGitHubNoreplyEmail('12345+anne@example.com')).toBe(false);
+    expect(isValidGitHubNoreplyEmail('12345+anne@noreply.github.com')).toBe(false);
+  });
+
+  it('rejects malformed input (case / whitespace / empty)', () => {
+    expect(isValidGitHubNoreplyEmail('')).toBe(false);
+    expect(isValidGitHubNoreplyEmail('  12345+anne@users.noreply.github.com')).toBe(false);
+    expect(isValidGitHubNoreplyEmail('12345+anne@users.noreply.github.com  ')).toBe(false);
+    expect(isValidGitHubNoreplyEmail('12345-anne@users.noreply.github.com')).toBe(false);
+  });
+});
+
+describe('GitHubEmailsStore', () => {
+  let path: string;
+
+  beforeEach(() => {
+    path = uniquePath();
+  });
+
+  afterEach(() => {
+    if (existsSync(path)) {
+      unlinkSync(path);
+    }
+    // Best-effort cleanup of the temp dir.
+    try { rmSync(join(path, '..'), { recursive: true, force: true }); } catch { /* */ }
+  });
+
+  it('returns undefined for unknown (platform, user)', () => {
+    const store = new GitHubEmailsStore(path);
+    expect(store.get('mm', 'alice')).toBeUndefined();
+  });
+
+  it('stores and retrieves an email per (platform, user)', () => {
+    const store = new GitHubEmailsStore(path);
+    store.set('mm', 'alice', '111+alice@users.noreply.github.com');
+    expect(store.get('mm', 'alice')).toBe('111+alice@users.noreply.github.com');
+  });
+
+  it('keeps platforms isolated (same username on different platforms)', () => {
+    // Per CLAUDE.md decision: scope is per platform — `bob` on Mattermost may
+    // be a different human than `bob` on Slack.
+    const store = new GitHubEmailsStore(path);
+    store.set('mm', 'bob', '111+bob@users.noreply.github.com');
+    store.set('slack', 'bob', '222+bob@users.noreply.github.com');
+    expect(store.get('mm', 'bob')).toBe('111+bob@users.noreply.github.com');
+    expect(store.get('slack', 'bob')).toBe('222+bob@users.noreply.github.com');
+  });
+
+  it('overwrites on second set for the same (platform, user)', () => {
+    const store = new GitHubEmailsStore(path);
+    store.set('mm', 'alice', '111+alice@users.noreply.github.com');
+    store.set('mm', 'alice', '222+alice@users.noreply.github.com');
+    expect(store.get('mm', 'alice')).toBe('222+alice@users.noreply.github.com');
+  });
+
+  it('delete removes the entry and reports whether anything was there', () => {
+    const store = new GitHubEmailsStore(path);
+    expect(store.delete('mm', 'ghost')).toBe(false);
+    store.set('mm', 'alice', '111+alice@users.noreply.github.com');
+    expect(store.delete('mm', 'alice')).toBe(true);
+    expect(store.get('mm', 'alice')).toBeUndefined();
+  });
+
+  it('rejects an invalid email at set() time so we never persist bad data', () => {
+    const store = new GitHubEmailsStore(path);
+    expect(() => store.set('mm', 'alice', 'alice@example.com')).toThrow(/noreply/);
+    expect(store.get('mm', 'alice')).toBeUndefined();
+  });
+
+  it('persists across instances (a fresh store reads what the previous wrote)', () => {
+    const a = new GitHubEmailsStore(path);
+    a.set('mm', 'alice', '111+alice@users.noreply.github.com');
+    const b = new GitHubEmailsStore(path);
+    expect(b.get('mm', 'alice')).toBe('111+alice@users.noreply.github.com');
+  });
+
+  it('writes the file with 0600 permissions to keep mappings local-user-readable only', () => {
+    const store = new GitHubEmailsStore(path);
+    store.set('mm', 'alice', '111+alice@users.noreply.github.com');
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('handles a malformed YAML file by starting empty (no crash)', () => {
+    writeFileSync(path, '::: not yaml :::', 'utf-8');
+    const store = new GitHubEmailsStore(path);
+    expect(store.get('mm', 'alice')).toBeUndefined();
+    // And a subsequent set still works (we overwrite the malformed file).
+    store.set('mm', 'alice', '111+alice@users.noreply.github.com');
+    expect(store.get('mm', 'alice')).toBe('111+alice@users.noreply.github.com');
+  });
+});

--- a/src/persistence/github-emails-store.ts
+++ b/src/persistence/github-emails-store.ts
@@ -1,0 +1,146 @@
+/**
+ * GitHubEmailsStore — persistence for users' GitHub noreply email addresses.
+ *
+ * Each collaborator self-registers via `!github-email <addr>` so we never
+ * read their platform email (privacy: it would otherwise leak into the chat
+ * thread and into Claude's local conversation history). The noreply form
+ * `<id>+<username>@users.noreply.github.com` is intentionally publishable —
+ * GitHub designed it to keep the real email private while still letting
+ * commits be matched to the account.
+ *
+ * Storage: YAML at ~/.config/claude-threads/github-emails.yaml, 0600.
+ * Shape: `{ <platformId>: { <username>: <noreplyEmail> } }`.
+ *
+ * Per-platform scope: a username on `mattermost-main` and the same string on
+ * `slack-workspace` may be different humans, so they keep separate entries.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, chmodSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import yaml from 'js-yaml';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('gh-emails');
+
+const DEFAULT_CONFIG_DIR = join(homedir(), '.config', 'claude-threads');
+const DEFAULT_FILE = join(DEFAULT_CONFIG_DIR, 'github-emails.yaml');
+
+/**
+ * GitHub noreply email format we accept. Required ID-prefix form
+ * (`<id>+<username>@users.noreply.github.com`) — the legacy username-only
+ * form silently fails to match for accounts created after July 2017, and
+ * we don't want to debug that on a user's behalf.
+ */
+const NOREPLY_REGEX = /^\d+\+[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})@users\.noreply\.github\.com$/;
+
+interface FileShape {
+  version: number;
+  /** platformId -> username -> noreply email */
+  emails: Record<string, Record<string, string>>;
+}
+
+const STORE_VERSION = 1;
+
+/**
+ * Returns true if the string is a valid GitHub noreply email in ID-prefix form.
+ */
+export function isValidGitHubNoreplyEmail(s: string): boolean {
+  return NOREPLY_REGEX.test(s);
+}
+
+export class GitHubEmailsStore {
+  private readonly file: string;
+  private readonly configDir: string;
+
+  constructor(filePath?: string) {
+    const envPath = process.env.CLAUDE_THREADS_GITHUB_EMAILS_PATH;
+    const effective = filePath ?? envPath;
+
+    if (effective) {
+      this.file = effective;
+      this.configDir = join(effective, '..');
+    } else {
+      this.file = DEFAULT_FILE;
+      this.configDir = DEFAULT_CONFIG_DIR;
+    }
+
+    if (!existsSync(this.configDir)) {
+      mkdirSync(this.configDir, { recursive: true });
+    }
+  }
+
+  /**
+   * Look up the registered noreply email for a (platform, user) pair.
+   * Returns undefined when the user has not registered.
+   */
+  get(platformId: string, username: string): string | undefined {
+    const data = this.loadRaw();
+    return data.emails[platformId]?.[username];
+  }
+
+  /**
+   * Register or replace the noreply email for a (platform, user) pair.
+   * Throws if the input is not a valid noreply address.
+   */
+  set(platformId: string, username: string, email: string): void {
+    if (!isValidGitHubNoreplyEmail(email)) {
+      throw new Error(
+        `Not a valid GitHub noreply email (expected <id>+<username>@users.noreply.github.com): ${email}`
+      );
+    }
+    const data = this.loadRaw();
+    if (!data.emails[platformId]) {
+      data.emails[platformId] = {};
+    }
+    data.emails[platformId][username] = email;
+    this.writeAtomic(data);
+    log.debug(`Stored GitHub email for ${platformId}/${username}`);
+  }
+
+  /**
+   * Remove the registration for a (platform, user) pair.
+   * Returns true if there was something to remove.
+   */
+  delete(platformId: string, username: string): boolean {
+    const data = this.loadRaw();
+    if (!data.emails[platformId] || !(username in data.emails[platformId])) {
+      return false;
+    }
+    delete data.emails[platformId][username];
+    if (Object.keys(data.emails[platformId]).length === 0) {
+      delete data.emails[platformId];
+    }
+    this.writeAtomic(data);
+    log.debug(`Removed GitHub email for ${platformId}/${username}`);
+    return true;
+  }
+
+  private loadRaw(): FileShape {
+    if (!existsSync(this.file)) {
+      return { version: STORE_VERSION, emails: {} };
+    }
+    try {
+      const raw = readFileSync(this.file, 'utf-8');
+      const parsed = yaml.load(raw) as Partial<FileShape> | undefined;
+      if (!parsed || typeof parsed !== 'object') {
+        return { version: STORE_VERSION, emails: {} };
+      }
+      const emails = (parsed.emails && typeof parsed.emails === 'object')
+        ? parsed.emails as Record<string, Record<string, string>>
+        : {};
+      return { version: parsed.version ?? STORE_VERSION, emails };
+    } catch (err) {
+      log.warn(`Failed to read ${this.file}: ${(err as Error).message} — starting empty`);
+      return { version: STORE_VERSION, emails: {} };
+    }
+  }
+
+  private writeAtomic(data: FileShape): void {
+    const tempFile = `${this.file}.tmp`;
+    const yamlText = yaml.dump(data, { sortKeys: true, lineWidth: -1 });
+    writeFileSync(tempFile, yamlText, { encoding: 'utf-8', mode: 0o600 });
+    renameSync(tempFile, this.file);
+    chmodSync(this.file, 0o600);
+  }
+}

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -179,6 +179,11 @@ function createMockSessionContext(sessions: Map<string, Session> = new Map()): S
         load: mock(() => new Map()),
         findByPostId: mock(() => undefined),
       } as any,
+      githubEmailsStore: {
+        get: mock(() => undefined),
+        set: mock(() => {}),
+        delete: mock(() => false),
+      } as any,
       isShuttingDown: false,
     },
     ops: {

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -22,7 +22,10 @@ import { cooldownDeadline } from '../claude/rate-limit-detector.js';
 import type { PersistedSession } from '../persistence/session-store.js';
 import { createThreadLogger } from '../persistence/thread-logger.js';
 import { VERSION } from '../version.js';
-import { generateChatPlatformPrompt, buildSessionContext } from '../commands/index.js';
+import {
+  generateChatPlatformPrompt,
+  buildAppendSystemPrompt,
+} from '../commands/index.js';
 import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
 import { keepAlive } from '../utils/keep-alive.js';
@@ -867,9 +870,19 @@ export async function startSession(
     log.info(`Starting session with interactive permissions (from !permissions command)`);
   }
 
-  // Build system prompt with session context
-  const sessionContext = buildSessionContext(platform, workingDir, actualThreadId);
-  const systemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
+  // Build system prompt with session context. New sessions only have the
+  // owner in `sessionAllowedUsers`, so the collaborator section is the
+  // standby one-liner. The full list is published into the thread later
+  // (by `postCollaboratorUpdatedNotice` on each !invite/!kick), and Claude
+  // reads it from there on the next turn — the static prompt is not rewritten.
+  const systemPrompt = await buildAppendSystemPrompt(
+    platform,
+    workingDir,
+    actualThreadId,
+    username,
+    [username],
+    CHAT_PLATFORM_PROMPT,
+  );
 
   // Create Claude CLI with options
   const platformMcpConfig = platform.getMcpConfig();
@@ -1126,9 +1139,16 @@ export async function resumeSession(
     state.forceInteractivePermissions ? 'default' : ctx.config.permissionMode;
   const platformMcpConfig = platform.getMcpConfig();
 
-  // Include system prompt for resumed sessions (provides platform context and command info)
-  const sessionContext = buildSessionContext(platform, state.workingDir, state.threadId);
-  const appendSystemPrompt = `${sessionContext}\n\n${CHAT_PLATFORM_PROMPT}`;
+  // Include system prompt for resumed sessions (platform context, command info,
+  // and collaborator co-author tags carried over from before the restart).
+  const appendSystemPrompt = await buildAppendSystemPrompt(
+    platform,
+    state.workingDir,
+    state.threadId,
+    state.startedBy,
+    state.sessionAllowedUsers || [state.startedBy],
+    CHAT_PLATFORM_PROMPT,
+  );
 
   // Resume MUST re-use the same Claude account the session started on —
   // for OAuth accounts the conversation history lives under that HOME.

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -33,6 +33,7 @@ import { logAndNotify, withErrorHandling } from '../utils/error-handler/index.js
 import { createLogger } from '../utils/logger.js';
 import { createSessionLog } from '../utils/session-log.js';
 import { post, postError, updateLastMessage } from '../operations/post-helpers/index.js';
+import { postResumeCoAuthorOnboarding } from '../operations/commands/handler.js';
 import type { SessionContext } from '../operations/session-context/index.js';
 import { suggestSessionMetadata } from '../operations/suggestions/title.js';
 import { suggestSessionTags } from '../operations/suggestions/tag.js';
@@ -877,11 +878,13 @@ export async function startSession(
   // reads it from there on the next turn — the static prompt is not rewritten.
   const systemPrompt = await buildAppendSystemPrompt(
     platform,
+    platformId,
     workingDir,
     actualThreadId,
     username,
     [username],
     CHAT_PLATFORM_PROMPT,
+    ctx.state.githubEmailsStore,
   );
 
   // Create Claude CLI with options
@@ -1143,11 +1146,13 @@ export async function resumeSession(
   // and collaborator co-author tags carried over from before the restart).
   const appendSystemPrompt = await buildAppendSystemPrompt(
     platform,
+    state.platformId,
     state.workingDir,
     state.threadId,
     state.startedBy,
     state.sessionAllowedUsers || [state.startedBy],
     CHAT_PLATFORM_PROMPT,
+    ctx.state.githubEmailsStore,
   );
 
   // Resume MUST re-use the same Claude account the session started on —
@@ -1341,6 +1346,12 @@ export async function resumeSession(
 
     // Update sticky channel message with resumed session
     await ctx.ops.updateStickyMessage();
+
+    // Co-author onboarding: if collaborators in this session haven't yet
+    // registered a GitHub noreply email, remind them once on resume so
+    // they get the chance to fix it before the next commit. Quiet for solo
+    // sessions and for sessions where everyone has already registered.
+    await postResumeCoAuthorOnboarding(session, ctx);
 
     // Update persistence with new activity time
     ctx.ops.persistSession(session);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -16,6 +16,7 @@ import { EventEmitter } from 'events';
 import { ClaudeEvent } from '../claude/cli.js';
 import type { PlatformClient, PlatformUser, PlatformPost, PlatformFile } from '../platform/index.js';
 import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persistence/session-store.js';
+import { GitHubEmailsStore } from '../persistence/github-emails-store.js';
 import { WorktreeMode, type LimitsConfig, type ResolvedLimits, type ClaudeAccount, type PermissionMode, resolveLimits, effectivePermissionMode } from '../config/index.js';
 import { AccountPool } from '../claude/account-pool.js';
 import type { SessionInfo } from '../ui/types.js';
@@ -86,6 +87,8 @@ export class SessionManager extends EventEmitter {
 
   // Persistence (accessed via registry.getSessionStore())
   private sessionStore!: SessionStore;
+  // Per-user GitHub noreply emails (registered via !github-email)
+  private githubEmailsStore!: GitHubEmailsStore;
 
   // Background tasks
   private sessionMonitor: SessionMonitor | null = null;       // Idle timeout + sticky refresh (1 min)
@@ -134,6 +137,7 @@ export class SessionManager extends EventEmitter {
     this.threadLogsRetentionDays = threadLogsRetentionDays;
     this.limits = resolveLimits(limits);
     this.sessionStore = new SessionStore(sessionsPath);
+    this.githubEmailsStore = new GitHubEmailsStore();
     this.registry = new SessionRegistry(this.sessionStore);
     this.accountPool = new AccountPool(claudeAccounts);
 
@@ -265,6 +269,7 @@ export class SessionManager extends EventEmitter {
       postIndex: this.registry.getPostIndex(),
       platforms: this.platforms,
       sessionStore: this.sessionStore,
+      githubEmailsStore: this.githubEmailsStore,
       isShuttingDown: this.isShuttingDown,
     };
 
@@ -1034,6 +1039,16 @@ export class SessionManager extends EventEmitter {
     await commands.kickUser(session, kickedUser, kickedBy, this.getContext());
   }
 
+  async setGitHubEmail(
+    threadId: string,
+    username: string,
+    arg: string | undefined,
+  ): Promise<void> {
+    const session = this.findSessionByThreadId(threadId);
+    if (!session) return;
+    await commands.setGitHubEmail(session, username, arg, this.getContext());
+  }
+
   /**
    * Change the permission mode of an active session. Respawns Claude with the
    * new mode. Session owner or a globally-allowed user only.
@@ -1225,6 +1240,7 @@ export class SessionManager extends EventEmitter {
       getThreadMessagesForContext: (s, limit, excludePostId) => contextPrompt.getThreadMessagesForContext(s, limit, excludePostId),
       formatContextForClaude: (messages, summary) => contextPrompt.formatContextForClaude(messages, summary),
       appendSystemPrompt: CHAT_PLATFORM_PROMPT,
+      githubEmailsStore: this.githubEmailsStore,
       registerPost: (postId, tid) => this.registerPost(postId, tid),
       updateStickyMessage: () => this.updateStickyMessage(),
       registerWorktreeUser: (path, sid) => this.registerWorktreeUser(path, sid),


### PR DESCRIPTION
## Summary

- When users join a session via `!invite`, they're now added as `Co-Authored-By:` trailers on commits Claude makes.
- Owner is the implicit author and excluded from attribution. The bot and AI assistants are explicitly excluded.
- Mid-session updates work without restart: `!invite`/`!kick` post a "Collaborators updated" notice in the thread, and Claude reads the current list from there on the next turn.
- All four Claude (re)spawn sites (`startSession`, `resumeSession`, `!cd`, worktree create/join) now compose `appendSystemPrompt` through one helper, so the attribution rule cannot silently drop on respawn.

## Behavior

**Solo session** — system prompt carries a one-line standby instruction so a later `!invite` is honored.
**With collaborators** — full `## Git commit attribution` section listing each name + email; thread notices supersede.
**Collaborators without an email** — skipped silently (no valid co-author trailer can be formed).

## Test plan

- [x] Unit tests for `resolveCollaborators`, `buildCollaboratorContext`, `formatCollaboratorListForChat`, `buildAppendSystemPrompt` (incl. legacy persisted state without `sessionAllowedUsers`)
- [x] Tests that `!invite` and `!kick` post a "Collaborators updated" notice (with RED-check verifying the test fails without the fix)
- [x] Test for the standby form having the same exclusion guidance as the full form (RED-checked)
- [x] Full suite: 2343 pass, lint clean, build clean
- [ ] Live test in Mattermost: solo session → `!invite` → ask Claude to commit → verify trailer
- [ ] Live test: invite a user with no platform email → verify silently skipped, no broken trailer
- [ ] Live test: `!cd` mid-session with a collaborator → verify attribution carries across the respawn