### PR TITLE
Coerce string-numeric tool args on MCP numeric inputs

### DIFF
--- a/src/mcp/mcp-server.test.ts
+++ b/src/mcp/mcp-server.test.ts
@@ -12,6 +12,10 @@ import {
   handleReadChannelHistoryWith,
   handleSearchMessagesWith,
   handleSendDmWith,
+  readPostInputSchema,
+  listThreadInputSchema,
+  readChannelHistoryInputSchema,
+  searchMessagesInputSchema,
   type PermissionHandlerConfig,
   type SendFileHandlerConfig,
   type ReadPostHandlerConfig,
@@ -22,6 +26,7 @@ import {
   type SearchMessagesHandlerConfig,
   type SendDmHandlerConfig,
 } from './mcp-server.js';
+import { z } from 'zod';
 import type { McpPlatformApi, McpPost, ReactionEvent } from '../platform/mcp-platform-api.js';
 import type { PlatformFormatter } from '../platform/formatter.js';
 
@@ -1918,5 +1923,60 @@ describe('handleSendDmWith', () => {
       makeSendDmCfg(api, state),
     );
     expect(state.inFlightPrompts.has(DM_RECIPIENT_ID)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Numeric input coercion — schemas must accept string-numerics
+// =============================================================================
+//
+// Some MCP runtimes (observed with the Claude CLI itself) serialize numeric
+// tool arguments as strings before they reach the server. The original
+// `z.number()` schemas rejected those at the boundary, surfacing as an
+// "expected number, received string" error from the MCP framework. The
+// `z.coerce.number()` switch lets either form through; downstream
+// clamp helpers already defend against non-finite / non-positive values
+// so the contract isn't widened beyond the documented caps.
+
+describe('numeric input schemas accept both number and string', () => {
+  // Wrap the schema shape in a z.object so we can call .parse on it.
+  const readPost = z.object(readPostInputSchema);
+  const listThread = z.object(listThreadInputSchema);
+  const readChannelHistory = z.object(readChannelHistoryInputSchema);
+  const searchMessages = z.object(searchMessagesInputSchema);
+
+  it.each([
+    ['read_post.max_messages', () => readPost.parse({ url: 'x', max_messages: '5' as unknown as number }).max_messages],
+    ['list_thread.max_messages', () => listThread.parse({ max_messages: '5' as unknown as number }).max_messages],
+    ['read_channel_history.max_messages', () => readChannelHistory.parse({ channel_id: 'a', max_messages: '5' as unknown as number }).max_messages],
+    ['search_messages.max_results', () => searchMessages.parse({ query: 'q', max_results: '5' as unknown as number }).max_results],
+  ] as const)('coerces string-numeric for %s', (_name, parse) => {
+    // RED test: this fails with `z.number()` (no coerce) — the parse throws
+    // ZodError("Invalid input: expected number, received string"). With
+    // `z.coerce.number()` the string is converted to 5 before validation.
+    const result = parse();
+    expect(result).toBe(5);
+    expect(typeof result).toBe('number');
+  });
+
+  it.each([
+    ['read_post.max_messages', () => readPost.parse({ url: 'x', max_messages: 5 }).max_messages],
+    ['list_thread.max_messages', () => listThread.parse({ max_messages: 5 }).max_messages],
+    ['read_channel_history.max_messages', () => readChannelHistory.parse({ channel_id: 'a', max_messages: 5 }).max_messages],
+    ['search_messages.max_results', () => searchMessages.parse({ query: 'q', max_results: 5 }).max_results],
+  ] as const)('still accepts native numbers for %s', (_name, parse) => {
+    expect(parse()).toBe(5);
+  });
+
+  it.each([
+    ['read_post.max_messages', () => readPost.parse({ url: 'x', max_messages: '1.5' as unknown as number })],
+    ['list_thread.max_messages', () => listThread.parse({ max_messages: '1.5' as unknown as number })],
+    ['read_channel_history.max_messages', () => readChannelHistory.parse({ channel_id: 'a', max_messages: '1.5' as unknown as number })],
+    ['search_messages.max_results', () => searchMessages.parse({ query: 'q', max_results: '1.5' as unknown as number })],
+  ] as const)('still rejects non-integer string for %s', (_name, parse) => {
+    // .int() runs after coercion, so '1.5' coerces to 1.5 then fails
+    // the integer check. Belt-and-suspenders: catches a future regression
+    // where someone weakens the schema to plain coerce.number().
+    expect(() => parse()).toThrow();
   });
 });

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -350,7 +350,9 @@ const sendFileInputSchema = {
     .describe('Optional message body / initial comment shown alongside the file.'),
 };
 
-const readPostInputSchema = {
+// Exported so a contract test can verify the numeric coerce behavior
+// without spinning up the full MCP transport. See mcp-server.test.ts.
+export const readPostInputSchema = {
   url: z
     .string()
     .describe(
@@ -363,7 +365,12 @@ const readPostInputSchema = {
       'When true, also fetch surrounding messages in the same thread (oldest first). Defaults to false.',
     ),
   max_messages: z
-    .number()
+    // z.coerce.number() so a runtime that sends `"5"` (string) rather than
+    // `5` (number) — observed in production with the Claude MCP runtime —
+    // doesn't get rejected at the boundary. Downstream clamp helpers
+    // already defend against non-finite / non-positive values, so the
+    // coercion can't widen the contract beyond the documented caps.
+    .coerce.number()
     .int()
     .optional()
     .describe(
@@ -395,7 +402,7 @@ const updateOwnPostInputSchema = {
     .describe('New message body. Replaces the existing post text in full.'),
 };
 
-const listThreadInputSchema = {
+export const listThreadInputSchema = {
   url: z
     .string()
     .optional()
@@ -403,7 +410,7 @@ const listThreadInputSchema = {
       'Permalink to any post in the target thread. If omitted, the current session thread is read.',
     ),
   max_messages: z
-    .number()
+    .coerce.number() // see read_post schema above for why coerce
     .int()
     .optional()
     .describe(
@@ -411,7 +418,7 @@ const listThreadInputSchema = {
     ),
 };
 
-const readChannelHistoryInputSchema = {
+export const readChannelHistoryInputSchema = {
   channel_id: z
     .string()
     .describe(
@@ -419,7 +426,7 @@ const readChannelHistoryInputSchema = {
         "Must be the bot's own channel or a public channel on the same instance.",
     ),
   max_messages: z
-    .number()
+    .coerce.number() // see read_post schema above for why coerce
     .int()
     .optional()
     .describe(
@@ -427,12 +434,12 @@ const readChannelHistoryInputSchema = {
     ),
 };
 
-const searchMessagesInputSchema = {
+export const searchMessagesInputSchema = {
   query: z
     .string()
     .describe('Search query (platform-specific syntax). Mattermost supports phrase quoting and from:user filters.'),
   max_results: z
-    .number()
+    .coerce.number() // see read_post schema above for why coerce
     .int()
     .optional()
     .describe('Maximum results to return. Defaults to 10, capped at 25.'),


### PR DESCRIPTION
## Summary

Bug surfaced live in v1.15.0 dogfooding: \`search_messages\` with \`max_results=5\` fails the MCP boundary with

\`\`\`
Invalid input: expected number, received string
\`\`\`

The Claude MCP runtime sometimes serializes numeric tool arguments as strings before they reach the server. The \`z.number().int()\` schemas rejected those at parse time even though they're clearly valid intent.

## Fix

Switch four fields to \`z.coerce.number().int()\`:
- \`read_post.max_messages\`
- \`list_thread.max_messages\`
- \`read_channel_history.max_messages\`
- \`search_messages.max_results\`

Downstream \`clamp*\` helpers already guard against non-finite / non-positive values, so coercion can't widen the contract beyond the documented caps. Non-integer strings like \`"1.5"\` still fail because \`.int()\` runs after coercion.

## Tests

12 new contract tests (3 variants × 4 schemas):
- string-numeric coerces to a number
- native number still works
- non-integer string \`"1.5"\` still rejected

RED-verified: each test fails when the schema is reverted to plain \`z.number()\`, with the same error message observed in the live failure.

## Test plan

- [ ] Mattermost: \`search_messages\` with explicit \`max_results: 5\` (number) — works
- [ ] Mattermost: \`search_messages\` with the runtime quirk that previously failed — now works  
- [ ] Mattermost: \`list_thread\` / \`read_channel_history\` / \`read_post\` with numeric caps under the same condition