### PR TITLE
1.20.1: Add "How it compares" section to website and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's official Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about the official integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
+- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about Anthropic's integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
 
 ## [1.20.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's official Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about the official integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
+
 ## [1.20.0] - 2026-08-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about Anthropic's integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
+- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, Cognition's Devin, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about Anthropic's integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
 
 ## [1.20.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.20.1] - 2026-08-06
 
 ### Added
 - **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, Cognition's Devin, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about Anthropic's integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.20.1] - 2026-08-06
 
 ### Added
-- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, Cognition's Devin, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. The website's "Why I built this" note about Anthropic's integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
+- **"How it compares" section on the website and README** - A short, respectful comparison with the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, Cognition's Devin, and community Slack bots. The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads positioned as the local, self-hosted option that also speaks Mattermost. A closing note names the strongest differentiators beyond that: in-thread permission approvals, multiplayer sessions, the multi-account pool, and no GitHub assumption. The website's "Why I built this" note about Anthropic's integration was updated to match (it is no longer Enterprise-gated: Pro/Max plans have Claude Code in Slack, Team/Enterprise have Claude Tag).
 
 ## [1.20.0] - 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -172,21 +172,22 @@ Who may do what (start sessions, react to permission prompts, approve guest mess
 
 ## How it compares
 
-Driving a coding agent from chat is a busy space: Anthropic, OpenAI, and Cursor each ship their own integration, and other open-source projects exist too — several of them excellent. The main difference is where the session actually runs.
+Driving a coding agent from chat is a busy space: Anthropic, OpenAI, Cursor, and Cognition each ship their own integration, and other open-source projects exist too — several of them excellent. The main difference is where the session actually runs.
 
 | Product                                                                                                                              | Sessions run on                                             | Chat platforms                                  | Account                                       |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------- | :---------------------------------------------- | :-------------------------------------------- |
-| **claude-threads**                                                                                                                    | Your machine — local checkout, your MCP servers and plugins | Slack + Mattermost, multiple workspaces at once | Any Claude subscription or API key            |
+| **claude-threads** (open source, Apache-2.0)                                                                                          | Your machine — local checkout, your MCP servers and plugins | Slack + Mattermost, multiple workspaces at once | Any Claude subscription or API key            |
 | [Claude Code in Slack](https://code.claude.com/docs/en/slack) / [Claude Tag](https://claude.com/docs/claude-tag/overview) (Anthropic) | Anthropic's cloud, against GitHub repos                     | Slack                                           | Claude Pro/Max; Claude Tag on Team/Enterprise |
 | [Codex in Slack](https://slack.com/marketplace/A09F5C369E3-openai-codex) (OpenAI)                                                     | OpenAI's Codex cloud                                        | Slack                                           | ChatGPT plan                                  |
 | [Cursor in Slack](https://cursor.com/docs/integrations/slack)                                                                         | Cursor's cloud agents                                       | Slack                                           | Cursor plan                                   |
+| [Devin](https://devin.ai/) (Cognition)                                                                                                | Cognition's cloud                                           | Slack (also Linear and Jira tickets)            | Devin plan                                    |
 | Community bots such as [claude-code-slack-bot](https://github.com/mpociot/claude-code-slack-bot)                                      | Your machine                                                | Slack                                           | Claude subscription or API key                |
 
-The cloud products share a working style: you delegate a task from a thread, an agent works in a vendor-hosted sandbox, and progress updates and a pull request come back. If your repositories live on GitHub and you want nothing to host, they are a good choice — Anthropic's own integration in particular runs the same Claude Code this bot does.
+The cloud products share a working style: you delegate from a thread, the work runs in a vendor-hosted sandbox, and progress updates and a pull request come back — Claude Tag additionally stays in the conversation as a shared teammate the whole channel can talk to. If your repositories live on GitHub and you want nothing to host, they are a good choice; Anthropic's own integration in particular runs the same Claude Code this bot does.
 
 claude-threads makes the opposite choice: the whole session stays in the thread and on your hardware. Output streams live, permission prompts land as emoji reactions, invited teammates type into the same session, and Claude works against a local checkout with whatever MCP servers and plugins you already configured. That fit matters when chat is self-hosted Mattermost, when code cannot leave the building, or when you want a session in chat to behave exactly like the one at your desk. The trade-off: you run the bot yourself, on a machine that has the repository.
 
-All of these products move quickly — if this table has gone stale, [open an issue](https://github.com/anneschuth/claude-threads/issues).
+This table is current as of August 2026. All of these products move quickly — if it has gone stale, [open an issue](https://github.com/anneschuth/claude-threads/issues).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ The cloud products share a working style: you delegate from a thread, the work r
 
 claude-threads makes the opposite choice: the whole session stays in the thread and on your hardware. Output streams live, permission prompts land as emoji reactions, invited teammates type into the same session, and Claude works against a local checkout with whatever MCP servers and plugins you already configured. That fit matters when chat is self-hosted Mattermost, when code cannot leave the building, or when you want a session in chat to behave exactly like the one at your desk. The trade-off: you run the bot yourself, on a machine that has the repository.
 
+A few more things set it apart. The full Claude Code permission model lives in the thread: every tool use can prompt for 👍/✅/👎 approval, with three modes switchable mid-session. Sessions are multiplayer: `!invite` teammates while Claude works, messages from uninvited users are gated behind approval, and commits credit everyone involved as co-author. An optional [account pool](https://github.com/anneschuth/claude-threads/blob/main/docs/CONFIGURATION.md#claude-accounts-optional-multi-account-mode) routes each new session to the Claude subscription with the most headroom and cools down rate-limited ones. And nothing assumes GitHub — the session works against any local checkout, whatever its host.
+
 This table is current as of August 2026. All of these products move quickly — if it has gone stale, [open an issue](https://github.com/anneschuth/claude-threads/issues).
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ Restrict who can use the bot during setup, or reconfigure later with `claude-thr
 
 Who may do what (start sessions, react to permission prompts, approve guest messages) is written down in the [authorization model](https://github.com/anneschuth/claude-threads/blob/main/SECURITY.md).
 
+## How it compares
+
+Driving a coding agent from chat is a busy space, with official products from Anthropic, OpenAI, and Cursor alongside community projects — several of them excellent. The main difference is where the session actually runs.
+
+| Product                                                                                                                              | Sessions run on                                             | Chat platforms                                  | Account                                       |
+| :----------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------- | :---------------------------------------------- | :-------------------------------------------- |
+| **claude-threads**                                                                                                                    | Your machine — local checkout, your MCP servers and plugins | Slack + Mattermost, multiple workspaces at once | Any Claude subscription or API key            |
+| [Claude Code in Slack](https://code.claude.com/docs/en/slack) / [Claude Tag](https://claude.com/docs/claude-tag/overview) (Anthropic) | Anthropic's cloud, against GitHub repos                     | Slack                                           | Claude Pro/Max; Claude Tag on Team/Enterprise |
+| [Codex in Slack](https://slack.com/marketplace/A09F5C369E3-openai-codex) (OpenAI)                                                     | OpenAI's Codex cloud                                        | Slack                                           | ChatGPT plan                                  |
+| [Cursor in Slack](https://cursor.com/docs/integrations/slack)                                                                         | Cursor's cloud agents                                       | Slack                                           | Cursor plan                                   |
+| Community bots such as [claude-code-slack-bot](https://github.com/mpociot/claude-code-slack-bot)                                      | Your machine                                                | Slack                                           | Claude subscription or API key                |
+
+The cloud products share a working style: you delegate a task from a thread, an agent works in a vendor-hosted sandbox, and progress updates and a pull request come back. If your repositories live on GitHub and you want nothing to host, they are a good choice — the official integration in particular runs the same Claude Code this bot does.
+
+claude-threads makes the opposite choice: the whole session stays in the thread and on your hardware. Output streams live, permission prompts land as emoji reactions, invited teammates type into the same session, and Claude works against a local checkout with whatever MCP servers and plugins you already configured. That fit matters when chat is self-hosted Mattermost, when code cannot leave the building, or when you want a session in chat to behave exactly like the one at your desk. The trade-off: you run the bot yourself, on a machine that has the repository.
+
+All of these products move quickly — if this table has gone stale, [open an issue](https://github.com/anneschuth/claude-threads/issues).
+
 ## Documentation
 
 - **[Setup Guide](https://github.com/anneschuth/claude-threads/blob/main/SETUP_GUIDE.md)** - Creating the bot account on Mattermost or Slack, step by step

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Who may do what (start sessions, react to permission prompts, approve guest mess
 
 ## How it compares
 
-Driving a coding agent from chat is a busy space, with official products from Anthropic, OpenAI, and Cursor alongside community projects — several of them excellent. The main difference is where the session actually runs.
+Driving a coding agent from chat is a busy space: Anthropic, OpenAI, and Cursor each ship their own integration, and other open-source projects exist too — several of them excellent. The main difference is where the session actually runs.
 
 | Product                                                                                                                              | Sessions run on                                             | Chat platforms                                  | Account                                       |
 | :----------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------- | :---------------------------------------------- | :-------------------------------------------- |
@@ -182,7 +182,7 @@ Driving a coding agent from chat is a busy space, with official products from An
 | [Cursor in Slack](https://cursor.com/docs/integrations/slack)                                                                         | Cursor's cloud agents                                       | Slack                                           | Cursor plan                                   |
 | Community bots such as [claude-code-slack-bot](https://github.com/mpociot/claude-code-slack-bot)                                      | Your machine                                                | Slack                                           | Claude subscription or API key                |
 
-The cloud products share a working style: you delegate a task from a thread, an agent works in a vendor-hosted sandbox, and progress updates and a pull request come back. If your repositories live on GitHub and you want nothing to host, they are a good choice — the official integration in particular runs the same Claude Code this bot does.
+The cloud products share a working style: you delegate a task from a thread, an agent works in a vendor-hosted sandbox, and progress updates and a pull request come back. If your repositories live on GitHub and you want nothing to host, they are a good choice — Anthropic's own integration in particular runs the same Claude Code this bot does.
 
 claude-threads makes the opposite choice: the whole session stays in the thread and on your hardware. Output streams live, permission prompts land as emoji reactions, invited teammates type into the same session, and Claude works against a local checkout with whatever MCP servers and plugins you already configured. That fit matters when chat is self-hosted Mattermost, when code cannot leave the building, or when you want a session in chat to behave exactly like the one at your desk. The trade-off: you run the bot yourself, on a machine that has the repository.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",

--- a/website/index.html
+++ b/website/index.html
@@ -618,7 +618,18 @@
               and on your hardware — streamed output, emoji permission prompts,
               teammates typing into the same session — which matters when chat
               is self-hosted Mattermost or the code cannot leave the building.
-              The trade-off: you run the bot yourself. Current as of August
+              The trade-off: you run the bot yourself.
+            </p>
+            <p class="compare-note">
+              A few more things set it apart: the full Claude Code permission
+              model lives in the thread (👍/✅/👎 per tool use, three modes
+              switchable mid-session), sessions are multiplayer (<code
+                >!invite</code
+              >
+              teammates, guest messages gated behind approval, shared co-author
+              credit on commits), an optional account pool routes each session
+              to the Claude subscription with the most headroom, and nothing
+              assumes GitHub — any local checkout works. Current as of August
               2026.
             </p>
           </div>
@@ -655,8 +666,7 @@ claude-threads"
               <pre>
 bun install -g claude-threads    # or: npm install -g claude-threads
 cd /your/project
-claude-threads</pre
-              >
+claude-threads</pre>
               <span class="copy-hint">click to copy</span>
             </button>
             <p>

--- a/website/index.html
+++ b/website/index.html
@@ -503,9 +503,107 @@
               same AI session actually works.
             </p>
             <p>
-              There is now an official way to put Claude in Slack, built by
-              Anthropic and gated to Enterprise plans. claude-threads remains
+              There are now official ways to put Claude in Slack, built by
+              Anthropic and running in Anthropic's cloud. claude-threads remains
               the local one: your machine, your chat server, any subscription.
+            </p>
+          </div>
+        </section>
+
+        <!-- How it compares -->
+        <section class="compare" id="compare">
+          <div class="container">
+            <h2>How it compares</h2>
+            <p class="section-intro">
+              There are official ways to drive a coding agent from chat, and
+              they are good. The main difference is where the session runs.
+            </p>
+            <table>
+              <tr>
+                <th>Product</th>
+                <th>Sessions run on</th>
+                <th>Chat platforms</th>
+                <th>Account</th>
+              </tr>
+              <tr>
+                <td><strong>claude-threads</strong></td>
+                <td>
+                  Your machine: local checkout, your MCP servers and plugins
+                </td>
+                <td>Slack + Mattermost, multiple workspaces at once</td>
+                <td>Any Claude subscription or API key</td>
+              </tr>
+              <tr>
+                <td>
+                  <a
+                    href="https://code.claude.com/docs/en/slack"
+                    target="_blank"
+                    rel="noopener"
+                    >Claude Code in Slack</a
+                  >
+                  /
+                  <a
+                    href="https://claude.com/docs/claude-tag/overview"
+                    target="_blank"
+                    rel="noopener"
+                    >Claude Tag</a
+                  >
+                  (Anthropic)
+                </td>
+                <td>Anthropic's cloud, against GitHub repos</td>
+                <td>Slack</td>
+                <td>Claude Pro/Max; Claude Tag on Team/Enterprise</td>
+              </tr>
+              <tr>
+                <td>
+                  <a
+                    href="https://slack.com/marketplace/A09F5C369E3-openai-codex"
+                    target="_blank"
+                    rel="noopener"
+                    >Codex in Slack</a
+                  >
+                  (OpenAI)
+                </td>
+                <td>OpenAI's Codex cloud</td>
+                <td>Slack</td>
+                <td>ChatGPT plan</td>
+              </tr>
+              <tr>
+                <td>
+                  <a
+                    href="https://cursor.com/docs/integrations/slack"
+                    target="_blank"
+                    rel="noopener"
+                    >Cursor in Slack</a
+                  >
+                </td>
+                <td>Cursor's cloud agents</td>
+                <td>Slack</td>
+                <td>Cursor plan</td>
+              </tr>
+              <tr>
+                <td>
+                  Community bots like
+                  <a
+                    href="https://github.com/mpociot/claude-code-slack-bot"
+                    target="_blank"
+                    rel="noopener"
+                    >claude-code-slack-bot</a
+                  >
+                </td>
+                <td>Your machine</td>
+                <td>Slack</td>
+                <td>Claude subscription or API key</td>
+              </tr>
+            </table>
+            <p class="compare-note">
+              The cloud products delegate: a task leaves the thread, a
+              vendor-hosted sandbox does the work, a pull request comes back.
+              claude-threads keeps the whole session in the thread and on your
+              hardware — streamed output, emoji permission prompts, teammates
+              typing into the same session — which matters when chat is
+              self-hosted Mattermost or the code cannot leave the building. The
+              trade-off: you run the bot yourself.
             </p>
           </div>
         </section>
@@ -541,7 +639,8 @@ claude-threads"
               <pre>
 bun install -g claude-threads    # or: npm install -g claude-threads
 cd /your/project
-claude-threads</pre>
+claude-threads</pre
+              >
               <span class="copy-hint">click to copy</span>
             </button>
             <p>

--- a/website/index.html
+++ b/website/index.html
@@ -515,8 +515,9 @@
           <div class="container">
             <h2>How it compares</h2>
             <p class="section-intro">
-              Anthropic, OpenAI, and Cursor each put their agent in Slack, and
-              they did it well. The main difference is where the session runs.
+              Anthropic, OpenAI, Cursor, and Cognition each put their agent in
+              Slack, and they did it well. The main difference is where the
+              session runs.
             </p>
             <table>
               <tr>
@@ -526,7 +527,9 @@
                 <th>Account</th>
               </tr>
               <tr>
-                <td><strong>claude-threads</strong></td>
+                <td>
+                  <strong>claude-threads</strong> (open source, Apache-2.0)
+                </td>
                 <td>
                   Your machine: local checkout, your MCP servers and plugins
                 </td>
@@ -583,7 +586,18 @@
               </tr>
               <tr>
                 <td>
-                  Community bots like
+                  <a href="https://devin.ai/" target="_blank" rel="noopener"
+                    >Devin</a
+                  >
+                  (Cognition)
+                </td>
+                <td>Cognition's cloud</td>
+                <td>Slack (also Linear and Jira tickets)</td>
+                <td>Devin plan</td>
+              </tr>
+              <tr>
+                <td>
+                  Community bots such as
                   <a
                     href="https://github.com/mpociot/claude-code-slack-bot"
                     target="_blank"
@@ -597,13 +611,15 @@
               </tr>
             </table>
             <p class="compare-note">
-              The cloud products delegate: a task leaves the thread, a
-              vendor-hosted sandbox does the work, a pull request comes back.
-              claude-threads keeps the whole session in the thread and on your
-              hardware — streamed output, emoji permission prompts, teammates
-              typing into the same session — which matters when chat is
-              self-hosted Mattermost or the code cannot leave the building. The
-              trade-off: you run the bot yourself.
+              With the cloud products, you delegate from a thread: the work runs
+              in a vendor-hosted sandbox and comes back as a pull request —
+              Claude Tag additionally stays in the conversation as a shared
+              teammate. claude-threads keeps the session itself in the thread
+              and on your hardware — streamed output, emoji permission prompts,
+              teammates typing into the same session — which matters when chat
+              is self-hosted Mattermost or the code cannot leave the building.
+              The trade-off: you run the bot yourself. Current as of August
+              2026.
             </p>
           </div>
         </section>

--- a/website/index.html
+++ b/website/index.html
@@ -503,9 +503,9 @@
               same AI session actually works.
             </p>
             <p>
-              There are now official ways to put Claude in Slack, built by
-              Anthropic and running in Anthropic's cloud. claude-threads remains
-              the local one: your machine, your chat server, any subscription.
+              Anthropic now has its own ways to put Claude in Slack, running in
+              Anthropic's cloud. claude-threads remains the local one: your
+              machine, your chat server, any subscription.
             </p>
           </div>
         </section>
@@ -515,8 +515,8 @@
           <div class="container">
             <h2>How it compares</h2>
             <p class="section-intro">
-              There are official ways to drive a coding agent from chat, and
-              they are good. The main difference is where the session runs.
+              Anthropic, OpenAI, and Cursor each put their agent in Slack, and
+              they did it well. The main difference is where the session runs.
             </p>
             <table>
               <tr>

--- a/website/styles.css
+++ b/website/styles.css
@@ -467,6 +467,19 @@ td code {
   color: var(--ink);
 }
 
+/* ---------- Compare ---------- */
+
+.compare td:first-child {
+  white-space: normal;
+  min-width: 11rem;
+}
+
+.compare-note {
+  color: var(--muted);
+  max-width: 620px;
+  margin-top: 1.25rem;
+}
+
 /* ---------- Quickstart ---------- */
 
 .quickstart .copyable.block {


### PR DESCRIPTION
## Summary

Adds a short, respectful comparison section to the website and README, positioning claude-threads among the other ways to drive a coding agent from chat: Anthropic's own Claude Code in Slack / Claude Tag, OpenAI's Codex in Slack, Cursor in Slack, Cognition's Devin, and community Slack bots.

The framing is a single axis — where the session runs (vendor cloud vs. your machine) — with claude-threads as the local, open-source (Apache-2.0) option that also speaks Mattermost. No feature-count scoreboards; the vendors' cloud products are credited as good choices for GitHub-hosted repos with nothing to host, and Claude Tag's in-channel multiplayer behavior is described accurately rather than flattened to fire-and-forget delegation. The table is date-stamped (August 2026) with an invitation to open an issue when it goes stale.

This PR also carries the **1.20.1 patch release**: version bump in `package.json`/`package-lock.json` and the CHANGELOG `[Unreleased]` entry promoted to `[1.20.1] - 2026-08-06`, so merging triggers `release.yml` to tag and publish.

## Changes

- **README**: new `## How it compares` section (six-row table + two short paragraphs) between Access Control and Documentation
- **Website**: new `#compare` section between "Why I built this" and Quickstart, using the site's existing table styling; small CSS additions so the product-name column wraps (`.compare td:first-child`) and the closing note reads muted (`.compare-note`)
- **Website**: the "Why I built this" note about Anthropic's integration updated — it is no longer Enterprise-gated (Pro/Max have Claude Code in Slack; Team/Enterprise have Claude Tag)
- Wording deliberately avoids calling the vendor products "official", which would implicitly cast claude-threads as unofficial
- **CHANGELOG**: entry promoted to `[1.20.1] - 2026-08-06`
- **Release**: `npm version patch` (1.20.0 → 1.20.1); `bun.lock` needs no change (it does not record the root version)

## Testing

- Rendered the website locally with Playwright and screenshotted the `#compare` section at 1200px and 420px viewports: table lays out cleanly on desktop, scrolls horizontally on mobile as the existing responsive rule intends
- `bunx prettier --check website/index.html website/styles.css` passes
- Docs + version metadata only: no runtime code touched

## Checklist

- [x] Tests pass (`bun test`) — not affected, docs/website only
- [x] Linting passes (`bun run lint`) — not affected, docs/website only
- [x] Documentation updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQMfSCwJq41WedH1U88rEm