### PR TITLE
Fix sticky status-indicator assertion (bypass-mode bot has no keep-alive)

### DIFF
--- a/tests/integration/suites/session-sticky.test.ts
+++ b/tests/integration/suites/session-sticky.test.ts
@@ -265,9 +265,16 @@ describe.skipIf(SKIP)('Sticky Channel Message', () => {
         const stickyPost = await waitForStickyWithTrigger(adminApi, ctx.channelId);
 
         expect(stickyPost).toBeDefined();
-        // Should contain status indicators (Auto/Interactive, Keep-alive, etc.)
+        // The status bar always carries a permission-mode chip (Default / Auto /
+        // Bypass) plus a session count and uptime. Keep-alive (💓) is only shown
+        // when enabled, so don't require it: this bot runs skipPermissions
+        // (Bypass mode) with no active session, so 💓 / Auto need not appear.
+        // (The previous assertion only passed by luck when keep-alive state
+        // leaked in from a prior suite — process isolation exposed that.)
         const hasStatusIndicators =
-          /Auto|Interactive|Keep-alive|💓|⚡/i.test(stickyPost!.message);
+          /Default|Auto|Bypass|Interactive|Keep-alive|💓|⚡|sessions|⏱️/i.test(
+            stickyPost!.message,
+          );
         expect(hasStatusIndicators).toBe(true);
       });
     });


### PR DESCRIPTION
Follow-up to #398. After per-suite process isolation landed, `Sticky Channel Message > should show status indicators` failed on `main` with `expect(hasStatusIndicators).toBe(true)` → received false.

## Cause

The assertion required `/Auto|Interactive|Keep-alive|💓|⚡/`, but:
- The test bot runs `skipPermissions: true` → **Bypass** permission mode (chip `⚠️ Bypass`), not Auto/Interactive.
- It has **no active session**, so keep-alive (`💓`) isn't enabled and doesn't appear.

So none of the required tokens are present. The test only ever passed because keep-alive state **leaked in from a prior suite** in the shared single process. Process isolation (#398) removed that leak and exposed the incorrect assertion.

## Fix

The status bar always carries a permission-mode chip (Default / Auto / Bypass), a session count, and an uptime. Assert on those always-present indicators instead of keep-alive-specific ones.

## Verification

- Sticky suite run in its own process (as CI does), 5/5 pass across 3 repeats.
- `tsc` clean.

Test-only change.