### PR TITLE
fix(uploads): dedupe identically-named attachments + remove inbound size cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Production deps** bumped: `@hono/node-server` 2.0.2 → 2.0.3 (preserves headers mutated after raw Response construction), `express-rate-limit` 8.5.1 → 8.5.2 (simplified IPv6 key generation). Lockfile-only. (#386)
 - **Dev deps** bumped: `@types/bun` 1.3.13 → 1.3.14, `@types/node` 25.7.0 → 25.9.1, `@types/react` 19.2.14 → 19.2.15, `eslint` 10.3.0 → 10.4.0 (adds `includeIgnoreFile()` and a `for-direction` sequence-expression check, both additive), `lint-staged` 17.0.4 → 17.0.5, `typescript-eslint` 8.59.3 → 8.59.4 (fixes a `no-floating-promises` stack overflow on recursive types). Lockfile-only. (#385)
 
+### Fixed
+- **Multiple pasted screenshots no longer silently vanish.** When you paste several clipboard images into one chat message, the platforms hand them all the same filename (`image.png`). The save path wrote each one with the `wx` (`O_EXCL`) flag, so the second and later files hit `EEXIST`, got caught, and were reported as a download failure, so they never reached Claude. Saves now dedupe filenames within a single message, inserting a numeric suffix before the extension (`image.png`, `image_1.png`, `image_2.png`); files without an extension get `report`, `report_1`, and so on. The unique name is resolved before the write, so the `wx` flag still does its job against symlink races. (#387)
+- **Inbound attachments are no longer capped at 100 MB.** A hard 100 MB ceiling on incoming files meant anything larger was skipped with a "too large" warning, which surprised people sharing big assets. The cap is gone; an attachment of any reported size is downloaded and written to disk. One tradeoff worth knowing: `downloadFile` still buffers the whole file in memory via `arrayBuffer()`, so a very large attachment is held in RAM while it's written. Streaming that download is a separate change. (#387)
+
 ## [1.16.0] - 2026-05-14
 
 ### Added

--- a/src/operations/streaming/handler.ts
+++ b/src/operations/streaming/handler.ts
@@ -14,20 +14,13 @@ import { join } from 'path';
 import type { PlatformClient, PlatformFile } from '../../platform/index.js';
 import type { Session } from '../../session/types.js';
 import { createLogger } from '../../utils/logger.js';
-import { sanitizeFilename, formatBytes } from '../../utils/safe-filename.js';
+import { sanitizeFilename, dedupeFilename, formatBytes } from '../../utils/safe-filename.js';
 
 const log = createLogger('streaming');
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-/**
- * Sanity ceiling on a single uploaded file. Files above this are skipped to
- * avoid pathological disk usage; everything below is written to disk and the
- * path is handed to Claude.
- */
-export const MAX_UPLOAD_SIZE = 100 * 1024 * 1024;
 
 const UPLOAD_ROOT_DIR = 'claude-threads-uploads';
 
@@ -109,6 +102,13 @@ function sanitizeForPrompt(value: string): string {
  * Download each file and write it to a fresh subdirectory under uploadDir.
  * Each call gets its own subdirectory so two messages uploading the same
  * filename don't collide.
+ *
+ * Inbound attachments are intentionally not size-capped (per issue #387):
+ * a user pasting a large screenshot or sharing a big asset should never have
+ * it silently dropped. Tradeoff: platform.downloadFile() buffers the whole
+ * file in memory via arrayBuffer(), so a very large attachment is held in RAM
+ * for the duration of the write. Left as-is here; streaming the download is a
+ * separate change.
  */
 export async function saveFilesToUploadDir(
   platform: PlatformClient,
@@ -145,19 +145,17 @@ export async function saveFilesToUploadDir(
   // collisions between concurrent messages are impossible.
   const messageDir = await mkdtemp(join(uploadDir, `${Date.now().toString(36)}-`));
 
-  for (const file of files) {
-    if (file.size > MAX_UPLOAD_SIZE) {
-      skipped.push({
-        name: file.name,
-        reason: `File too large (${formatBytes(file.size)} > ${formatBytes(MAX_UPLOAD_SIZE)} limit)`,
-        suggestion: 'Split the file or share it via an external link',
-      });
-      continue;
-    }
+  // Filenames used within this single call, so multiple identically-named
+  // attachments (e.g. several clipboard pastes that all arrive as `image.png`)
+  // get distinct on-disk names instead of colliding on the 'wx' write below.
+  const usedNames = new Set<string>();
 
+  for (const file of files) {
     try {
       const buffer = await platform.downloadFile(file.id);
-      const safeName = sanitizeFilename(file.name);
+      // Resolve a unique name BEFORE writing so the 'wx' flag stays meaningful
+      // for symlink-race protection rather than tripping on our own dupes.
+      const safeName = dedupeFilename(sanitizeFilename(file.name), usedNames);
       const absolutePath = join(messageDir, safeName);
       // 'wx' = O_CREAT | O_EXCL: fail rather than follow a pre-existing
       // symlink at the target. Together with the per-message mkdtemp this

--- a/src/utils/safe-filename.test.ts
+++ b/src/utils/safe-filename.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'bun:test';
+import { dedupeFilename, sanitizeFilename, formatBytes } from './safe-filename.js';
+
+describe('dedupeFilename', () => {
+  test('returns the name unchanged the first time it is seen', () => {
+    const used = new Set<string>();
+    expect(dedupeFilename('image.png', used)).toBe('image.png');
+    expect(used.has('image.png')).toBe(true);
+  });
+
+  test('appends a numeric suffix before the extension on collision', () => {
+    const used = new Set<string>();
+    expect(dedupeFilename('image.png', used)).toBe('image.png');
+    expect(dedupeFilename('image.png', used)).toBe('image_1.png');
+    expect(dedupeFilename('image.png', used)).toBe('image_2.png');
+  });
+
+  test('appends the suffix directly when there is no extension', () => {
+    const used = new Set<string>();
+    expect(dedupeFilename('report', used)).toBe('report');
+    expect(dedupeFilename('report', used)).toBe('report_1');
+    expect(dedupeFilename('report', used)).toBe('report_2');
+  });
+
+  test('treats a dotfile as having no extension', () => {
+    const used = new Set<string>();
+    expect(dedupeFilename('.env', used)).toBe('.env');
+    expect(dedupeFilename('.env', used)).toBe('.env_1');
+  });
+
+  test('handles multi-dot names by splitting on the last dot', () => {
+    const used = new Set<string>();
+    expect(dedupeFilename('archive.tar.gz', used)).toBe('archive.tar.gz');
+    expect(dedupeFilename('archive.tar.gz', used)).toBe('archive.tar_1.gz');
+  });
+
+  test('skips over a suffix that is already taken', () => {
+    const used = new Set<string>(['image.png', 'image_1.png']);
+    expect(dedupeFilename('image.png', used)).toBe('image_2.png');
+  });
+
+  test('keeps distinct names independent', () => {
+    const used = new Set<string>();
+    expect(dedupeFilename('a.png', used)).toBe('a.png');
+    expect(dedupeFilename('b.png', used)).toBe('b.png');
+    expect(dedupeFilename('a.png', used)).toBe('a_1.png');
+  });
+});
+
+describe('sanitizeFilename', () => {
+  test('strips path components', () => {
+    expect(sanitizeFilename('../../etc/passwd')).toBe('passwd');
+  });
+
+  test('falls back to attachment for empty names', () => {
+    expect(sanitizeFilename('')).toBe('attachment');
+  });
+});
+
+describe('formatBytes', () => {
+  test('formats across units', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(2048)).toBe('2.0 KB');
+  });
+});

--- a/src/utils/safe-filename.ts
+++ b/src/utils/safe-filename.ts
@@ -18,6 +18,42 @@ export function sanitizeFilename(name: string): string {
   return cleaned;
 }
 
+/**
+ * Resolve a filename that is unique within a single batch of writes.
+ *
+ * When `name` has already been used (tracked in `used`), append a numeric
+ * suffix before the extension until a free name is found: `image.png` becomes
+ * `image_1.png`, then `image_2.png`. Names without an extension get the suffix
+ * appended directly: `report` becomes `report_1`. A dotfile like `.env` is
+ * treated as having no extension, so it becomes `.env_1`.
+ *
+ * The returned name is added to `used` so the caller can keep calling this in a
+ * loop. Used to keep multiple identically-named clipboard pastes (which most
+ * platforms name `image.png`) from colliding on disk.
+ */
+export function dedupeFilename(name: string, used: Set<string>): string {
+  if (!used.has(name)) {
+    used.add(name);
+    return name;
+  }
+
+  // Split off the extension, but treat a leading dot as part of the stem so a
+  // dotfile (`.env`) keeps its leading dot rather than being read as ext-only.
+  const lastDot = name.lastIndexOf('.');
+  const hasExt = lastDot > 0;
+  const stem = hasExt ? name.slice(0, lastDot) : name;
+  const ext = hasExt ? name.slice(lastDot) : '';
+
+  let counter = 1;
+  let candidate = `${stem}_${counter}${ext}`;
+  while (used.has(candidate)) {
+    counter += 1;
+    candidate = `${stem}_${counter}${ext}`;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
 /** Format a byte count as a short human-readable string. */
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;

--- a/tests/unit/file-attachments.test.ts
+++ b/tests/unit/file-attachments.test.ts
@@ -14,7 +14,6 @@ import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import {
-  MAX_UPLOAD_SIZE,
   buildMessageContent,
   cleanupSessionUploads,
   formatSkippedFilesFeedback,
@@ -222,17 +221,51 @@ describe('saveFilesToUploadDir', () => {
     expect(saved[0].absolutePath.endsWith('attachment')).toBe(true);
   });
 
-  it('skips files that exceed MAX_UPLOAD_SIZE without downloading them', async () => {
-    const platform = createMockPlatform(Buffer.from('would never run'));
-    const huge = createMockFile({ name: 'huge.bin', size: MAX_UPLOAD_SIZE + 1 });
+  it('accepts inbound files of any size — no upload cap (issue #387)', async () => {
+    // Report a 200 MB file but hand the mock a tiny buffer so the test never
+    // allocates 200 MB. Before the fix this size tripped a 100 MB cap and the
+    // file was dropped; now it goes straight to disk.
+    const platform = createMockPlatform(Buffer.from('tiny payload'));
+    const huge = createMockFile({ name: 'huge.bin', size: 200 * 1024 * 1024 });
 
     const { saved, skipped } = await saveFilesToUploadDir(platform, uploadDir, [huge]);
 
-    expect(saved).toHaveLength(0);
-    expect(skipped).toHaveLength(1);
-    expect(skipped[0].name).toBe('huge.bin');
-    expect(skipped[0].reason).toContain('too large');
-    expect(platform.downloadFile).not.toHaveBeenCalled();
+    expect(skipped).toHaveLength(0);
+    expect(saved).toHaveLength(1);
+    expect(saved[0].originalName).toBe('huge.bin');
+    expect(platform.downloadFile).toHaveBeenCalled();
+  });
+
+  it('dedupes identically-named files within one call so none are dropped (issue #387)', async () => {
+    // Pasting several clipboard screenshots in one message names them all
+    // "image.png". Each must still land on disk under a distinct name rather
+    // than the second one tripping the 'wx' EEXIST guard and getting skipped.
+    let call = 0;
+    const platform = createMockPlatform();
+    (platform.downloadFile as ReturnType<typeof mock>).mockImplementation(() => {
+      call++;
+      return Promise.resolve(Buffer.from(`paste-${call}`));
+    });
+
+    const files = [
+      createMockFile({ id: '1', name: 'image.png' }),
+      createMockFile({ id: '2', name: 'image.png' }),
+    ];
+
+    const { saved, skipped } = await saveFilesToUploadDir(platform, uploadDir, files);
+
+    expect(skipped).toEqual([]);
+    expect(saved).toHaveLength(2);
+    // Both keep the user-facing original name in their metadata.
+    expect(saved.map(f => f.originalName)).toEqual(['image.png', 'image.png']);
+
+    // On disk they get distinct names: the second gets a numeric suffix.
+    const onDisk = saved.map(f => f.absolutePath.split('/').pop());
+    expect(onDisk).toEqual(['image.png', 'image_1.png']);
+
+    // And both files actually exist with their own bytes.
+    expect((await readFile(saved[0].absolutePath)).toString()).toBe('paste-1');
+    expect((await readFile(saved[1].absolutePath)).toString()).toBe('paste-2');
   });
 
   it('surfaces a download failure as a skipped file rather than crashing', async () => {


### PR DESCRIPTION
Fixes two inbound file-attachment bugs from #387.

## Bug 1 — duplicate filenames when several screenshots arrive in one message

Paste several clipboard screenshots into a single message and Slack and Mattermost name them all the same (`image.png`). `saveFilesToUploadDir` creates one directory per message and writes each file with the `wx` flag (`O_EXCL`). The second file with the same name hit `EEXIST`, got caught as "Download failed", and was silently dropped.

Now every collision within a single call gets a numeric suffix before the extension: `image.png` → `image_1.png` → `image_2.png`. The `wx` flag stays (it protects against the symlink race, see the comment in `handler.ts`); the unique name is resolved first, then written. The dedupe logic lives as a pure helper `dedupeFilename(name, used)` in `safe-filename.ts`, independently testable.

## Bug 2 — inbound file size cap removed

`MAX_UPLOAD_SIZE` (100 MB) was also applied to inbound attachments: anything larger was skipped. That gets in the way of data imports. The cap check on inbound attachments is gone; the constant itself was removed since nothing else imported it (outbound uploads have their own `maxBytes`). A comment records that inbound is intentionally uncapped, and that `downloadFile` buffers the whole file in memory via `arrayBuffer()` — a tradeoff that is noted, not solved.

## Tests (RED-GREEN verified)

- Two `image.png` files in one `saveFilesToUploadDir` call both land on disk (`image.png` + `image_1.png`), both in `saved`, none in `skipped`. RED confirmed: without dedupe the second file ends up in `skipped` with `EEXIST`.
- Pure unit tests for `dedupeFilename`: extension, no-extension, dotfile, multi-dot, already-taken suffix.
- A 200 MB file (mock returns a few bytes) is saved, not skipped. RED confirmed: with the cap restored the test fails.

Full suite, lint, and typecheck green.

Closes #387