### PR TITLE
1.19.2: fix T stem height in logo, clear new high audit advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.19.2] - 2026-08-03
+
+### Fixed
+- **The T in the logo now reaches the baseline.** The C in the CT mark is drawn with its bottom stroke centered on the baseline, so its visible edge extends half a stroke-width below it — while the T's stem (butt cap) stopped exactly on the centerline, making the T look too short. The stem now extends to the C's outer bottom edge in both `logo.svg` and `favicon.svg`. (#452)
+
+### Security
+- **Cleared three new high advisories flagged by `bun audit`**, all in transitive dependencies, by raising version overrides: `fast-uri` to `>=4.1.2` (GHSA-7p8r-x3mc-p8w7, host confusion via backslash authority introducer), `brace-expansion` to `>=5.0.9` (GHSA-rgw5-rvv9-x895, DoS via unbounded intermediate arrays), and a new `ip-address` `>=10.3.1` override (GHSA-mwp4-54f8-5fhr, SSRF via leading-zero octet confusion). (#452)
+
 ## [1.19.1] - 2026-07-28
 
 ### Changed

--- a/bun.lock
+++ b/bun.lock
@@ -46,11 +46,12 @@
   },
   "overrides": {
     "@hono/node-server": "2.0.12",
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "express-rate-limit": "^8.3.0",
-    "fast-uri": ">=3.1.4",
+    "fast-uri": ">=4.1.2",
     "flatted": ">=3.4.0",
     "hono": "4.12.32",
+    "ip-address": ">=10.3.1",
     "path-to-regexp": ">=8.4.0",
     "picomatch": ">=2.3.2",
     "shell-quote": ">=1.10.0",
@@ -261,7 +262,7 @@
 
     "boxen": ["boxen@7.1.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^7.0.1", "chalk": "^5.2.0", "cli-boxes": "^3.0.0", "string-width": "^5.1.2", "type-fest": "^2.13.0", "widest-line": "^4.0.1", "wrap-ansi": "^8.1.0" } }, "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
@@ -379,7 +380,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@4.1.1", "", {}, "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ=="],
+    "fast-uri": ["fast-uri@4.1.2", "", {}, "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="],
 
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
@@ -447,7 +448,7 @@
 
     "ink-scroll-view": ["ink-scroll-view@0.3.5", "", { "peerDependencies": { "ink": ">=6", "react": ">=19" } }, "sha512-NDCKQz0DDvcLQEboXf25oGQ4g2VpoO3NojMC/eG+eaqEz9PDiGJyg7Y+HTa4QaCjogvME6A+IwGyV+yTLCGdaw=="],
 
-    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+    "ip-address": ["ip-address@10.4.0", "", {}, "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.19.1",
+      "version": "1.19.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.0.12",
@@ -35,7 +35,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/bun": "*",
+        "@types/bun": "latest",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^26.1.1",
         "@types/prompts": "^2.4.9",
@@ -1766,9 +1766,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2536,9 +2536,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -3137,9 +3137,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",
@@ -121,8 +121,9 @@
     "flatted": ">=3.4.0",
     "picomatch": ">=2.3.2",
     "path-to-regexp": ">=8.4.0",
-    "fast-uri": ">=3.1.4",
-    "brace-expansion": ">=5.0.7",
+    "fast-uri": ">=4.1.2",
+    "brace-expansion": ">=5.0.9",
+    "ip-address": ">=10.3.1",
     "ws": "$ws",
     "shell-quote": ">=1.10.0"
   },
@@ -133,8 +134,9 @@
     "flatted": ">=3.4.0",
     "picomatch": ">=2.3.2",
     "path-to-regexp": ">=8.4.0",
-    "fast-uri": ">=3.1.4",
-    "brace-expansion": ">=5.0.7",
+    "fast-uri": ">=4.1.2",
+    "brace-expansion": ">=5.0.9",
+    "ip-address": ">=10.3.1",
     "ws": "$ws",
     "shell-quote": ">=1.10.0"
   }

--- a/website/assets/favicon.svg
+++ b/website/assets/favicon.svg
@@ -10,5 +10,5 @@
   <!-- CT in heavy strokes (blue) -->
   <path d="M20.5 9.5 H14.5 V22.5 H20.5" stroke="#4a8fe7" stroke-width="3" stroke-linecap="butt" stroke-linejoin="miter"/>
   <path d="M23 9.5 H30.5" stroke="#4a8fe7" stroke-width="3" stroke-linecap="butt"/>
-  <path d="M26.75 9.5 V22.5" stroke="#4a8fe7" stroke-width="3" stroke-linecap="butt"/>
+  <path d="M26.75 9.5 V24" stroke="#4a8fe7" stroke-width="3" stroke-linecap="butt"/>
 </svg>

--- a/website/assets/logo.svg
+++ b/website/assets/logo.svg
@@ -16,5 +16,5 @@
 
   <!-- T in heavy strokes -->
   <path d="M112 21 H182" stroke="#4a8fe7" stroke-width="10" stroke-linecap="butt"/>
-  <path d="M147 21 V79" stroke="#4a8fe7" stroke-width="10" stroke-linecap="butt"/>
+  <path d="M147 21 V84" stroke="#4a8fe7" stroke-width="10" stroke-linecap="butt"/>
 </svg>


### PR DESCRIPTION
## Summary

Two things, shipped as patch release **1.19.2** (version bump included, so `release.yml` tags and publishes on merge):

1. **Logo fix.** The T in the CT mark looked too short: the C is drawn as a single path whose bottom stroke is centered on the baseline, so its visible edge extends half a stroke-width below it, while the T's stem (butt cap) ended exactly on the centerline. The stem now extends to the C's outer bottom edge so both letters share the same baseline.
2. **Security job unblocked.** `bun audit` started failing on three new high advisories in transitive dependencies (pre-existing on `main`, unrelated to this branch). Cleared by raising version overrides, following the same pattern as 1.18.4.

## Changes

- `website/assets/logo.svg`: extend the T stem from `V79` to `V84` (stroke width 10 → C's bottom edge is at y=84)
- `website/assets/favicon.svg`: same fix at favicon scale, `V22.5` to `V24` (stroke width 3 → C's bottom edge is at y=24)
- `package.json` overrides/resolutions: `fast-uri` `>=3.1.4` → `>=4.1.2` (GHSA-7p8r-x3mc-p8w7), `brace-expansion` `>=5.0.7` → `>=5.0.9` (GHSA-rgw5-rvv9-x895), new `ip-address` `>=10.3.1` (GHSA-mwp4-54f8-5fhr); both lockfiles regenerated
- Version bump 1.19.1 → 1.19.2 and CHANGELOG promoted to `[1.19.2] - 2026-08-03`

## Testing

- Rendered both SVGs with headless Chromium and visually verified the T now sits on the same baseline as the C
- Ran the security job's exact `bun audit` command locally: exit 0, no findings
- `bun test`: 2724 pass, 0 fail

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2WRQTQiBPcFLcAi7Bm3if