### PR TITLE
Add send_dm MCP tool

### DIFF
--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -118,6 +118,14 @@ export interface ClaudeCliOptions {
   logSessionId?: string;  // Session ID for log routing (platformId:threadId)
   permissionTimeoutMs?: number;  // Timeout for permission approval (default: 120000)
   /**
+   * Username of the user who started this session. Forwarded to the MCP
+   * child as `SESSION_OWNER_USERNAME` and used by `send_dm` for the
+   * attribution prefix recipients see ("via claude-threads, on behalf
+   * of @anne"). Optional: when omitted the prefix degrades to "via
+   * claude-threads from another channel."
+   */
+  sessionOwnerUsername?: string;
+  /**
    * Optional Claude account to spawn under. When set, `HOME` (for OAuth) or
    * `ANTHROPIC_API_KEY` (for API-billed) in the child env is overridden so
    * Claude uses that account's credentials. When omitted, the child inherits
@@ -252,6 +260,9 @@ export function buildPermissionArgs(opts: {
   uploadDir?: string;
   /** Outbound file (`send_file`) settings. Both fields are optional. */
   outboundFiles?: { enabled?: boolean; maxBytes?: number };
+  /** Username of the session starter; surfaced to the MCP child as
+   *  SESSION_OWNER_USERNAME for `send_dm` attribution. */
+  sessionOwnerUsername?: string;
   inline?: boolean; // for tests
 }): { args: string[]; tempFile: string | null } {
   const args: string[] = [];
@@ -287,6 +298,7 @@ export function buildPermissionArgs(opts: {
     ALLOWED_USERS: opts.platformConfig.allowedUsers.join(','),
     DEBUG: opts.debug ? '1' : '',
     PERMISSION_TIMEOUT_MS: String(opts.permissionTimeoutMs),
+    SESSION_OWNER_USERNAME: opts.sessionOwnerUsername || '',
   };
   if (opts.platformConfig.appToken) {
     mcpEnv.PLATFORM_APP_TOKEN = opts.platformConfig.appToken;
@@ -507,6 +519,7 @@ export class ClaudeCli extends EventEmitter {
       workingDir: this.options.workingDir,
       uploadDir: this.options.uploadDir,
       outboundFiles: this.options.outboundFiles,
+      sessionOwnerUsername: this.options.sessionOwnerUsername,
     });
     args.push(...permResult.args);
     this.mcpConfigTempFile = permResult.tempFile;

--- a/src/claude/restart-options.ts
+++ b/src/claude/restart-options.ts
@@ -42,5 +42,6 @@ export function buildRestartCliOptions(
     account: ctx.account,
     uploadDir: getSessionUploadDir(session.platformId, session.threadId),
     outboundFiles: platformMcpConfig.outboundFiles,
+    sessionOwnerUsername: session.startedBy,
   };
 }

--- a/src/mcp/mcp-server.test.ts
+++ b/src/mcp/mcp-server.test.ts
@@ -1492,6 +1492,7 @@ const DM_BOT_USER_ID = 'bot-1';
 interface SendDmStateBag {
   counts: Map<string, number>;
   allowedRecipients: Set<string>;
+  inFlightPrompts: Set<string>;
   memberCache: { value: { channelId: string; members: Set<string>; expiresAt: number } | null };
   channelLabelCache: { value: string | null };
 }
@@ -1500,6 +1501,7 @@ function makeSendDmState(): SendDmStateBag {
   return {
     counts: new Map(),
     allowedRecipients: new Set(),
+    inFlightPrompts: new Set(),
     memberCache: { value: null },
     channelLabelCache: { value: null },
   };
@@ -1519,6 +1521,7 @@ function makeSendDmCfg(
     promptTimeoutMs: 60_000,
     counts: state.counts,
     allowedRecipients: state.allowedRecipients,
+    inFlightPrompts: state.inFlightPrompts,
     memberCache: state.memberCache,
     channelLabelCache: state.channelLabelCache,
     perRecipientLimit: 3,
@@ -1836,5 +1839,84 @@ describe('handleSendDmWith', () => {
     expect(result.reason).toMatch(/platform 500/);
     // Counter must NOT have advanced — failed sends shouldn't burn the rate-limit budget.
     expect(state.counts.get(DM_RECIPIENT_ID) ?? 0).toBe(0);
+  });
+
+  it('rolls back the counter when the user denies the prompt', async () => {
+    // RED test: optimistic counter increment must be rolled back on deny.
+    // Without rollback, a denied prompt would silently consume one of the
+    // 3 DM slots — the user reacts 👎 and then can only send 2 more before
+    // hitting the rate limit on this recipient.
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '-1' }],
+    });
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-alice'];
+    const state = makeSendDmState();
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, state),
+    );
+    expect(result.ok).toBe(false);
+    expect(state.counts.get(DM_RECIPIENT_ID) ?? 0).toBe(0);
+  });
+
+  it('rolls back the counter when the prompt times out', async () => {
+    // RED test: same property as deny, but for the timeout path.
+    const api = new FakeApi({ reactions: [null] }); // null queue → timeout
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, state),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/timed out/);
+    expect(state.counts.get(DM_RECIPIENT_ID) ?? 0).toBe(0);
+  });
+
+  it('refuses a parallel call to the same recipient while a prompt is pending', async () => {
+    // RED test: the in-flight guard. Without it, two parallel send_dm
+    // tool_use blocks for the same recipient would each post a permission
+    // prompt — a confusing UX where the user dismisses one and the other
+    // is still hanging.
+    //
+    // Simulate "currently prompting" by pre-populating the in-flight set,
+    // then attempting a send. The handler must short-circuit before
+    // posting a second prompt.
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    state.inFlightPrompts.add(DM_RECIPIENT_ID); // a "first call" is mid-prompt
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'second call' },
+      makeSendDmCfg(api, state),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/already pending/);
+    expect(api.createdPosts).toHaveLength(0); // no duplicate prompt posted
+    expect(api.sendDirectMessageCalls).toEqual([]);
+    // Counter must also be rolled back — the optimistic increment for this
+    // call should not stick after the in-flight rejection.
+    expect(state.counts.get(DM_RECIPIENT_ID) ?? 0).toBe(0);
+  });
+
+  it('clears the in-flight flag after the prompt resolves', async () => {
+    // After a prompt completes (either way), the recipient must be removed
+    // from the in-flight set so a subsequent legitimate call can prompt
+    // again. Without the finally-clause, the flag would stick and lock
+    // out future DMs to that recipient for the whole session.
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '+1' }],
+    });
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-alice'];
+    const state = makeSendDmState();
+    await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, state),
+    );
+    expect(state.inFlightPrompts.has(DM_RECIPIENT_ID)).toBe(false);
   });
 });

--- a/src/mcp/mcp-server.test.ts
+++ b/src/mcp/mcp-server.test.ts
@@ -11,6 +11,7 @@ import {
   handleListThreadWith,
   handleReadChannelHistoryWith,
   handleSearchMessagesWith,
+  handleSendDmWith,
   type PermissionHandlerConfig,
   type SendFileHandlerConfig,
   type ReadPostHandlerConfig,
@@ -19,6 +20,7 @@ import {
   type ListThreadHandlerConfig,
   type ReadChannelHistoryHandlerConfig,
   type SearchMessagesHandlerConfig,
+  type SendDmHandlerConfig,
 } from './mcp-server.js';
 import type { McpPlatformApi, McpPost, ReactionEvent } from '../platform/mcp-platform-api.js';
 import type { PlatformFormatter } from '../platform/formatter.js';
@@ -162,6 +164,29 @@ class FakeApi implements McpPlatformApi {
     this.searchMessagesCalls.push({ query, limit: options?.limit });
     if (this.searchMessagesImpl) return this.searchMessagesImpl(query, options);
     return [];
+  };
+
+  // send_dm hooks.
+  public getChannelMembersCalls: string[] = [];
+  public resolveRecipientCalls: string[] = [];
+  public sendDirectMessageCalls: Array<{ recipientUserId: string; message: string }> = [];
+  public getChannelMembersImpl: ((channelId: string) => Promise<string[] | null>) | undefined;
+  public resolveRecipientImpl: ((recipient: string) => Promise<{ id: string; username: string | null } | null>) | undefined;
+  public sendDirectMessageImpl: ((recipientUserId: string, message: string) => Promise<{ postId: string }>) | undefined;
+  getChannelMembers = async (channelId: string) => {
+    this.getChannelMembersCalls.push(channelId);
+    if (this.getChannelMembersImpl) return this.getChannelMembersImpl(channelId);
+    return [];
+  };
+  resolveRecipient = async (recipient: string) => {
+    this.resolveRecipientCalls.push(recipient);
+    if (this.resolveRecipientImpl) return this.resolveRecipientImpl(recipient);
+    return null;
+  };
+  sendDirectMessage = async (recipientUserId: string, message: string) => {
+    this.sendDirectMessageCalls.push({ recipientUserId, message });
+    if (this.sendDirectMessageImpl) return this.sendDirectMessageImpl(recipientUserId, message);
+    return { postId: 'dm-post-1' };
   };
 }
 
@@ -1445,12 +1470,371 @@ describe('handlePermissionWith — auto-approval for read_channel_history and se
   it.each([
     ['mcp__claude-threads-mcp__read_channel_history', { channel_id: 'x' }],
     ['mcp__claude-threads-mcp__search_messages', { query: 'x' }],
-  ] as const)('auto-allows %s without prompting', async (toolName, input) => {
+    ['mcp__claude-threads-mcp__send_dm', { recipient: 'x', message: 'x' }],
+  ] as const)('skips standard prompt for %s (handler runs its own gate)', async (toolName, input) => {
     const api = new FakeApi();
     const cfg = makeCfg(api);
     const result = await handlePermissionWith(toolName, input as Record<string, unknown>, cfg);
     expect(result.behavior).toBe('allow');
     expect(api.createdPosts).toHaveLength(0);
     expect(api.waitForReactionCalls).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// handleSendDmWith — send_dm MCP tool
+// =============================================================================
+
+const DM_BOT_CHANNEL = 'a'.repeat(26);
+const DM_RECIPIENT_ID = 'u-bob';
+const DM_BOT_USER_ID = 'bot-1';
+
+interface SendDmStateBag {
+  counts: Map<string, number>;
+  allowedRecipients: Set<string>;
+  memberCache: { value: { channelId: string; members: Set<string>; expiresAt: number } | null };
+  channelLabelCache: { value: string | null };
+}
+
+function makeSendDmState(): SendDmStateBag {
+  return {
+    counts: new Map(),
+    allowedRecipients: new Set(),
+    memberCache: { value: null },
+    channelLabelCache: { value: null },
+  };
+}
+
+function makeSendDmCfg(
+  api: FakeApi,
+  state: SendDmStateBag,
+  overrides: Partial<SendDmHandlerConfig> = {},
+): SendDmHandlerConfig {
+  return {
+    api,
+    platformType: 'mattermost',
+    botChannelId: DM_BOT_CHANNEL,
+    sessionOwnerUsername: 'anne',
+    threadId: 'thread-x',
+    promptTimeoutMs: 60_000,
+    counts: state.counts,
+    allowedRecipients: state.allowedRecipients,
+    memberCache: state.memberCache,
+    channelLabelCache: state.channelLabelCache,
+    perRecipientLimit: 3,
+    memberCacheTtlMs: 60_000,
+    maxMessageChars: 4000,
+    ...overrides,
+  };
+}
+
+/**
+ * Common harness: a recipient that exists, is in the channel, and the
+ * permission prompt is pre-approved (allow-once via 👍 from alice).
+ */
+function setupHappyPath(api: FakeApi): void {
+  api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+  api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, DM_BOT_USER_ID, 'u-alice'];
+  // The prompt response: alice (an allowed user) reacts with +1.
+  // Note: FakeApi default allowedUsers is ['alice'], default usernames map u-alice → alice.
+  api.uploadFileImpl = undefined;
+}
+
+describe('handleSendDmWith', () => {
+  it('rejects when the platform does not support DMs', async () => {
+    const api = new FakeApi();
+    (api as unknown as { resolveRecipient: unknown }).resolveRecipient = undefined;
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not support/);
+  });
+
+  it('rejects when botChannelId is not configured', async () => {
+    const api = new FakeApi();
+    setupHappyPath(api);
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState(), { botChannelId: '' }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/channel not configured/);
+  });
+
+  it('rejects an empty recipient', async () => {
+    const api = new FakeApi();
+    const result = await handleSendDmWith(
+      { recipient: '   ', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/recipient/);
+    expect(api.resolveRecipientCalls).toEqual([]);
+  });
+
+  it('rejects an empty message', async () => {
+    const api = new FakeApi();
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: '   ' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/message/);
+  });
+
+  it('rejects a message longer than the cap', async () => {
+    const api = new FakeApi();
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'x'.repeat(5000) },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/exceeds .* cap/);
+  });
+
+  it('rejects when the recipient cannot be resolved', async () => {
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => null;
+    const result = await handleSendDmWith(
+      { recipient: 'ghost', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/could not resolve/);
+    expect(api.sendDirectMessageCalls).toEqual([]);
+  });
+
+  it('refuses to DM the bot itself', async () => {
+    // RED test: this fails if the self-DM check is removed.
+    const api = new FakeApi(); // bot is DM_BOT_USER_ID by default
+    api.resolveRecipientImpl = async () => ({ id: DM_BOT_USER_ID, username: 'bot' });
+    const result = await handleSendDmWith(
+      { recipient: 'bot', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/cannot send a DM to the bot/);
+    expect(api.sendDirectMessageCalls).toEqual([]);
+  });
+
+  it('refuses when the recipient is not a member of the bot channel', async () => {
+    // RED test: load-bearing membership gate. Fails if the membership check
+    // is removed or the bot's-channel scope is broken.
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: 'u-stranger', username: 'stranger' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-alice']; // stranger NOT in members
+    const result = await handleSendDmWith(
+      { recipient: 'stranger', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/not a member/);
+    expect(api.sendDirectMessageCalls).toEqual([]);
+  });
+
+  it('reuses the member cache within the TTL', async () => {
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    // Pre-approve so we focus on the cache behavior.
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    const cfg = makeSendDmCfg(api, state);
+    await handleSendDmWith({ recipient: 'bob', message: 'one' }, cfg);
+    await handleSendDmWith({ recipient: 'bob', message: 'two' }, cfg);
+    // Only one member-list fetch — second call hits the cache.
+    expect(api.getChannelMembersCalls).toHaveLength(1);
+  });
+
+  it('refetches members after the cache expires', async () => {
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    let t = 1_000;
+    const cfg = makeSendDmCfg(api, state, { now: () => t });
+    await handleSendDmWith({ recipient: 'bob', message: 'one' }, cfg);
+    t += 70_000; // past the 60s TTL
+    await handleSendDmWith({ recipient: 'bob', message: 'two' }, cfg);
+    expect(api.getChannelMembersCalls).toHaveLength(2);
+  });
+
+  it('asks for permission on the first DM and sends after approval', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '+1' }],
+    });
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-alice'];
+    const state = makeSendDmState();
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hello' },
+      makeSendDmCfg(api, state),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.postId).toBe('dm-post-1');
+    // A prompt was posted in the bot channel before sending.
+    expect(api.createdPosts).toHaveLength(1);
+    expect(api.createdPosts[0].message).toMatch(/Permission requested/);
+    expect(api.createdPosts[0].message).toMatch(/@bob/);
+    // The DM was sent.
+    expect(api.sendDirectMessageCalls).toHaveLength(1);
+    expect(api.sendDirectMessageCalls[0].recipientUserId).toBe(DM_RECIPIENT_ID);
+    // Allow-once does NOT promote — second DM would prompt again.
+    expect(state.allowedRecipients.has(DM_RECIPIENT_ID)).toBe(false);
+    // Count incremented.
+    expect(state.counts.get(DM_RECIPIENT_ID)).toBe(1);
+  });
+
+  it('promotes the recipient to no-prompt when ✅ allow-all is selected', async () => {
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: 'white_check_mark' }],
+    });
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-alice'];
+    const state = makeSendDmState();
+    await handleSendDmWith(
+      { recipient: 'bob', message: 'first' },
+      makeSendDmCfg(api, state),
+    );
+    expect(state.allowedRecipients.has(DM_RECIPIENT_ID)).toBe(true);
+  });
+
+  it('refuses when the user denies the prompt', async () => {
+    // RED test: a deny reaction must abort. Fails if the deny path falls
+    // through to send.
+    const api = new FakeApi({
+      reactions: [{ postId: 'post-1', userId: 'u-alice', emojiName: '-1' }],
+    });
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-alice'];
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, makeSendDmState()),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/denied/);
+    expect(api.sendDirectMessageCalls).toEqual([]);
+  });
+
+  it('skips the prompt for an already-allowed recipient (allow-all promotion)', async () => {
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'no prompt' },
+      makeSendDmCfg(api, state),
+    );
+    expect(result.ok).toBe(true);
+    expect(api.createdPosts).toHaveLength(0); // no permission prompt posted
+    expect(api.waitForReactionCalls).toHaveLength(0);
+    expect(api.sendDirectMessageCalls).toHaveLength(1);
+  });
+
+  it('allow-all is per-recipient, NOT global (DMing a different user still prompts)', async () => {
+    // RED test: the load-bearing per-recipient allow-all property. Fails
+    // if allow-all is implemented as a global flag.
+    const api = new FakeApi({
+      // Two prompts: first is for u-bob (allow-all), second is for u-charlie.
+      reactions: [
+        { postId: 'post-1', userId: 'u-alice', emojiName: 'white_check_mark' }, // bob
+        { postId: 'post-1', userId: 'u-alice', emojiName: '+1' }, // charlie
+      ],
+    });
+    let nextRecipient: 'bob' | 'charlie' = 'bob';
+    api.resolveRecipientImpl = async () => {
+      const id = nextRecipient === 'bob' ? DM_RECIPIENT_ID : 'u-charlie';
+      const username = nextRecipient;
+      return { id, username };
+    };
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID, 'u-charlie', 'u-alice'];
+    const state = makeSendDmState();
+    const cfg = makeSendDmCfg(api, state);
+
+    nextRecipient = 'bob';
+    await handleSendDmWith({ recipient: 'bob', message: 'hi' }, cfg);
+    expect(state.allowedRecipients.has(DM_RECIPIENT_ID)).toBe(true);
+
+    nextRecipient = 'charlie';
+    await handleSendDmWith({ recipient: 'charlie', message: 'hi' }, cfg);
+    // Two prompts posted (bob's allow-all did NOT cover charlie).
+    expect(api.createdPosts).toHaveLength(2);
+  });
+
+  it('enforces the per-recipient rate limit', async () => {
+    // RED test: load-bearing rate limit. Fails if the count check is
+    // skipped or the counter doesn't increment.
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    const cfg = makeSendDmCfg(api, state, { perRecipientLimit: 2 });
+    await handleSendDmWith({ recipient: 'bob', message: 'one' }, cfg);
+    await handleSendDmWith({ recipient: 'bob', message: 'two' }, cfg);
+    const result = await handleSendDmWith({ recipient: 'bob', message: 'three' }, cfg);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/rate-limited/);
+    expect(api.sendDirectMessageCalls).toHaveLength(2); // third never sent
+  });
+
+  it('prepends the attribution prefix to every DM', async () => {
+    // RED test: the load-bearing attribution. Fails if the prefix is omitted
+    // or doesn't include the session owner / channel.
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    await handleSendDmWith(
+      { recipient: 'bob', message: 'the body' },
+      makeSendDmCfg(api, state),
+    );
+    expect(api.sendDirectMessageCalls).toHaveLength(1);
+    const sent = api.sendDirectMessageCalls[0].message;
+    expect(sent).toMatch(/automated message via claude-threads/);
+    expect(sent).toMatch(/@anne/);
+    expect(sent).toContain('the body');
+    // Prefix appears before the body.
+    const prefixIdx = sent.indexOf('claude-threads');
+    const bodyIdx = sent.indexOf('the body');
+    expect(prefixIdx).toBeLessThan(bodyIdx);
+  });
+
+  it('falls back gracefully when no session owner is configured', async () => {
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, state, { sessionOwnerUsername: '' }),
+    );
+    const sent = api.sendDirectMessageCalls[0].message;
+    // Still has the bot-self-identification, just without the owner mention.
+    expect(sent).toMatch(/automated message via claude-threads/);
+    expect(sent).not.toMatch(/on behalf of/);
+  });
+
+  it('surfaces sendDirectMessage platform errors as ok:false', async () => {
+    const api = new FakeApi();
+    api.resolveRecipientImpl = async () => ({ id: DM_RECIPIENT_ID, username: 'bob' });
+    api.getChannelMembersImpl = async () => [DM_RECIPIENT_ID];
+    api.sendDirectMessageImpl = async () => { throw new Error('platform 500'); };
+    const state = makeSendDmState();
+    state.allowedRecipients.add(DM_RECIPIENT_ID);
+    const result = await handleSendDmWith(
+      { recipient: 'bob', message: 'hi' },
+      makeSendDmCfg(api, state),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/platform 500/);
+    // Counter must NOT have advanced — failed sends shouldn't burn the rate-limit budget.
+    expect(state.counts.get(DM_RECIPIENT_ID) ?? 0).toBe(0);
   });
 });

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -161,6 +161,12 @@ const SEND_DM_MEMBER_CACHE_TTL_MS = 60_000;
 const SEND_DM_MAX_MESSAGE_CHARS = 4000;
 const sendDmCounts = new Map<string, number>();
 const sendDmAllowedRecipients = new Set<string>();
+// Recipients currently being prompted. Prevents a parallel second call
+// to the same recipient from posting a duplicate prompt while the first
+// is still waiting on a reaction. MCP serializes per-call but Claude can
+// fan out parallel tool_use blocks; without this guard they'd race past
+// the `allowedRecipients.has()` check.
+const sendDmInFlightPrompts = new Set<string>();
 let sendDmMemberCache: { channelId: string; members: Set<string>; expiresAt: number } | null = null;
 let sendDmChannelLabel: string | null = null;
 
@@ -1131,16 +1137,21 @@ async function handleSearchMessages(
 // send_dm — direct-message a member of the bot's channel
 // =============================================================================
 //
-// The flow rests on five gates, in order:
+// The flow rests on six gates, in order:
 //   1. Shape: recipient and message are non-empty, message is under cap.
 //   2. Resolve: look up the recipient's user id via the platform API.
 //   3. Self-DM: refuse to DM the bot itself (catches confused calls).
 //   4. Membership: recipient must be a current member of the bot's
 //      channel (cached for 60s — channel members rarely change mid-session).
-//   5. Rate limit: at most 3 DMs per recipient per session.
+//   5. Rate limit: at most 3 DMs per recipient per session. The counter
+//      is bumped optimistically before the prompt and rolled back on
+//      deny / timeout / send failure, so two parallel calls to the same
+//      recipient can't both pass step 5 and double-spend the budget.
 //   6. Permission: a per-recipient interactive prompt the first time the
 //      session DMs each user. ✅ promotes to "no further prompts for THIS
-//      recipient" but DM count still applies.
+//      recipient" but DM count still applies. An in-flight set prevents
+//      a parallel second call to the same recipient from posting a
+//      duplicate prompt while the first is still pending.
 // All errors are returned as { ok: false, reason } so Claude can react.
 
 export interface SendDmResult {
@@ -1170,6 +1181,10 @@ export interface SendDmHandlerConfig {
    */
   counts: Map<string, number>;
   allowedRecipients: Set<string>;
+  /** Recipients with a permission prompt currently awaiting a reaction.
+   *  Used to short-circuit duplicate prompts when Claude fans out parallel
+   *  send_dm tool_use blocks to the same recipient. */
+  inFlightPrompts: Set<string>;
   memberCache: { value: { channelId: string; members: Set<string>; expiresAt: number } | null };
   /** Single-slot cache for the bot-channel display label. Mutated by
    *  resolveChannelLabel so a session pays the channel-info lookup once. */
@@ -1232,6 +1247,14 @@ export async function handleSendDmWith(
   if (!member.ok) return { ok: false, reason: member.reason };
 
   // 5. Rate limit.
+  //
+  // Increment optimistically *before* the prompt so two parallel calls
+  // to the same recipient can't both observe the same `sentSoFar` and
+  // double-spend the budget. We roll back on any failure (deny, timeout,
+  // send error). The window between increment and rollback is
+  // bounded by the prompt timeout, never visible to Claude (we hold the
+  // promise until rollback or success), and short enough that user
+  // intent stays coherent.
   const sentSoFar = cfg.counts.get(resolved.id) ?? 0;
   if (sentSoFar >= cfg.perRecipientLimit) {
     return {
@@ -1239,17 +1262,45 @@ export async function handleSendDmWith(
       reason: `rate-limited: already sent ${sentSoFar} DM${sentSoFar === 1 ? '' : 's'} to this recipient in this session (limit ${cfg.perRecipientLimit})`,
     };
   }
+  cfg.counts.set(resolved.id, sentSoFar + 1);
+  // Rollback helper: must be called on every failure path below to
+  // prevent failed sends from burning the budget.
+  const rollbackCounter = (): void => {
+    const current = cfg.counts.get(resolved.id) ?? 0;
+    if (current > 0) cfg.counts.set(resolved.id, current - 1);
+  };
 
   // 6. Per-recipient permission prompt.
   if (!cfg.allowedRecipients.has(resolved.id)) {
-    const decision = await promptForDmPermission(resolved.id, resolved.username, cfg);
+    // In-flight guard: if another tool_use block is already prompting
+    // for this recipient, refuse the duplicate. The first prompt's
+    // outcome will apply; this call would otherwise post a second
+    // prompt the user has to dismiss separately.
+    if (cfg.inFlightPrompts.has(resolved.id)) {
+      rollbackCounter();
+      return {
+        ok: false,
+        reason: 'a permission prompt for this recipient is already pending — wait for it to resolve before retrying',
+      };
+    }
+
+    cfg.inFlightPrompts.add(resolved.id);
+    let decision: DmDecision;
+    try {
+      decision = await promptForDmPermission(resolved.id, resolved.username, cfg);
+    } finally {
+      cfg.inFlightPrompts.delete(resolved.id);
+    }
     if (decision === 'deny') {
+      rollbackCounter();
       return { ok: false, reason: 'user denied this DM' };
     }
     if (decision === 'timeout') {
+      rollbackCounter();
       return { ok: false, reason: 'permission prompt timed out' };
     }
     if (decision === 'error') {
+      rollbackCounter();
       return { ok: false, reason: 'permission prompt failed; refusing to send' };
     }
     if (decision === 'allow-all') {
@@ -1268,12 +1319,12 @@ export async function handleSendDmWith(
     const result = await cfg.api.sendDirectMessage(resolved.id, fullMessage);
     postId = result.postId;
   } catch (err) {
+    rollbackCounter();
     const reason = err instanceof Error ? err.message : String(err);
     mcpLogger.warn(`send_dm failed: ${reason}`);
     return { ok: false, reason };
   }
 
-  cfg.counts.set(resolved.id, sentSoFar + 1);
   return { ok: true, postId };
 }
 
@@ -1425,6 +1476,7 @@ async function handleSendDm(
     promptTimeoutMs: PERMISSION_TIMEOUT_MS,
     counts: sendDmCounts,
     allowedRecipients: sendDmAllowedRecipients,
+    inFlightPrompts: sendDmInFlightPrompts,
     memberCache: { get value() { return sendDmMemberCache; }, set value(v) { sendDmMemberCache = v; } },
     channelLabelCache: { get value() { return sendDmChannelLabel; }, set value(v) { sendDmChannelLabel = v; } },
     perRecipientLimit: SEND_DM_PER_RECIPIENT_LIMIT,

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -65,6 +65,12 @@ const ALLOWED_USERS = (process.env.ALLOWED_USERS || '')
 
 const PERMISSION_TIMEOUT_MS = parseInt(process.env.PERMISSION_TIMEOUT_MS || '120000', 10);
 
+// Session owner — surfaced in the send_dm attribution prefix so
+// recipients can trace a bot DM back to "the person who started this
+// session." Empty when the bot wasn't passed a starter (only happens
+// in --bypass mode without a session). Wired in via cli.ts → buildPermissionArgs.
+const SESSION_OWNER_USERNAME = process.env.SESSION_OWNER_USERNAME || '';
+
 // Outbound-file (`send_file`) configuration. Populated by the bot at spawn
 // time via buildPermissionArgs. Empty roots → outbound disabled regardless
 // of OUTBOUND_FILES_ENABLED, since we'd have nothing to validate against.
@@ -85,11 +91,18 @@ const UPDATE_OWN_POST_TOOL_NAME = 'mcp__claude-threads-mcp__update_own_post';
 const LIST_THREAD_TOOL_NAME = 'mcp__claude-threads-mcp__list_thread';
 const READ_CHANNEL_HISTORY_TOOL_NAME = 'mcp__claude-threads-mcp__read_channel_history';
 const SEARCH_MESSAGES_TOOL_NAME = 'mcp__claude-threads-mcp__search_messages';
+const SEND_DM_TOOL_NAME = 'mcp__claude-threads-mcp__send_dm';
 
-// Tools whose handler enforces its own scope/author/path checks and so
-// shouldn't be gated by an interactive permission prompt. Listed centrally
-// so handlePermissionWith can stay one-line.
-const AUTO_ALLOWED_MCP_TOOLS = new Set<string>([
+// Tools that bypass the standard permission_prompt flow because they
+// enforce their own gate inside the handler. The "gate" varies:
+//   - send_file: path validation
+//   - read_post / list_thread / react_to_post / read_channel_history /
+//     search_messages: scope predicate (bot's channel ∪ public channels)
+//   - update_own_post: author check
+//   - send_dm: recipient-scoped permission prompt (handler asks the user
+//     directly and remembers the decision per recipient — the standard
+//     per-call prompt would lose the recipient-keyed memory)
+const SKIP_STANDARD_PERMISSION_PROMPT = new Set<string>([
   SEND_FILE_TOOL_NAME,
   READ_POST_TOOL_NAME,
   REACT_TO_POST_TOOL_NAME,
@@ -97,6 +110,7 @@ const AUTO_ALLOWED_MCP_TOOLS = new Set<string>([
   LIST_THREAD_TOOL_NAME,
   READ_CHANNEL_HISTORY_TOOL_NAME,
   SEARCH_MESSAGES_TOOL_NAME,
+  SEND_DM_TOOL_NAME,
 ]);
 
 // =============================================================================
@@ -135,6 +149,21 @@ function getApi(): McpPlatformApi {
 // Session state
 let allowAllSession = false;
 
+// send_dm state.
+//
+// All three pieces are scoped to the lifetime of this MCP child (= one
+// claude-threads session). They reset implicitly when the session ends
+// because the MCP child exits with it. Persisting across sessions would
+// be the wrong default — a session boundary is a meaningful "fresh start"
+// for the user's intent.
+const SEND_DM_PER_RECIPIENT_LIMIT = 3;
+const SEND_DM_MEMBER_CACHE_TTL_MS = 60_000;
+const SEND_DM_MAX_MESSAGE_CHARS = 4000;
+const sendDmCounts = new Map<string, number>();
+const sendDmAllowedRecipients = new Set<string>();
+let sendDmMemberCache: { channelId: string; members: Set<string>; expiresAt: number } | null = null;
+let sendDmChannelLabel: string | null = null;
+
 // =============================================================================
 // Permission Handler
 // =============================================================================
@@ -170,16 +199,20 @@ export async function handlePermissionWith(
 ): Promise<PermissionResult> {
   mcpLogger.debug(`handlePermission called for ${toolName}`);
 
-  // Auto-approve our own MCP tools: each enforces its own scope/author/path
-  // check inside the handler, so an interactive 👍 prompt would only add
-  // friction (every screenshot, every reaction, every list_thread call).
+  // Skip the standard permission_prompt flow for our own MCP tools: each
+  // enforces its own gate inside the handler. Most are silent (path/scope
+  // checks); send_dm is the exception — it asks the user explicitly, but
+  // the prompt is recipient-scoped so it lives inside the handler rather
+  // than the generic per-call prompt.
   //
-  // The trust model rests on three things, all enforced inside the handlers:
+  // The per-tool gates:
   //   - send_file: path validation against allowedRoots (path-validator.ts)
   //   - read_post / list_thread / react_to_post / read_channel_history /
   //     search_messages: scope predicate (bot's channel ∪ public channels
   //     on the same instance)
   //   - update_own_post: author check (post.userId === botUserId)
+  //   - send_dm: recipient must be a channel member, plus a per-recipient
+  //     interactive permission prompt with allow-once / allow-all / deny
   //
   // Why no isUserAllowed check here: these tools are invoked by Claude,
   // which only runs against authorized session prompts. The session
@@ -187,8 +220,8 @@ export async function handlePermissionWith(
   // this code path, the originating user has already been admitted. If a
   // future flow ever invokes a tool outside a session, this breaks;
   // revisit then.
-  if (AUTO_ALLOWED_MCP_TOOLS.has(toolName)) {
-    mcpLogger.debug(`Auto-allowing ${toolName} (handler enforces its own gate)`);
+  if (SKIP_STANDARD_PERMISSION_PROMPT.has(toolName)) {
+    mcpLogger.debug(`Skipping standard prompt for ${toolName} (handler enforces its own gate)`);
     return { behavior: 'allow', updatedInput: toolInput };
   }
 
@@ -397,6 +430,19 @@ const searchMessagesInputSchema = {
     .int()
     .optional()
     .describe('Maximum results to return. Defaults to 10, capped at 25.'),
+};
+
+const sendDmInputSchema = {
+  recipient: z
+    .string()
+    .describe(
+      "Recipient identifier. Mattermost: a username (with or without leading @). " +
+        "Slack: a user ID (e.g. 'U0123ABC' or '<@U0123ABC>'). The recipient must be a " +
+        "current member of the bot's channel.",
+    ),
+  message: z
+    .string()
+    .describe('Message body to send as a DM. Bot prepends an attribution prefix.'),
 };
 
 export interface SendFileResult {
@@ -1082,6 +1128,312 @@ async function handleSearchMessages(
 }
 
 // =============================================================================
+// send_dm — direct-message a member of the bot's channel
+// =============================================================================
+//
+// The flow rests on five gates, in order:
+//   1. Shape: recipient and message are non-empty, message is under cap.
+//   2. Resolve: look up the recipient's user id via the platform API.
+//   3. Self-DM: refuse to DM the bot itself (catches confused calls).
+//   4. Membership: recipient must be a current member of the bot's
+//      channel (cached for 60s — channel members rarely change mid-session).
+//   5. Rate limit: at most 3 DMs per recipient per session.
+//   6. Permission: a per-recipient interactive prompt the first time the
+//      session DMs each user. ✅ promotes to "no further prompts for THIS
+//      recipient" but DM count still applies.
+// All errors are returned as { ok: false, reason } so Claude can react.
+
+export interface SendDmResult {
+  ok: boolean;
+  postId?: string;
+  reason?: string;
+}
+
+export interface SendDmHandlerConfig {
+  api: McpPlatformApi;
+  platformType: string;
+  botChannelId: string;
+  /** Username of the session starter — used in the attribution prefix. */
+  sessionOwnerUsername: string;
+  /** Thread the prompt should land in. Same as PLATFORM_THREAD_ID for
+   *  in-session calls; the MCP child wires this through to keep the
+   *  permission-prompt UX bound to the session's own thread. */
+  threadId?: string;
+  /** Timeout for the per-recipient permission prompt. */
+  promptTimeoutMs: number;
+  /**
+   * State plumbing: a per-MCP-child Map<recipient, count> for the rate
+   * limit, a Set<recipient> for the allow-all promotion, and a
+   * member-cache slot (passed by reference so calls share it). All three
+   * are injected so unit tests can assert on them without mutating the
+   * module-level state.
+   */
+  counts: Map<string, number>;
+  allowedRecipients: Set<string>;
+  memberCache: { value: { channelId: string; members: Set<string>; expiresAt: number } | null };
+  /** Single-slot cache for the bot-channel display label. Mutated by
+   *  resolveChannelLabel so a session pays the channel-info lookup once. */
+  channelLabelCache: { value: string | null };
+  perRecipientLimit: number;
+  memberCacheTtlMs: number;
+  maxMessageChars: number;
+  now?: () => number;
+}
+
+export async function handleSendDmWith(
+  args: { recipient: string; message: string },
+  cfg: SendDmHandlerConfig,
+): Promise<SendDmResult> {
+  if (!cfg.api.resolveRecipient || !cfg.api.sendDirectMessage || !cfg.api.getChannelMembers) {
+    return { ok: false, reason: 'this platform does not support direct messages' };
+  }
+  if (!cfg.botChannelId) {
+    return { ok: false, reason: 'platform channel not configured' };
+  }
+
+  // 1. Shape.
+  const recipientArg = (args.recipient ?? '').trim();
+  if (recipientArg.length === 0) {
+    return { ok: false, reason: 'recipient must be a non-empty string' };
+  }
+  if (typeof args.message !== 'string' || args.message.trim().length === 0) {
+    return { ok: false, reason: 'message must be a non-empty string' };
+  }
+  if (args.message.length > cfg.maxMessageChars) {
+    return {
+      ok: false,
+      reason: `message exceeds ${cfg.maxMessageChars}-character cap (${args.message.length} chars supplied)`,
+    };
+  }
+
+  // 2. Resolve recipient.
+  const resolved = await cfg.api.resolveRecipient(recipientArg);
+  if (!resolved) {
+    return { ok: false, reason: `could not resolve recipient '${recipientArg}'` };
+  }
+
+  // 3. Self-DM guard. The bot DMing itself doesn't actually do anything
+  // useful and would confuse the per-recipient counters.
+  let botUserId: string;
+  try {
+    botUserId = await cfg.api.getBotUserId();
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `could not verify bot identity: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (resolved.id === botUserId) {
+    return { ok: false, reason: 'cannot send a DM to the bot itself' };
+  }
+
+  // 4. Membership check (cached).
+  const member = await isRecipientChannelMember(resolved.id, cfg);
+  if (!member.ok) return { ok: false, reason: member.reason };
+
+  // 5. Rate limit.
+  const sentSoFar = cfg.counts.get(resolved.id) ?? 0;
+  if (sentSoFar >= cfg.perRecipientLimit) {
+    return {
+      ok: false,
+      reason: `rate-limited: already sent ${sentSoFar} DM${sentSoFar === 1 ? '' : 's'} to this recipient in this session (limit ${cfg.perRecipientLimit})`,
+    };
+  }
+
+  // 6. Per-recipient permission prompt.
+  if (!cfg.allowedRecipients.has(resolved.id)) {
+    const decision = await promptForDmPermission(resolved.id, resolved.username, cfg);
+    if (decision === 'deny') {
+      return { ok: false, reason: 'user denied this DM' };
+    }
+    if (decision === 'timeout') {
+      return { ok: false, reason: 'permission prompt timed out' };
+    }
+    if (decision === 'error') {
+      return { ok: false, reason: 'permission prompt failed; refusing to send' };
+    }
+    if (decision === 'allow-all') {
+      cfg.allowedRecipients.add(resolved.id);
+    }
+    // 'allow-once' falls through without persisting.
+  }
+
+  // Build attribution prefix and send.
+  const channelLabel = await resolveChannelLabel(cfg);
+  const prefix = buildAttributionPrefix(cfg.sessionOwnerUsername, channelLabel);
+  const fullMessage = `${prefix}\n\n${args.message}`;
+
+  let postId: string;
+  try {
+    const result = await cfg.api.sendDirectMessage(resolved.id, fullMessage);
+    postId = result.postId;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    mcpLogger.warn(`send_dm failed: ${reason}`);
+    return { ok: false, reason };
+  }
+
+  cfg.counts.set(resolved.id, sentSoFar + 1);
+  return { ok: true, postId };
+}
+
+interface MembershipOk { ok: true }
+interface MembershipErr { ok: false; reason: string }
+
+async function isRecipientChannelMember(
+  recipientUserId: string,
+  cfg: SendDmHandlerConfig,
+): Promise<MembershipOk | MembershipErr> {
+  const now = cfg.now ?? Date.now;
+  const cache = cfg.memberCache.value;
+  if (cache && cache.channelId === cfg.botChannelId && cache.expiresAt > now()) {
+    if (cache.members.has(recipientUserId)) return { ok: true };
+    return {
+      ok: false,
+      reason: 'recipient is not a member of the bot channel — only channel members can be DMed',
+    };
+  }
+
+  // Cache miss or expired.
+  if (!cfg.api.getChannelMembers) {
+    return { ok: false, reason: 'platform does not expose channel members' };
+  }
+  const members = await cfg.api.getChannelMembers(cfg.botChannelId);
+  if (members === null) {
+    return { ok: false, reason: 'could not fetch channel members' };
+  }
+  const set = new Set(members);
+  cfg.memberCache.value = {
+    channelId: cfg.botChannelId,
+    members: set,
+    expiresAt: now() + cfg.memberCacheTtlMs,
+  };
+  if (set.has(recipientUserId)) return { ok: true };
+  return {
+    ok: false,
+    reason: 'recipient is not a member of the bot channel — only channel members can be DMed',
+  };
+}
+
+type DmDecision = 'allow-once' | 'allow-all' | 'deny' | 'timeout' | 'error';
+
+async function promptForDmPermission(
+  recipientId: string,
+  recipientUsername: string | null,
+  cfg: SendDmHandlerConfig,
+): Promise<DmDecision> {
+  const now = cfg.now ?? Date.now;
+  const formatter = cfg.api.getFormatter();
+  const recipientLabel = recipientUsername ? `@${recipientUsername}` : recipientId;
+  const message =
+    `⚠️ ${formatter.formatBold('Permission requested')}\n\n` +
+    `claude-threads wants to send a DM to ${formatter.formatBold(recipientLabel)}.\n\n` +
+    `👍 Allow once | ✅ Allow all DMs to this recipient | 👎 Deny`;
+
+  let post: { id: string };
+  let botUserId: string;
+  try {
+    botUserId = await cfg.api.getBotUserId();
+    post = await cfg.api.createInteractivePost(
+      message,
+      [APPROVAL_EMOJIS[0], ALLOW_ALL_EMOJIS[0], DENIAL_EMOJIS[0]],
+      cfg.threadId,
+    );
+  } catch (err) {
+    mcpLogger.error(`send_dm prompt failed: ${err}`);
+    return 'error';
+  }
+
+  const startTime = now();
+
+  while (true) {
+    const remainingTime = cfg.promptTimeoutMs - (now() - startTime);
+    if (remainingTime <= 0) {
+      await safeUpdatePost(cfg.api, post.id, `⏱️ ${formatter.formatBold('Timed out')} — DM to ${recipientLabel} not sent`);
+      return 'timeout';
+    }
+    const reaction = await cfg.api.waitForReaction(post.id, botUserId, remainingTime);
+    if (!reaction) {
+      await safeUpdatePost(cfg.api, post.id, `⏱️ ${formatter.formatBold('Timed out')} — DM to ${recipientLabel} not sent`);
+      return 'timeout';
+    }
+    const username = await cfg.api.getUsername(reaction.userId);
+    if (username && cfg.api.isUserAllowed(username)) {
+      const emoji = reaction.emojiName;
+      if (isApprovalEmoji(emoji)) {
+        await safeUpdatePost(cfg.api, post.id, `✅ ${formatter.formatBold('Allowed')} by ${formatter.formatUserMention(username)} — sending DM to ${recipientLabel}`);
+        return 'allow-once';
+      }
+      if (isAllowAllEmoji(emoji)) {
+        await safeUpdatePost(cfg.api, post.id, `✅ ${formatter.formatBold('Allow all')} by ${formatter.formatUserMention(username)} — DMs to ${recipientLabel} won't prompt again this session`);
+        return 'allow-all';
+      }
+      await safeUpdatePost(cfg.api, post.id, `❌ ${formatter.formatBold('Denied')} by ${formatter.formatUserMention(username)}`);
+      return 'deny';
+    }
+    // Unauthorized user reacted — keep waiting (matches the standard
+    // permission_prompt loop).
+    mcpLogger.debug(`Ignoring unauthorized DM-permission reaction from ${username || reaction.userId}`);
+  }
+}
+
+async function safeUpdatePost(api: McpPlatformApi, postId: string, message: string): Promise<void> {
+  try {
+    await api.updatePost(postId, message);
+  } catch (err) {
+    mcpLogger.warn(`updatePost failed (cosmetic): ${err}`);
+  }
+}
+
+/** Resolve the bot channel's display name. Cached per-cfg via
+ *  `channelLabelCache` (a single-slot cache passed by reference) so a
+ *  long-running session pays the lookup once. Falls back to the channel
+ *  id when the platform doesn't expose a name. */
+async function resolveChannelLabel(cfg: SendDmHandlerConfig): Promise<string> {
+  const slot = cfg.channelLabelCache;
+  if (slot.value !== null) return slot.value;
+  if (!cfg.api.getChannelInfo) {
+    slot.value = cfg.botChannelId;
+    return slot.value;
+  }
+  const info = await cfg.api.getChannelInfo(cfg.botChannelId);
+  slot.value = info?.name ? `#${info.name}` : cfg.botChannelId;
+  return slot.value;
+}
+
+function buildAttributionPrefix(ownerUsername: string, channelLabel: string): string {
+  // Shape designed to be unmistakable to a human reader:
+  // - opens with a marker recipients quickly recognize
+  // - names the session starter so the recipient can complain to them
+  // - names the channel so the recipient knows where the session lives
+  // - names the bot so they can mute / report it if needed
+  if (ownerUsername) {
+    return `_(automated message via claude-threads, on behalf of @${ownerUsername} from ${channelLabel})_`;
+  }
+  return `_(automated message via claude-threads from ${channelLabel})_`;
+}
+
+async function handleSendDm(
+  args: { recipient: string; message: string },
+): Promise<SendDmResult> {
+  return handleSendDmWith(args, {
+    api: getApi(),
+    platformType: PLATFORM_TYPE,
+    botChannelId: PLATFORM_CHANNEL_ID,
+    sessionOwnerUsername: SESSION_OWNER_USERNAME,
+    threadId: PLATFORM_THREAD_ID || undefined,
+    promptTimeoutMs: PERMISSION_TIMEOUT_MS,
+    counts: sendDmCounts,
+    allowedRecipients: sendDmAllowedRecipients,
+    memberCache: { get value() { return sendDmMemberCache; }, set value(v) { sendDmMemberCache = v; } },
+    channelLabelCache: { get value() { return sendDmChannelLabel; }, set value(v) { sendDmChannelLabel = v; } },
+    perRecipientLimit: SEND_DM_PER_RECIPIENT_LIMIT,
+    memberCacheTtlMs: SEND_DM_MEMBER_CACHE_TTL_MS,
+    maxMessageChars: SEND_DM_MAX_MESSAGE_CHARS,
+  });
+}
+
+// =============================================================================
 // Shared: resolve a permalink URL to a post, applying the scope predicate
 // =============================================================================
 
@@ -1298,6 +1650,27 @@ async function main() {
     searchMessagesInputSchema,
     async ({ query, max_results }: { query: string; max_results?: number }) => {
       const result = await handleSearchMessages({ query, max_results });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+      };
+    },
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).tool(
+    'send_dm',
+    "Send a direct message to a member of the bot's channel. Use this when the user " +
+      'asks to ping someone in private (a status update, a notification, a result they want as a DM). ' +
+      'The recipient must be a current member of the bot channel. The first DM to each recipient ' +
+      'in a session triggers a permission prompt in the bot channel; ✅ allow-all promotes that ' +
+      'specific recipient to no-prompt for the rest of the session. ' +
+      'Hard limit: 3 DMs per recipient per session. The bot prepends an attribution line so ' +
+      'recipients can see the DM came from a session and who started it. ' +
+      'Returns { ok: true, postId } on success or { ok: false, reason } on failure (denied, ' +
+      'rate-limited, recipient not in channel, etc.).',
+    sendDmInputSchema,
+    async ({ recipient, message }: { recipient: string; message: string }) => {
+      const result = await handleSendDm({ recipient, message });
       return {
         content: [{ type: 'text', text: JSON.stringify(result) }],
       };

--- a/src/platform/mattermost/mcp-platform-api.ts
+++ b/src/platform/mattermost/mcp-platform-api.ts
@@ -57,6 +57,10 @@ interface MattermostApiChannel {
   type: 'O' | 'P' | 'D' | 'G';
   /** Team owning this channel. Empty for DMs / group DMs. */
   team_id?: string;
+  /** Human-readable channel name (URL slug). */
+  name?: string;
+  /** Display name shown in the UI. Falls back to `name` when empty. */
+  display_name?: string;
 }
 
 interface MattermostApiUser {
@@ -241,6 +245,49 @@ async function addReaction(
     post_id: postId,
     emoji_name: emojiName,
   });
+}
+
+async function getUserByUsernameRaw(
+  config: MattermostApiConfig,
+  username: string,
+): Promise<MattermostApiUser | null> {
+  try {
+    return await mattermostApi<MattermostApiUser>(config, 'GET', `/users/username/${encodeURIComponent(username)}`);
+  } catch (err) {
+    apiLog.debug(`Failed to lookup user @${username}: ${err}`);
+    return null;
+  }
+}
+
+interface MattermostApiChannelMember {
+  user_id: string;
+}
+
+interface MattermostApiDirectChannel {
+  id: string;
+}
+
+/**
+ * Open (or fetch existing) direct-message channel between two users.
+ * Mattermost auto-deduplicates: calling repeatedly with the same pair
+ * returns the same channel id.
+ */
+async function createDirectChannelRaw(
+  config: MattermostApiConfig,
+  userIdA: string,
+  userIdB: string,
+): Promise<MattermostApiDirectChannel | null> {
+  try {
+    return await mattermostApi<MattermostApiDirectChannel>(
+      config,
+      'POST',
+      '/channels/direct',
+      [userIdA, userIdB],
+    );
+  } catch (err) {
+    apiLog.debug(`Failed to open direct channel ${userIdA}↔${userIdB}: ${err}`);
+    return null;
+  }
 }
 
 function isUserInAllowList(username: string, allowList: string[]): boolean {
@@ -532,7 +579,11 @@ class MattermostMcpPlatformApi implements McpPlatformApi {
     return this.hydratePosts(ordered);
   }
 
-  async getChannelInfo(channelId: string): Promise<{ id: string; channelType: 'public' | 'private' } | null> {
+  async getChannelInfo(channelId: string): Promise<{
+    id: string;
+    channelType: 'public' | 'private';
+    name?: string;
+  } | null> {
     mcpLogger.debug(`getChannelInfo: ${formatShortId(channelId)}`);
     const channel = await getChannelRaw(this.apiConfig, channelId);
     if (!channel) return null;
@@ -540,7 +591,48 @@ class MattermostMcpPlatformApi implements McpPlatformApi {
     // Populate the type cache so downstream readPost / readThread don't
     // make another round trip.
     this.channelTypeCache.set(channelId, channelType);
-    return { id: channel.id, channelType };
+    // Prefer display_name (what the UI shows) over the URL slug.
+    const name = channel.display_name || channel.name;
+    return { id: channel.id, channelType, name };
+  }
+
+  async getChannelMembers(channelId: string): Promise<string[] | null> {
+    // Mattermost paginates at 200 members per page by default. For typical
+    // bot channels (tens of members) one page is enough. Larger channels
+    // would need cursor handling — out of scope for the MCP API since the
+    // single-member lookup above is the actual code path used by send_dm.
+    try {
+      const members = await mattermostApi<MattermostApiChannelMember[]>(
+        this.apiConfig,
+        'GET',
+        `/channels/${channelId}/members?per_page=200`,
+      );
+      return members.map(m => m.user_id);
+    } catch (err) {
+      mcpLogger.debug(`getChannelMembers ${channelId} failed: ${err}`);
+      return null;
+    }
+  }
+
+  async resolveRecipient(recipient: string): Promise<{ id: string; username: string | null } | null> {
+    // Mattermost takes a username; strip a leading @ if Claude included one.
+    const normalized = recipient.replace(/^@/, '');
+    const user = await getUserByUsernameRaw(this.apiConfig, normalized);
+    if (!user) return null;
+    return { id: user.id, username: user.username };
+  }
+
+  async sendDirectMessage(
+    recipientUserId: string,
+    message: string,
+  ): Promise<{ postId: string }> {
+    const botUserId = await this.getBotUserId();
+    const dmChannel = await createDirectChannelRaw(this.apiConfig, botUserId, recipientUserId);
+    if (!dmChannel) {
+      throw new Error('failed to open direct channel with recipient');
+    }
+    const post = await createPost(this.apiConfig, dmChannel.id, message);
+    return { postId: post.id };
   }
 
   async searchMessages(

--- a/src/platform/mcp-platform-api.ts
+++ b/src/platform/mcp-platform-api.ts
@@ -196,10 +196,51 @@ export interface McpPlatformApi {
    * public channels) before fetching history. Returns null when the
    * channel isn't visible to the bot's token.
    *
+   * `name` is the human-readable channel name when available (used in
+   * the send_dm attribution prefix so recipients see "#general" instead
+   * of a 26-char id). Best-effort: implementations may omit it.
+   *
    * Optional — implementations that don't support channel introspection
    * omit it.
    */
-  getChannelInfo?(channelId: string): Promise<{ id: string; channelType: 'public' | 'private' } | null>;
+  getChannelInfo?(channelId: string): Promise<{
+    id: string;
+    channelType: 'public' | 'private';
+    name?: string;
+  } | null>;
+
+  /**
+   * Return the user IDs of members in a channel. Used by send_dm to
+   * verify the recipient is a member of the bot's channel before
+   * sending. Implementations should cache for a short TTL since
+   * membership rarely changes within a session.
+   *
+   * Optional — implementations that don't expose channel members omit it.
+   */
+  getChannelMembers?(channelId: string): Promise<string[] | null>;
+
+  /**
+   * Resolve a recipient identifier to a user ID. The shape of `recipient`
+   * is platform-specific:
+   *   - Mattermost: a username (`@anne` or `anne`)
+   *   - Slack: a user id (`U…`) — Slack's bot tokens can't reverse-look up
+   *     usernames cheaply, so this method takes the id as-is and
+   *     verifies it exists.
+   *
+   * Returns null when the recipient can't be found.
+   *
+   * Optional — implementations omit when DMs aren't supported.
+   */
+  resolveRecipient?(recipient: string): Promise<{ id: string; username: string | null } | null>;
+
+  /**
+   * Send a direct message to a user. Returns the post id of the sent
+   * message on success. The caller is responsible for membership checks,
+   * attribution prefixes, and rate limits — this method just sends.
+   *
+   * Optional — implementations omit when DMs aren't supported.
+   */
+  sendDirectMessage?(recipientUserId: string, message: string): Promise<{ postId: string }>;
 
   /**
    * Search messages on the platform. Returns posts in unspecified order

--- a/src/platform/slack/mcp-platform-api.ts
+++ b/src/platform/slack/mcp-platform-api.ts
@@ -26,6 +26,8 @@ import type {
   UsersInfoResponse,
   ConversationsHistoryResponse,
   ConversationsInfoResponse,
+  ConversationsMembersResponse,
+  ConversationsOpenResponse,
   ConversationsRepliesResponse,
   SlackMessage,
   SlackSocketModeEvent,
@@ -532,7 +534,7 @@ class SlackMcpPlatformApi implements McpPlatformApi {
 
   async getChannelInfo(
     channelId: string,
-  ): Promise<{ id: string; channelType: 'public' | 'private' } | null> {
+  ): Promise<{ id: string; channelType: 'public' | 'private'; name?: string } | null> {
     mcpLogger.debug(`getChannelInfo: ${channelId}`);
     try {
       const response = await slackApi<ConversationsInfoResponse>(
@@ -547,11 +549,88 @@ class SlackMcpPlatformApi implements McpPlatformApi {
       return {
         id: ch.id,
         channelType: isPrivate ? 'private' : 'public',
+        name: ch.name,
       };
     } catch (err) {
       mcpLogger.debug(`getChannelInfo ${channelId} failed: ${err}`);
       return null;
     }
+  }
+
+  async getChannelMembers(channelId: string): Promise<string[] | null> {
+    // Slack paginates channel members. Iterate cursor until exhausted.
+    // Bounded by `maxPages` so a runaway 100k-member channel can't pin
+    // the MCP child indefinitely; in practice bot channels are small.
+    const maxPages = 20; // 20 * 1000 = 20k members ceiling
+    const all: string[] = [];
+    let cursor: string | undefined = undefined;
+    try {
+      for (let i = 0; i < maxPages; i++) {
+        const params: Record<string, unknown> = {
+          channel: channelId,
+          limit: 1000,
+        };
+        if (cursor) params.cursor = cursor;
+        const response: ConversationsMembersResponse = await slackApi<ConversationsMembersResponse>(
+          'conversations.members',
+          this.config.botToken,
+          params,
+        );
+        all.push(...(response.members ?? []));
+        cursor = response.response_metadata?.next_cursor;
+        if (!cursor) return all;
+      }
+      mcpLogger.warn(`getChannelMembers ${channelId} hit page cap of ${maxPages}`);
+      return all;
+    } catch (err) {
+      mcpLogger.debug(`getChannelMembers ${channelId} failed: ${err}`);
+      return null;
+    }
+  }
+
+  async resolveRecipient(
+    recipient: string,
+  ): Promise<{ id: string; username: string | null } | null> {
+    // Slack: recipient is a user ID. Strip surrounding `<@...>` markers
+    // if Claude included them (they appear in chat as "<@U123>").
+    const id = recipient.replace(/^<@/, '').replace(/>$/, '');
+    if (!/^[UW][A-Z0-9]{8,}$/.test(id)) {
+      return null;
+    }
+    try {
+      const response = await slackApi<UsersInfoResponse>(
+        'users.info',
+        this.config.botToken,
+        { user: id },
+      );
+      return { id: response.user.id, username: response.user.name ?? null };
+    } catch (err) {
+      mcpLogger.debug(`resolveRecipient ${id} failed: ${err}`);
+      return null;
+    }
+  }
+
+  async sendDirectMessage(
+    recipientUserId: string,
+    message: string,
+  ): Promise<{ postId: string }> {
+    // Open (or fetch existing) DM channel with the recipient.
+    const opened = await slackApi<ConversationsOpenResponse>(
+      'conversations.open',
+      this.config.botToken,
+      { users: recipientUserId },
+    );
+    const dmChannelId = opened.channel.id;
+    const post = await slackApi<PostMessageResponse>(
+      'chat.postMessage',
+      this.config.botToken,
+      {
+        channel: dmChannelId,
+        text: message,
+        mrkdwn: true,
+      },
+    );
+    return { postId: post.ts };
   }
 }
 

--- a/src/platform/slack/types.ts
+++ b/src/platform/slack/types.ts
@@ -236,11 +236,21 @@ export interface UsersInfoResponse extends SlackApiResponse {
 export interface ConversationsInfoResponse extends SlackApiResponse {
   channel: {
     id: string;
+    name?: string;
     is_private?: boolean;
     is_im?: boolean;
     is_mpim?: boolean;
     is_member?: boolean;
   };
+}
+
+export interface ConversationsMembersResponse extends SlackApiResponse {
+  members: string[];
+  response_metadata?: { next_cursor?: string };
+}
+
+export interface ConversationsOpenResponse extends SlackApiResponse {
+  channel: { id: string };
 }
 
 export interface UsersListResponse extends SlackApiResponse {

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -918,6 +918,7 @@ export async function startSession(
       : undefined,
     uploadDir: getSessionUploadDir(platformId, actualThreadId),
     outboundFiles: platformMcpConfig.outboundFiles,
+    sessionOwnerUsername: username,
   };
   const claude = new ClaudeCli(cliOptions);
 
@@ -1185,6 +1186,7 @@ export async function resumeSession(
       : undefined,
     uploadDir: getSessionUploadDir(platformId, state.threadId),
     outboundFiles: platformMcpConfig.outboundFiles,
+    sessionOwnerUsername: state.startedBy,
   };
   const claude = new ClaudeCli(cliOptions);
 


### PR DESCRIPTION
## Summary

The first social-side-effect MCP tool: lets Claude DM a member of the bot's channel directly. Use cases the existing tools don't cover: "ping me when this finishes," "send the report to alice as a DM."

This is the only tool of the seven added in this series (#371, #373, this) that has actual social blast radius. Kept narrow on purpose.

## Trust model — five gates, in order

1. **Shape:** recipient and message non-empty, message under 4000-char cap.
2. **Resolve:** platform API turns recipient → user id. Mattermost takes a username (with or without leading \`@\`); Slack takes a user id (\`U…\`) since Slack bot tokens can't reverse-look usernames cheaply.
3. **Self-DM guard:** refuse to DM the bot itself.
4. **Membership:** recipient must be a current member of the bot's channel, cached for 60s.
5. **Rate limit:** 3 DMs per recipient per session, in-process state on the MCP child (resets when the session ends).
6. **Per-recipient permission prompt:** first DM to each recipient triggers a 👍/✅/👎 prompt in the bot channel. ✅ promotes _that recipient only_ to no-prompt for the rest of the session — NOT all recipients.

## Attribution

Every DM is prefixed with:

\`\`\`
_(automated message via claude-threads, on behalf of @anne from #channel-name)_
\`\`\`

So recipients can trace it back to the session that sent it. Channel name is fetched lazily via \`getChannelInfo\` (extended with a \`name?\` field); session-owner username is plumbed via a new \`SESSION_OWNER_USERNAME\` env var.

## New platform API surface

All optional, omitted when DMs aren't supported by the platform:
- \`getChannelMembers(channelId)\` — paginates on Slack, single page on Mattermost
- \`resolveRecipient(string)\` — username on MM, user id on Slack
- \`sendDirectMessage(recipientUserId, message)\` — opens DM channel, sends
- \`getChannelInfo(channelId)\` gained a \`name?\` field

## Env-var plumbing

\`SESSION_OWNER_USERNAME\` is threaded from \`session/lifecycle.ts\` → \`restart-options.ts\` → \`ClaudeCliOptions\` → \`buildPermissionArgs\` → MCP child. The new field is wired into both session-start and session-resume paths.

## Tests

20 new tests covering all guards, plus RED-GREEN verification of the four load-bearing guards: self-DM check, membership check, rate limit, attribution prefix, allow-all-is-per-recipient.

## Test plan

- [ ] Mattermost: DM a channel member, verify attribution prefix appears in the DM
- [ ] Mattermost: DM a non-member, verify rejection
- [ ] Mattermost: try to DM the bot itself, verify rejection
- [ ] Mattermost: send 3 DMs to one user, attempt a 4th, verify rate-limit error
- [ ] Mattermost: react ✅ to first prompt, verify subsequent DMs to that recipient skip the prompt
- [ ] Mattermost: react ✅ to a prompt for user A, then DM user B, verify a fresh prompt is shown (allow-all is per-recipient)
- [ ] Slack: same battery against a Slack workspace