### PR TITLE
1.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.1] - 2026-07-28
+
+### Changed
+- **Dependency updates.** Production: `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, `hono` 4.12.31 → 4.12.32, `@hono/node-server` 2.0.11 → 2.0.12, `express-rate-limit` 8.6.0 → 8.6.1. Dev: `@types/node` 26.1.1 → 26.1.2. Dependabot maintains `package-lock.json` only, so `bun.lock` was regenerated alongside it — CI installs with Bun, and without that sync the bumps would not actually reach CI. (#447, #448)
+
 ## [1.19.0] - 2026-07-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Patch release cutting the two Dependabot dependency updates that just merged (#447, #448) into an actual published version. Merging this to `main` triggers `release.yml`, which tags `v1.19.1`, creates the GitHub release, and publishes to npm.

### Changed
- Bumps `package.json` to **1.19.1** and promotes the CHANGELOG with a `## [1.19.1] - 2026-07-28` section.
- Dependencies shipped in this release:
  - Production: `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0, `hono` 4.12.31 → 4.12.32, `@hono/node-server` 2.0.11 → 2.0.12, `express-rate-limit` 8.6.0 → 8.6.1
  - Dev: `@types/node` 26.1.1 → 26.1.2

`bun.lock` needs no change (it does not record the root version, and the dependency bumps already landed via #447/#448). Typecheck and build pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112ELjv4eu4Q2oa7VMVzqq7

---
_Generated by [Claude Code](https://claude.ai/code/session_0112ELjv4eu4Q2oa7VMVzqq7)_