### PR TITLE
Resolve react_to_post target server-side instead of per-message permalink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`react_to_post` resolves the triggering message server-side instead of via a per-message permalink.** v1.18.0 fixed `react_to_post` always landing on the thread root by prepending a `[message permalink: ...]` line to every follow-up message's content — correct, but paid for on every single message in every thread even though reactions are occasional. `url` is now optional: when omitted, the MCP server resolves it to the most recent message in the session's own thread via the same `readThread` call `list_thread` already uses, so no per-message metadata needs to ride along in message content at all. (Mattermost and Slack `readThread` apply `limit` differently — Mattermost takes the newest N, Slack's `conversations.replies` paginates from the thread root forward — so the resolver fetches the default page and takes the last element on both platforms rather than relying on `limit: 1`.)
+
 ## [1.18.0] - 2026-07-17
 
 ### Added

--- a/src/mcp/mcp-server.test.ts
+++ b/src/mcp/mcp-server.test.ts
@@ -853,6 +853,7 @@ function makeReactCfg(api: FakeApi, overrides: Partial<ReactToPostHandlerConfig>
     platformUrl: PLATFORM_URL,
     platformType: 'mattermost',
     channelId: 'C-default',
+    sessionThreadId: 'session-thread-1',
     ...overrides,
   };
 }
@@ -946,6 +947,47 @@ describe('handleReactToPostWith', () => {
     expect(api.readPostCalls).toHaveLength(0);
     expect(api.addReactionCalls).toHaveLength(0);
   });
+
+  it('without a url, reacts to the most recent message in the session thread', async () => {
+    // RED test: fails if the no-url path reacts to thread.at(0) (the root)
+    // instead of thread.at(-1) (the latest reply) — exactly the bug #422 was
+    // about, just moved server-side instead of via a per-message permalink.
+    const api = new FakeApi();
+    const root = fakePost({ id: 'root-post' });
+    const latest = fakePost({ id: 'latest-post' });
+    api.readThreadImpl = async () => [root, latest];
+    const result = await handleReactToPostWith(
+      { emoji: 'eyes' },
+      makeReactCfg(api),
+    );
+    expect(result).toEqual({ ok: true });
+    expect(api.readThreadCalls).toEqual([{ rootId: 'session-thread-1', limit: undefined }]);
+    expect(api.addReactionCalls).toEqual([{ postId: 'latest-post', emojiName: 'eyes' }]);
+    expect(api.readPostCalls).toHaveLength(0); // no permalink to resolve
+  });
+
+  it('without a url, fails gracefully when there is no session thread', async () => {
+    const api = new FakeApi();
+    const result = await handleReactToPostWith(
+      { emoji: 'eyes' },
+      makeReactCfg(api, { sessionThreadId: '' }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/no session thread/);
+    expect(api.addReactionCalls).toHaveLength(0);
+  });
+
+  it('without a url, fails gracefully when the session thread is empty', async () => {
+    const api = new FakeApi();
+    api.readThreadImpl = async () => [];
+    const result = await handleReactToPostWith(
+      { emoji: 'eyes' },
+      makeReactCfg(api),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/empty/);
+    expect(api.addReactionCalls).toHaveLength(0);
+  });
 });
 
 describe('handleReactToPostWith — Slack', () => {
@@ -955,6 +997,7 @@ describe('handleReactToPostWith — Slack', () => {
       platformUrl: '',
       platformType: 'slack',
       channelId: SLACK_CHANNEL,
+      sessionThreadId: 'session-thread-1',
       ...overrides,
     };
   }

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -381,10 +381,11 @@ export const readPostInputSchema = {
 const reactToPostInputSchema = {
   url: z
     .string()
+    .optional()
     .describe(
       'Permalink URL to a post the bot can already see (its own channel, or a public channel on the same instance). '
-      + 'To react to a specific user message (e.g. to acknowledge the one that triggered the current task), use the '
-      + 'per-message permalink provided in that message\'s context — do NOT default to the thread-root permalink.',
+      + 'Omit to react to the most recent message in the current session thread (e.g. to acknowledge the message '
+      + 'that triggered the current task) — this is the common case and does NOT default to the thread root.',
     ),
   emoji: z
     .string()
@@ -701,10 +702,47 @@ export interface ReactToPostHandlerConfig {
   platformUrl: string;
   platformType: string;
   channelId: string;
+  /** The bot's current session thread id (Mattermost root_id / Slack thread_ts). */
+  sessionThreadId: string;
+}
+
+/**
+ * Resolve "the most recent message in the current session thread" — used when
+ * `react_to_post` is called without a url. Reuses the same `readThread` call
+ * `list_thread` makes (oldest-first; last element is the newest message), so
+ * no per-message permalink needs to be threaded through message content.
+ *
+ * Deliberately does NOT pass `limit: 1` through to `readThread`: Mattermost's
+ * `limit` takes the newest N (slice from the end), but Slack's
+ * `conversations.replies` applies `limit` from the thread root forward, so
+ * `limit: 1` there would return the ROOT post, not the latest reply — exactly
+ * the bug this whole feature exists to avoid. Fetching the default page and
+ * slicing client-side works correctly on both platforms.
+ */
+async function resolveLatestThreadPost(cfg: ReactToPostHandlerConfig): Promise<ResolvedPostResult> {
+  if (!cfg.api.readThread) {
+    return { ok: false, reason: 'this platform does not support reading threads' };
+  }
+  if (!cfg.sessionThreadId) {
+    return { ok: false, reason: 'no session thread to react in — pass a permalink URL instead' };
+  }
+  let thread: McpPost[];
+  try {
+    thread = await cfg.api.readThread(cfg.sessionThreadId);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    mcpLogger.warn(`react_to_post: failed to resolve latest thread message: ${reason}`);
+    return { ok: false, reason };
+  }
+  const latest = thread.at(-1);
+  if (!latest) {
+    return { ok: false, reason: 'session thread is empty — pass a permalink URL instead' };
+  }
+  return { ok: true, post: latest };
 }
 
 export async function handleReactToPostWith(
-  args: { url: string; emoji: string },
+  args: { url?: string; emoji: string },
   cfg: ReactToPostHandlerConfig,
 ): Promise<ReactToPostResult> {
   if (!cfg.api.addReaction) {
@@ -717,7 +755,7 @@ export async function handleReactToPostWith(
     };
   }
 
-  const resolved = await resolvePostFromUrl(args.url, cfg);
+  const resolved = args.url ? await resolvePostFromUrl(args.url, cfg) : await resolveLatestThreadPost(cfg);
   if (!resolved.ok) return { ok: false, reason: resolved.reason };
 
   try {
@@ -730,12 +768,13 @@ export async function handleReactToPostWith(
   }
 }
 
-async function handleReactToPost(args: { url: string; emoji: string }): Promise<ReactToPostResult> {
+async function handleReactToPost(args: { url?: string; emoji: string }): Promise<ReactToPostResult> {
   return handleReactToPostWith(args, {
     api: getApi(),
     platformUrl: PLATFORM_URL,
     platformType: PLATFORM_TYPE,
     channelId: PLATFORM_CHANNEL_ID,
+    sessionThreadId: PLATFORM_THREAD_ID,
   });
 }
 
@@ -1635,11 +1674,12 @@ async function main() {
   (server as any).tool(
     'react_to_post',
     'Add an emoji reaction to a post on the chat platform. Use this to acknowledge a request ' +
-      "(✅), flag something ambiguous (👀), mark a triggering message done, etc. The post must be in " +
-      "the bot's own channel or in a public channel on the same instance. Returns { ok: true } on " +
+      "(✅), flag something ambiguous (👀), mark a triggering message done, etc. Omit `url` to react " +
+      'to the most recent message in the current session thread — the common case. The post must be ' +
+      "in the bot's own channel or in a public channel on the same instance. Returns { ok: true } on " +
       'success or { ok: false, reason } on failure.',
     reactToPostInputSchema,
-    async ({ url, emoji }: { url: string; emoji: string }) => {
+    async ({ url, emoji }: { url?: string; emoji: string }) => {
       const result = await handleReactToPost({ url, emoji });
       return {
         content: [{ type: 'text', text: JSON.stringify(result) }],

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -374,16 +374,9 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      // Content now carries this message's own permalink (so a reaction targets
-      // THIS message, not the thread root), followed by the user's text.
       expect(session.sendFollowUp).toHaveBeenCalledWith(
-        'thread1',
-        expect.stringContaining('please help me with this code'),
-        undefined, 'allowed-user', 'User',
+        'thread1', 'please help me with this code', undefined, 'allowed-user', 'User',
       );
-      const sentContent = (session.sendFollowUp as any).mock.calls[0][1] as string;
-      expect(sentContent).toContain('message permalink');
-      expect(sentContent).toContain('https://mm.test/pl/post1'); // permalink to the follow-up post
     });
 
     test('requests approval for unauthorized user', async () => {
@@ -486,7 +479,7 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', expect.stringContaining('please continue'), undefined, 'allowed-user', 'User');
+      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'please continue', undefined, 'allowed-user', 'User');
     });
 
     test('when quiet mode off (default), responds to a non-mention reply', async () => {
@@ -508,7 +501,7 @@ describe('handleMessage', () => {
 
       await handleMessage(client, session, post, user, options);
 
-      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', expect.stringContaining('keep going please'), undefined, 'allowed-user', 'User');
+      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'keep going please', undefined, 'allowed-user', 'User');
     });
 
     test('when quiet mode on, a pending worktree-prompt reply is still handled (bypasses the gate)', async () => {
@@ -1907,7 +1900,7 @@ describe('handleMessage', () => {
 
       expect(session.handleWorktreeBranchResponse).toHaveBeenCalled();
       // Should fall through to sendFollowUp
-      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', expect.stringContaining('not a valid branch response'), undefined, 'allowed-user', 'User');
+      expect(session.sendFollowUp).toHaveBeenCalledWith('thread1', 'not a valid branch response', undefined, 'allowed-user', 'User');
     });
 
     test('does not handle branch response for unauthorized user', async () => {

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -20,17 +20,6 @@ import type { InitialSessionOptions } from './session/types.js';
 import { logSilentError } from './utils/error-handler/index.js';
 
 /**
- * Prefix a user message with a permalink to THAT specific message, so the model
- * has a handle on the exact message (rather than only the thread-root permalink
- * from the session context). Kept to a bare metadata line — WHAT to do with it
- * (e.g. react to the message) is taught once in the base/system prompt and the
- * tool descriptions, not repeated per message.
- */
-function withMessagePermalink(client: PlatformClient, post: PlatformPost, content: string): string {
-  return `[message permalink: ${client.getPostPermalink(post)}]\n${content}`;
-}
-
-/**
  * Logger interface for message handler
  */
 export interface MessageHandlerLogger {
@@ -213,15 +202,7 @@ export async function handleMessage(
       // Get any attached files (images)
       const files = post.metadata?.files;
 
-      if (content || files?.length) {
-        // Attach this message's own permalink when it differs from the thread
-        // root (the root's permalink is already in the session context). Only
-        // annotate when there's text.
-        const contentForAgent = content && post.id !== threadRoot
-          ? withMessagePermalink(client, post, content)
-          : content;
-        await session.sendFollowUp(threadRoot, contentForAgent, files, username, user?.displayName);
-      }
+      if (content || files?.length) await session.sendFollowUp(threadRoot, content, files, username, user?.displayName);
       return;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #429/#422. That fix worked but prepends a `[message permalink: ...]` line to every follow-up message's content, forever, in every thread — real per-message overhead for a feature (reacting to acknowledge a task) that's used occasionally, and inconsistent with the existing convention of injecting the thread-root permalink once into the system prompt.

- `react_to_post`'s `url` parameter is now optional. When omitted, the MCP server resolves the target to the most recent message in the session's own thread, reusing the same `readThread` call `list_thread` already makes — no new IPC, no permalink riding along in message content.
- The per-message permalink prefix added in #429 is reverted from `message-handler.ts`.

## Why this needed care

Mattermost's `readThread` `limit` option takes the newest N messages (`slice(-limit)`), but Slack's `conversations.replies` applies `limit` from the thread root forward. Naively calling `readThread(rootId, { limit: 1 })` would have returned the **thread root** on Slack — the exact bug this is meant to fix, just moved server-side. The resolver instead fetches the default page and takes the last element on both platforms.

## Testing

- New unit tests for `handleReactToPostWith` without a `url`: resolves to the latest thread message, fails gracefully with no session thread, fails gracefully on an empty thread.
- RED-verified the core test: forcing `thread.at(0)` instead of `thread.at(-1)` fails the "reacts to the most recent message" test.
- `bun test` (2681 tests), `bun run lint`, `bun run typecheck`, `bun run build` all pass.