### PR TITLE
Allow read_post on public Mattermost channels outside the bot's channel

### DIFF
--- a/src/platform/mattermost/mcp-platform-api.test.ts
+++ b/src/platform/mattermost/mcp-platform-api.test.ts
@@ -292,6 +292,116 @@ describe('MattermostMcpPlatformApi.readPost', () => {
     const post = await makeApi().readPost!('post-1');
     expect(post?.channelId).toBe('some-channel');
   });
+
+  it('marks public channels (Mattermost type "O") as public', async () => {
+    fetchResponder = (url) => {
+      if (url.endsWith('/posts/post-1')) {
+        return jsonResponse({
+          id: 'post-1',
+          channel_id: 'c-public',
+          message: 'hi',
+          user_id: 'u-1',
+          create_at: 1,
+        });
+      }
+      if (url.endsWith('/channels/c-public')) {
+        return jsonResponse({ id: 'c-public', type: 'O' });
+      }
+      return jsonResponse({ id: 'u-1', username: 'alice' });
+    };
+    const post = await makeApi().readPost!('post-1');
+    expect(post?.channelType).toBe('public');
+  });
+
+  it('marks private channels (type "P") as private', async () => {
+    fetchResponder = (url) => {
+      if (url.endsWith('/posts/post-1')) {
+        return jsonResponse({
+          id: 'post-1',
+          channel_id: 'c-private',
+          message: 'hi',
+          user_id: 'u-1',
+          create_at: 1,
+        });
+      }
+      if (url.endsWith('/channels/c-private')) {
+        return jsonResponse({ id: 'c-private', type: 'P' });
+      }
+      return jsonResponse({ id: 'u-1', username: 'alice' });
+    };
+    const post = await makeApi().readPost!('post-1');
+    expect(post?.channelType).toBe('private');
+  });
+
+  it('marks DMs (type "D") and group DMs (type "G") as private', async () => {
+    for (const t of ['D', 'G'] as const) {
+      fetchResponder = (url) => {
+        if (url.endsWith('/posts/post-1')) {
+          return jsonResponse({
+            id: 'post-1',
+            channel_id: `c-${t}`,
+            message: 'hi',
+            user_id: 'u-1',
+            create_at: 1,
+          });
+        }
+        if (url.endsWith(`/channels/c-${t}`)) {
+          return jsonResponse({ id: `c-${t}`, type: t });
+        }
+        return jsonResponse({ id: 'u-1', username: 'alice' });
+      };
+      const post = await makeApi().readPost!('post-1');
+      expect(post?.channelType).toBe('private');
+    }
+  });
+
+  it('leaves channelType undefined when the channel lookup fails', async () => {
+    // Fail-safe: if we can't classify the channel, the resolver treats
+    // it as private. Test exercises that no exception bubbles up.
+    fetchResponder = (url) => {
+      if (url.endsWith('/posts/post-1')) {
+        return jsonResponse({
+          id: 'post-1',
+          channel_id: 'c-unknown',
+          message: 'hi',
+          user_id: 'u-1',
+          create_at: 1,
+        });
+      }
+      if (url.endsWith('/channels/c-unknown')) {
+        return errorResponse(403, 'forbidden');
+      }
+      return jsonResponse({ id: 'u-1', username: 'alice' });
+    };
+    const post = await makeApi().readPost!('post-1');
+    expect(post).not.toBeNull();
+    expect(post!.channelType).toBeUndefined();
+  });
+
+  it('caches channel-type lookups across reads', async () => {
+    let channelCalls = 0;
+    fetchResponder = (url) => {
+      if (url.includes('/posts/post-1') || url.includes('/posts/post-2')) {
+        const id = url.endsWith('/posts/post-1') ? 'post-1' : 'post-2';
+        return jsonResponse({
+          id,
+          channel_id: 'c-shared',
+          message: 'hi',
+          user_id: 'u-1',
+          create_at: 1,
+        });
+      }
+      if (url.endsWith('/channels/c-shared')) {
+        channelCalls += 1;
+        return jsonResponse({ id: 'c-shared', type: 'O' });
+      }
+      return jsonResponse({ id: 'u-1', username: 'alice' });
+    };
+    const api = makeApi();
+    await api.readPost!('post-1');
+    await api.readPost!('post-2');
+    expect(channelCalls).toBe(1);
+  });
 });
 
 // -----------------------------------------------------------------------------

--- a/src/platform/mattermost/mcp-platform-api.ts
+++ b/src/platform/mattermost/mcp-platform-api.ts
@@ -48,6 +48,15 @@ interface MattermostApiPost {
   create_at?: number;
 }
 
+interface MattermostApiChannel {
+  id: string;
+  /**
+   * Channel type per Mattermost: 'O' = open/public, 'P' = private,
+   * 'D' = direct message, 'G' = group message.
+   */
+  type: 'O' | 'P' | 'D' | 'G';
+}
+
 interface MattermostApiUser {
   id: string;
   username: string;
@@ -140,6 +149,18 @@ async function getPostRaw(
   }
 }
 
+async function getChannelRaw(
+  config: MattermostApiConfig,
+  channelId: string,
+): Promise<MattermostApiChannel | null> {
+  try {
+    return await mattermostApi<MattermostApiChannel>(config, 'GET', `/channels/${channelId}`);
+  } catch (err) {
+    apiLog.debug(`Failed to get channel ${channelId}: ${err}`);
+    return null;
+  }
+}
+
 async function getThreadRaw(
   config: MattermostApiConfig,
   threadRootId: string,
@@ -205,6 +226,12 @@ class MattermostMcpPlatformApi implements McpPlatformApi {
   private readonly config: MattermostMcpApiConfig;
   private readonly formatter = new MattermostFormatter();
   private botUserIdCache: string | null = null;
+  // Channel-type lookups are cached for the lifetime of the MCP child:
+  // visibility flips are rare and a stale "public" decision only widens
+  // the read_post guard for a public→private transition (operationally
+  // safe because the bot still needs token-side access to fetch the post
+  // contents in the first place).
+  private channelTypeCache = new Map<string, 'public' | 'private'>();
 
   constructor(config: MattermostMcpApiConfig) {
     this.config = config;
@@ -393,7 +420,18 @@ class MattermostMcpPlatformApi implements McpPlatformApi {
     const post = await getPostRaw(this.apiConfig, postId);
     if (!post) return null;
     const username = post.user_id ? await this.getUsername(post.user_id) : null;
-    return toMcpPost(post, username);
+    const channelType = await this.getChannelType(post.channel_id);
+    return toMcpPost(post, username, channelType);
+  }
+
+  private async getChannelType(channelId: string): Promise<'public' | 'private' | undefined> {
+    const cached = this.channelTypeCache.get(channelId);
+    if (cached) return cached;
+    const channel = await getChannelRaw(this.apiConfig, channelId);
+    if (!channel) return undefined;
+    const visibility: 'public' | 'private' = channel.type === 'O' ? 'public' : 'private';
+    this.channelTypeCache.set(channelId, visibility);
+    return visibility;
   }
 
   async readThread(
@@ -421,13 +459,26 @@ class MattermostMcpPlatformApi implements McpPlatformApi {
       }
     }
 
+    // All replies share the thread root's channel; one lookup is enough.
+    const channelType = limited[0]
+      ? await this.getChannelType(limited[0].channel_id)
+      : undefined;
+
     return limited.map(p =>
-      toMcpPost(p, p.user_id ? usernameByUserId.get(p.user_id) ?? null : null),
+      toMcpPost(
+        p,
+        p.user_id ? usernameByUserId.get(p.user_id) ?? null : null,
+        channelType,
+      ),
     );
   }
 }
 
-function toMcpPost(post: MattermostApiPost, username: string | null): McpPost {
+function toMcpPost(
+  post: MattermostApiPost,
+  username: string | null,
+  channelType?: 'public' | 'private',
+): McpPost {
   return {
     id: post.id,
     channelId: post.channel_id,
@@ -436,6 +487,7 @@ function toMcpPost(post: MattermostApiPost, username: string | null): McpPost {
     message: post.message,
     createAt: post.create_at ?? 0,
     threadRootId: post.root_id || undefined,
+    channelType,
   };
 }
 

--- a/src/platform/mattermost/permalink.test.ts
+++ b/src/platform/mattermost/permalink.test.ts
@@ -289,6 +289,37 @@ describe('resolvePermalink', () => {
     expect(result).toEqual({ ok: false, error: { kind: 'wrong-channel' } });
   });
 
+  it('allows cross-channel reads when the target channel is public', async () => {
+    // Public channels on the same instance are readable by anyone in the
+    // thread already, so the guard adds no privacy value. The resolver
+    // must let these through.
+    const api = makeFakeApi({
+      posts: { [ID_A]: makePost({ channelId: 'c-other', channelType: 'public' }) },
+    });
+    const result = await resolvePermalink(api, ID_A, BOT_CHANNEL);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.resolved.post.channelId).toBe('c-other');
+  });
+
+  it('still rejects cross-channel reads when the channel is private', async () => {
+    const api = makeFakeApi({
+      posts: { [ID_A]: makePost({ channelId: 'c-other', channelType: 'private' }) },
+    });
+    const result = await resolvePermalink(api, ID_A, BOT_CHANNEL);
+    expect(result).toEqual({ ok: false, error: { kind: 'wrong-channel' } });
+  });
+
+  it('treats missing channelType as private (fail-safe)', async () => {
+    // Older platform implementations or persisted state may not set
+    // channelType. The resolver must not silently widen the guard.
+    const api = makeFakeApi({
+      posts: { [ID_A]: makePost({ channelId: 'c-other', channelType: undefined }) },
+    });
+    const result = await resolvePermalink(api, ID_A, BOT_CHANNEL);
+    expect(result).toEqual({ ok: false, error: { kind: 'wrong-channel' } });
+  });
+
   it('does not check channel scope when botChannelId is undefined', async () => {
     const api = makeFakeApi({
       posts: { [ID_A]: makePost({ channelId: 'c-other' }) },

--- a/src/platform/mattermost/permalink.ts
+++ b/src/platform/mattermost/permalink.ts
@@ -163,7 +163,16 @@ export async function resolvePermalink(
     return { ok: false, error: { kind: 'not-found' } };
   }
 
-  if (botChannelId !== undefined && post.channelId !== botChannelId) {
+  // Public channels on the same instance are readable by anyone with
+  // an account, so the channel-scope guard adds no privacy value when
+  // the target is public — anyone in the bot's thread could already
+  // navigate to the post themselves. Skip the check in that case.
+  // Missing channelType is treated as private (fail-safe).
+  if (
+    botChannelId !== undefined &&
+    post.channelId !== botChannelId &&
+    post.channelType !== 'public'
+  ) {
     return { ok: false, error: { kind: 'wrong-channel' } };
   }
 

--- a/src/platform/mcp-platform-api.ts
+++ b/src/platform/mcp-platform-api.ts
@@ -60,6 +60,21 @@ export interface McpPost {
   createAt: number;
   /** Empty / undefined for top-level posts. */
   threadRootId?: string;
+  /**
+   * Visibility of the channel the post lives in. The Mattermost resolver
+   * uses this to allow cross-channel reads when the target channel is a
+   * public channel on the same instance — anyone in the thread could
+   * already navigate there themselves, so the channel-scope guard adds no
+   * privacy value. Slack does not currently set this field: its
+   * MCP-side `readPost` is hard-scoped to the bot's configured channel
+   * via `conversations.history`, so cross-channel reads aren't possible
+   * on Slack regardless of channel visibility.
+   *
+   * Optional: implementations that don't classify channels (or older
+   * sessions persisted before this field existed) leave it undefined,
+   * which the resolver treats as "private" — fail-safe.
+   */
+  channelType?: 'public' | 'private';
 }
 
 /**


### PR DESCRIPTION
## Summary

The cross-channel guard rejects any permalink that points outside the bot's session channel. That's the right default for private / DM / group channels, where the resolver leaking content to thread participants who don't have access to the source channel is a real concern. Public channels are different: anyone with an account can already navigate there, so the guard adds no privacy value and just blocks legitimate "read this post in #general" requests.

`McpPost` gains a `channelType?: 'public' | 'private'` field. The Mattermost impl populates it via `/channels/{id}` (Mattermost type `O` = public, anything else private) with a per-process cache so a chatty thread doesn't trigger N redundant lookups. The resolver skips the wrong-channel check when `channelType === 'public'`; missing `channelType` is treated as private (fail-safe).

Slack is unchanged: its MCP-side `readPost` is hard-scoped to the bot's configured channel via `conversations.history`, so cross-channel reads aren't possible there regardless of channel visibility. Documented on the `McpPost` field.

## Why this is safe

The threat model the original guard addressed: Alice shares a permalink to #management-only in a thread Bob is also reading, and Bob doesn't belong to #management-only. The bot resolves the post and dumps the content into the thread → Bob sees content he shouldn't.

For private channels (Mattermost type `P`), DMs (`D`), group DMs (`G`), and unknown types: guard remains. For public channels (`O`): Bob could navigate to that channel himself in any case, so the bot is not the leak vector.

The resolver still requires the bot's own token to be able to fetch the post — token-side ACLs remain the floor. We're only relaxing the additional channel-equality check, which was a defense-in-depth measure that was overzealous for public channels.

## Test plan

- [x] Resolver tests: public-channel cross-read passes; private-channel cross-read still rejected; missing `channelType` treated as private; same-channel read unaffected
- [x] Mattermost API tests: `readPost` sets `channelType: 'public'` for type `O`, `'private'` for `P`/`D`/`G`, leaves it undefined when `/channels/{id}` returns 4xx, and caches the lookup across calls
- [x] RED-verified: stashed the impl change and re-ran — 4 new readPost tests + 1 resolver test fail; all pass after restore
- [x] Full unit suite: 2479 pass / 0 fail. Lint clean. `tsc --noEmit` clean.
- [ ] Live test: share a permalink to a public channel from #annes-claude-code-sessies → expect content. Share one to a private channel → expect "different channel" error.