### PR TITLE
Fix Mattermost permalink parser for subpath installs

### DIFF
--- a/src/platform/mattermost/permalink.test.ts
+++ b/src/platform/mattermost/permalink.test.ts
@@ -57,9 +57,66 @@ describe('parseMattermostPermalink', () => {
       .toEqual({ postId: ID_A });
   });
 
-  it('matches when baseUrl includes a path component (origin-only match)', () => {
-    expect(parseMattermostPermalink(`${BASE}/digilab/pl/${ID_A}`, `${BASE}/some/extra/path`))
+  it('requires the URL path to be under the baseUrl path', () => {
+    // When baseUrl has a path component, the permalink path must include
+    // it as a prefix. Without this, /chat installs would match permalinks
+    // that aren't actually on the bot's instance.
+    expect(parseMattermostPermalink(`${BASE}/some/extra/path/digilab/pl/${ID_A}`, `${BASE}/some/extra/path`))
       .toEqual({ postId: ID_A });
+    expect(parseMattermostPermalink(`${BASE}/digilab/pl/${ID_A}`, `${BASE}/some/extra/path`))
+      .toBeNull();
+  });
+
+  // Mattermost subpath-installs ("https://host/chat") are common: the
+  // permalink path then has a leading "/chat" prefix that must be stripped
+  // before the {team}/pl/{id} segments. Without this, the bot rejects every
+  // permalink on its own instance.
+  describe('subpath installs', () => {
+    const SUBPATH_BASE = 'https://digilab.overheid.nl/chat';
+
+    it('parses /chat/{team}/pl/{id} when the base has a /chat subpath', () => {
+      expect(parseMattermostPermalink(
+        `https://digilab.overheid.nl/chat/digilab/pl/${ID_A}`,
+        SUBPATH_BASE,
+      )).toEqual({ postId: ID_A });
+    });
+
+    it('parses /chat/_redirect/pl/{id} when the base has a /chat subpath', () => {
+      expect(parseMattermostPermalink(
+        `https://digilab.overheid.nl/chat/_redirect/pl/${ID_A}`,
+        SUBPATH_BASE,
+      )).toEqual({ postId: ID_A });
+    });
+
+    it('matches when the base has a trailing slash on the subpath', () => {
+      expect(parseMattermostPermalink(
+        `https://digilab.overheid.nl/chat/digilab/pl/${ID_A}`,
+        `${SUBPATH_BASE}/`,
+      )).toEqual({ postId: ID_A });
+    });
+
+    it('rejects a permalink that omits the configured subpath', () => {
+      expect(parseMattermostPermalink(
+        `https://digilab.overheid.nl/digilab/pl/${ID_A}`,
+        SUBPATH_BASE,
+      )).toBeNull();
+    });
+
+    it('rejects a permalink under a different subpath', () => {
+      expect(parseMattermostPermalink(
+        `https://digilab.overheid.nl/other/digilab/pl/${ID_A}`,
+        SUBPATH_BASE,
+      )).toBeNull();
+    });
+
+    it('rejects a path that only happens to start with the subpath string', () => {
+      // /chatter/{team}/pl/{id} must not match when the base subpath is /chat:
+      // we compare path segments, not raw string prefixes.
+      expect(parseMattermostPermalink(
+        `https://digilab.overheid.nl/chatter/digilab/pl/${ID_A}`,
+        SUBPATH_BASE,
+      )).toBeNull();
+    });
   });
 
   it('returns null for URLs on a different host', () => {

--- a/src/platform/mattermost/permalink.ts
+++ b/src/platform/mattermost/permalink.ts
@@ -53,8 +53,10 @@ export interface ParsedPermalink {
  *   {baseUrl}/{team}/pl/{postId}     — chat permalink (team-scoped)
  *   {baseUrl}/_redirect/pl/{postId}  — redirect permalink (no team)
  *
- * `baseUrl` is matched on origin (scheme + host + port) only; trailing
- * paths in the configured URL are ignored.
+ * `baseUrl` is matched on origin (scheme + host + port) plus path
+ * prefix, so subpath installs like `https://host/chat` work — the
+ * configured subpath is stripped before the {team}/pl/{id} segments
+ * are validated.
  *
  * The two shapes are recognized explicitly. Anything else (channel
  * URLs, search results, settings pages, malformed paths) returns null.
@@ -72,14 +74,23 @@ export function parseMattermostPermalink(
     return null;
   }
 
-  // Origin match: same scheme + host + port. The configured baseUrl
-  // might have a trailing slash or path component, but only the origin
-  // matters for permalink routing.
+  // Origin match: same scheme + host + port.
   if (parsed.origin !== base.origin) {
     return null;
   }
 
-  const segments = parsed.pathname.replace(/^\/+|\/+$/g, '').split('/');
+  // Strip configured subpath. Mattermost installs at `/chat` show up in
+  // every permalink as a leading `/chat` segment that the parser must
+  // remove before the team/pl/id segments are validated. Compare segment
+  // arrays so `/chat` doesn't accidentally match `/chatter`.
+  const baseSegments = base.pathname.replace(/^\/+|\/+$/g, '').split('/').filter(Boolean);
+  const allSegments = parsed.pathname.replace(/^\/+|\/+$/g, '').split('/');
+
+  for (let i = 0; i < baseSegments.length; i++) {
+    if (allSegments[i] !== baseSegments[i]) return null;
+  }
+  const segments = allSegments.slice(baseSegments.length);
+
   if (segments.length !== 3) return null;
 
   // Second segment must literally be 'pl'.


### PR DESCRIPTION
## Summary

`parseMattermostPermalink` matched only on origin and ignored the configured baseUrl path. On a Mattermost install at `/chat` (e.g. `digilab.overheid.nl/chat`) every permalink has a leading `/chat` segment that pushed the path to four segments. The parser then rejected the URL with `not a Mattermost permalink for https://digilab.overheid.nl/chat (the bot can only follow links on its own instance)` even though the link was on the bot's own instance — \`read_post\` was unusable on that deployment.

The parser now strips the configured subpath as a path-segment prefix before validating the `{team}/pl/{id}` or `_redirect/pl/{id}` shape. Segment-level comparison so `/chat` does not accidentally match `/chatter`.

Regression from #366.

## Test plan

- [x] Five new subpath cases (positive: `/chat/{team}/pl/{id}`, `/chat/_redirect/pl/{id}`, trailing slash on the base; negative: omitted subpath, different subpath, `/chatter` near-match)
- [x] RED-verified: all four positive new tests + the existing path-component test failed before the fix; all pass after
- [x] Existing 36 parser tests still pass — including the wrong-host, wrong-scheme, malformed-id, segment-count, team-name boundary tests
- [x] Full unit suite: 2471 pass / 0 fail. Lint clean. `tsc --noEmit` clean.
- [ ] Live test in #annes-claude-code-sessies: send a permalink, expect `read_post` to resolve to the body instead of the wrong-instance error