### PR TITLE
1.18.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.18.3] - 2026-07-27
+## [1.18.4] - 2026-07-27
+
+> Version 1.18.3 was bumped but never tagged or published — releasing it needed a
+> local machine with the `gh` CLI, which is the very gap `release.yml` (below)
+> closes. Its contents ship here instead; no 1.18.3 artifact ever existed.
 
 ### Fixed
 - **CI is green again on `main`.** Two jobs had been failing on the daily scheduled run without any code change, both because an unpinned tool pulled a newer release. (#441)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.18.3",
+      "version": "1.18.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## What

Bumps the version to 1.18.4 and retitles the CHANGELOG section accordingly.

## Why not 1.18.3

1.18.3 was bumped on `main` (`85ad8ed`) but **never tagged and never published** — cutting a release required a local machine with the `gh` CLI, which is precisely the gap `release.yml` (#443) closes. No 1.18.3 artifact ever reached npm, so its section is retitled rather than left next to a release that does not exist. A note in the CHANGELOG records the skip so the gap in the version sequence isn't a mystery later.

## What this ships

Everything that was staged as 1.18.3:
- knip pinned + `knip.json` entry points + tooling ignores, and the `security` job's HIGH advisories cleared (#441)
- `hono` 4.12.31 / `@hono/node-server` 2.0.11 (#434), `body-parser` 2.3.0 (#436), dev tooling bumps (#442)
- `release.yml` itself (#443)

## How it gets released

Merging this touches `package.json` on `main`, which is `release.yml`'s push trigger. The workflow then re-runs typecheck/lint/knip/tests/build, creates the `v1.18.4` tag, creates the GitHub release, and publishes to npm — no local machine involved.

This is also the first real exercise of that workflow's push path end-to-end.

## Verification

Ran `release.yml`'s own gate locally on this commit: typecheck, lint, knip, build all clean; 2607 tests pass. `package.json` and `package-lock.json` versions are in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3XKJQj5RJwiBZvyLYfc7M

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3XKJQj5RJwiBZvyLYfc7M)_