### PR TITLE
Fix: honor quiet mode when resuming a paused session (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Quiet mode (`!mentions on`) now survives an idle pause.** A session with "respond only when mentioned" enabled would still resume on the first non-mention reply once it had been paused for inactivity, defeating the whole point of quiet mode. The active-session path honored the gate but the paused-session resume path did not check the persisted `respondOnlyWhenMentioned` flag, so any plain message woke the session up. The resume path now applies the same gate: while quiet mode is on, a reply that doesn't @mention the bot no longer resumes a paused session. Commands (including `!stop`) still bypass the gate as before. (#410)
+
 ### Security
 - **`hono` 4.12.23 → 4.12.25** to resolve CVE-2026-54290 (HIGH): the CORS middleware reflected any `Origin` with credentials when `origin` defaulted to `*`.
 - **Pinned transitive `ws` ≥ 8.21.0 and `shell-quote` ≥ 1.8.4** (both pulled in via `ink`) to clear GHSA-96hv-2xvq-fx4p (HIGH, `ws` memory-exhaustion DoS) and GHSA-w7jw-789q-3m8p (CRITICAL, `shell-quote` newline escaping). Added to the existing `overrides`/`resolutions` blocks; runtime behavior is unchanged.

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -656,6 +656,75 @@ describe('handleMessage', () => {
 
       expect(session.resumePausedSession).not.toHaveBeenCalled();
     });
+
+    test('quiet mode on: a non-mention reply does not resume the paused session (#410)', async () => {
+      // Regression for #410: the persisted respondOnlyWhenMentioned flag must
+      // survive the idle pause. A plain reply (no @mention) should be ignored,
+      // not silently resume the session like it did before the fix.
+      (session.getPersistedSession as any).mockReturnValue({
+        sessionAllowedUsers: ['allowed-user'],
+        respondOnlyWhenMentioned: true,
+      });
+
+      const post: PlatformPost = {
+        id: 'post1',
+        platformId: 'test',
+        channelId: 'channel1',
+        userId: 'user1',
+        message: 'just chatting with a colleague here',
+        rootId: 'thread1',
+        createAt: Date.now(),
+      };
+      const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+
+      await handleMessage(client, session, post, user, options);
+
+      expect(session.resumePausedSession).not.toHaveBeenCalled();
+    });
+
+    test('quiet mode on: an @mention reply still resumes the paused session (#410)', async () => {
+      (session.getPersistedSession as any).mockReturnValue({
+        sessionAllowedUsers: ['allowed-user'],
+        respondOnlyWhenMentioned: true,
+      });
+
+      const post: PlatformPost = {
+        id: 'post1',
+        platformId: 'test',
+        channelId: 'channel1',
+        userId: 'user1',
+        message: '@claude-bot please continue',
+        rootId: 'thread1',
+        createAt: Date.now(),
+      };
+      const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+
+      await handleMessage(client, session, post, user, options);
+
+      expect(session.resumePausedSession).toHaveBeenCalledWith('thread1', 'please continue', undefined, 'allowed-user');
+    });
+
+    test('quiet mode off (default): a non-mention reply still resumes the paused session', async () => {
+      (session.getPersistedSession as any).mockReturnValue({
+        sessionAllowedUsers: ['allowed-user'],
+        respondOnlyWhenMentioned: false,
+      });
+
+      const post: PlatformPost = {
+        id: 'post1',
+        platformId: 'test',
+        channelId: 'channel1',
+        userId: 'user1',
+        message: 'continue please',
+        rootId: 'thread1',
+        createAt: Date.now(),
+      };
+      const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+
+      await handleMessage(client, session, post, user, options);
+
+      expect(session.resumePausedSession).toHaveBeenCalledWith('thread1', 'continue please', undefined, 'allowed-user');
+    });
   });
 
   describe('new session', () => {

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -255,6 +255,16 @@ export async function handleMessage(
         }
       }
 
+      // Quiet mode (#402, fix #410): a session that opted into "respond only
+      // when mentioned" keeps that setting while paused. A plain reply that
+      // doesn't @mention the bot must not silently resume the session — the
+      // persisted flag survives the idle pause, so honor it here just like the
+      // active-session gate above. Commands (incl. !stop) are handled earlier
+      // and so still bypass this gate.
+      if (persistedSession?.respondOnlyWhenMentioned && !client.isBotMentioned(message)) {
+        return;
+      }
+
       // Get any attached files (images)
       const files = post.metadata?.files;
 


### PR DESCRIPTION
## Problem

Fixes #410.

When a session has quiet mode on (`!mentions on` / `respondOnlyWhenMentioned: true`), the bot is supposed to stay silent on thread replies that don't `@mention` it. This worked for an active session, but **not after the session was paused for inactivity**: the first non-mention message would resume the session and make the bot respond anyway.

## Root cause

`src/message-handler.ts` has two paths:

- The **active-session** path gates non-mention replies behind `respondOnlyWhenMentioned` and returns early.
- The **paused-session resume** path had no such gate. The `respondOnlyWhenMentioned` flag is persisted on `PersistedSession` and survives the pause, but the resume path never read it, so any plain message woke the session.

## Fix

The resume path now applies the same gate, reading the persisted flag: while quiet mode is on, a reply that doesn't `@mention` the bot no longer resumes a paused session. Commands (including `!stop`) are parsed earlier in the path, so they still bypass the gate exactly as before.

## Tests

Three regression tests added under `paused session`:

- quiet mode on + non-mention reply → does **not** resume (RED-verified: fails without the fix)
- quiet mode on + `@mention` reply → still resumes
- quiet mode off (default) → non-mention reply still resumes (control)

Full suite passes (2658 tests).

## Incidental

The repo's pre-commit hook (`knip`) was already failing on `main` over four unlisted platform binaries (`gh`, `caffeinate`, `systemd-inhibit`, `powershell`) that are genuine conditional runtime dependencies. Added them to `knip.json`'s `ignoreBinaries` in a separate commit so the hook passes.