### PR TITLE
Fix session teardown races during Claude respawn + flaky CI tests, release 1.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A respawning session can no longer be torn down by its own dying Claude process.** Two stacked races made `!cd` / `!permissions` / worktree respawns flaky (seen as the recurring `!cd should restart Claude CLI` failure on main's Integration Tests): a last event flushed by the dying process ran `resetSessionActivity`, which unconditionally flipped the session's `restarting` state back to `active` — so when the old process's exit landed, `handleExit` mistook it for the current process dying and did a full session teardown mid-restart. `resetSessionActivity` now leaves `restarting`/`cancelling` states alone, `handleExit` ignores exits from a CLI instance that is no longer the session's current one (the exit event can be delivered after the respawn already swapped in the new instance), and a successful respawn transitions to `active` explicitly instead of relying on the old exit's side effect. `ClaudeCli.kill()` gained an integration-test caller trace, mirroring the existing `sendMessage` one — attributing kills is the key question when debugging these races in CI logs.
+- **`checkGitHubCli` unit tests no longer spawn the real `gh` CLI.** The two subprocess probes each carry a 5s timeout, overrunning bun's 5s per-test budget on a slow runner (the flaky `checkGitHubCli` timeout on main's CI). The exec call is now injectable and the tests cover all three outcomes (installed+authenticated, not installed, not authenticated) deterministically.
+- **Integration: the `!cd` confirmation wait no longer matches the user's own message.** The loose `/changed|directory|\/tmp/i` pattern matched the `!cd /tmp` command itself, ending the test while the respawn was still in flight — `afterEach`'s `killAllSessions` then raced the restart and leaked an orphaned mock CLI into the next test.
+
 ## [1.21.0] - 2026-08-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.21.1] - 2026-08-07
 
 ### Fixed
 - **A respawning session can no longer be torn down by its own dying Claude process.** Two stacked races made `!cd` / `!permissions` / worktree respawns flaky (seen as the recurring `!cd should restart Claude CLI` failure on main's Integration Tests): a last event flushed by the dying process ran `resetSessionActivity`, which unconditionally flipped the session's `restarting` state back to `active` — so when the old process's exit landed, `handleExit` mistook it for the current process dying and did a full session teardown mid-restart. `resetSessionActivity` now leaves `restarting`/`cancelling` states alone, `handleExit` ignores exits from a CLI instance that is no longer the session's current one (the exit event can be delivered after the respawn already swapped in the new instance), and a successful respawn transitions to `active` explicitly instead of relying on the old exit's side effect. `ClaudeCli.kill()` gained an integration-test caller trace, mirroring the existing `sendMessage` one — attributing kills is the key question when debugging these races in CI logs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.21.0",
+      "version": "1.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -831,6 +831,13 @@ export class ClaudeCli extends EventEmitter {
     this.process = null;
 
     this.log.debug(`Killing Claude process (pid=${pid})`);
+    // Diagnostic for integration tests: trace every kill call with caller,
+    // mirroring the sendMessage trace above. Which code path killed a CLI is
+    // the key question when debugging session-teardown races in CI logs.
+    if (process.env.INTEGRATION_TEST === '1') {
+      const stack = new Error().stack?.split('\n').slice(2, 7).join(' > ').replace(/\s+at\s+/g, ' < ') ?? '?';
+      process.stderr.write(`[claude-cli kill pid=${pid}] | ${stack}\n`);
+    }
 
     return new Promise<void>((resolve) => {
       // Send first SIGINT (interrupts current operation)

--- a/src/operations/bug-report/handler.test.ts
+++ b/src/operations/bug-report/handler.test.ts
@@ -390,20 +390,31 @@ describe('formatBugPreview', () => {
 // =============================================================================
 
 describe('checkGitHubCli', () => {
-  test('returns result object with expected properties', () => {
-    const result = checkGitHubCli();
-    expect(result).toHaveProperty('installed');
-    expect(result).toHaveProperty('authenticated');
-    expect(typeof result.installed).toBe('boolean');
-    expect(typeof result.authenticated).toBe('boolean');
+  // Exec fakes are injected so tests never spawn real `gh` processes — the
+  // real calls carry 5s subprocess timeouts that overrun bun's per-test
+  // timeout on slow CI runners.
+  test('reports installed and authenticated when both gh calls succeed', () => {
+    const result = checkGitHubCli(() => '');
+    expect(result).toEqual({ installed: true, authenticated: true });
   });
 
-  test('provides error message when not installed', () => {
-    const result = checkGitHubCli();
-    if (!result.installed) {
-      expect(result.error).toBeDefined();
-      expect(result.error).toContain('GitHub CLI');
-    }
+  test('reports not installed when gh --version fails', () => {
+    const result = checkGitHubCli(() => {
+      throw new Error('command not found: gh');
+    });
+    expect(result.installed).toBe(false);
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toContain('GitHub CLI');
+  });
+
+  test('reports not authenticated when gh auth status fails', () => {
+    const result = checkGitHubCli((command) => {
+      if (command === 'gh auth status') throw new Error('not logged in');
+      return '';
+    });
+    expect(result.installed).toBe(true);
+    expect(result.authenticated).toBe(false);
+    expect(result.error).toContain('gh auth login');
   });
 });
 

--- a/src/operations/bug-report/handler.ts
+++ b/src/operations/bug-report/handler.ts
@@ -659,12 +659,18 @@ function escapeShell(str: string): string {
 }
 
 /**
- * Check if GitHub CLI is installed and authenticated
+ * Check if GitHub CLI is installed and authenticated.
+ *
+ * `exec` is injectable so tests don't spawn real `gh` processes — the two
+ * subprocess calls each carry a 5s timeout, which overruns bun's 5s per-test
+ * budget on a slow CI runner (seen as a flaky timeout on main).
  */
-export function checkGitHubCli(): { installed: boolean; authenticated: boolean; error?: string } {
+export function checkGitHubCli(
+  exec: (command: string, options: { encoding: 'utf-8'; timeout: number; stdio: ['pipe', 'pipe', 'pipe'] }) => unknown = execSync
+): { installed: boolean; authenticated: boolean; error?: string } {
   try {
     // Check if gh is installed
-    execSync('gh --version', {
+    exec('gh --version', {
       encoding: 'utf-8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -679,7 +685,7 @@ export function checkGitHubCli(): { installed: boolean; authenticated: boolean; 
 
   try {
     // Check if authenticated
-    execSync('gh auth status', {
+    exec('gh auth status', {
       encoding: 'utf-8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -131,19 +131,26 @@ export async function restartClaudeSession(
   }
 
   // Create new Claude CLI
-  session.claude = new ClaudeCli(cliOptions);
+  const newClaude = new ClaudeCli(cliOptions);
+  session.claude = newClaude;
 
   // Rebind event handlers (use sessionId which is the composite key).
   // The rate-limit listener MUST be rebound here too — without it, a !cd or
   // !permissions interactive restart would silently drop rate-limit signals
   // from the new Claude process and the account would never enter cooldown.
-  session.claude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(session.sessionId, e));
-  session.claude.on('exit', (code: number) => ctx.ops.handleExit(session.sessionId, code));
-  session.claude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
+  newClaude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(session.sessionId, e));
+  newClaude.on('exit', (code: number) => ctx.ops.handleExit(session.sessionId, code, newClaude));
+  newClaude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
 
   // Start the new Claude CLI
   try {
-    session.claude.start();
+    newClaude.start();
+    // Respawn succeeded. The old process's exit usually resets 'restarting'
+    // to 'active' via handleExit's restarting guard, but that exit can also
+    // arrive after the swap above (where the stale-source check in
+    // handleExit drops it) — transition explicitly so the session never
+    // sticks in 'restarting'.
+    transitionTo(session, 'active');
     return true;
   } catch (err) {
     transitionTo(session, 'active');

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Session } from '../../session/types.js';
-import { transitionTo } from '../../session/types.js';
+import { transitionTo, isSessionRestarting } from '../../session/types.js';
 import type { SessionContext } from '../session-context/index.js';
 import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../../claude/cli.js';
 import {
@@ -149,11 +149,17 @@ export async function restartClaudeSession(
     // to 'active' via handleExit's restarting guard, but that exit can also
     // arrive after the swap above (where the stale-source check in
     // handleExit drops it) — transition explicitly so the session never
-    // sticks in 'restarting'.
-    transitionTo(session, 'active');
+    // sticks in 'restarting'. Guarded: a `!stop` issued during the respawn
+    // window has moved the session to 'cancelling', which must not be
+    // clobbered back to 'active'.
+    if (isSessionRestarting(session)) {
+      transitionTo(session, 'active');
+    }
     return true;
   } catch (err) {
-    transitionTo(session, 'active');
+    if (isSessionRestarting(session)) {
+      transitionTo(session, 'active');
+    }
     await logAndNotify(err, { action: actionName, session });
     return false;
   }

--- a/src/operations/post-helpers/index.ts
+++ b/src/operations/post-helpers/index.ts
@@ -312,8 +312,17 @@ export function resetSessionActivity(session: Session): void {
   session.lastActivityAt = new Date();
   session.timeoutWarningPosted = false;
   session.lifecyclePostId = undefined;
-  // Reset lifecycle state to active (clearing paused/interrupted states)
-  transitionTo(session, 'active');
+  // Reset lifecycle state to active (clearing paused/interrupted states) —
+  // but never clobber an in-progress restart or cancel. This runs on every
+  // Claude event, and the dying process of a `!cd`/`!permissions`/worktree
+  // respawn can emit one last event during kill(); flipping 'restarting'
+  // back to 'active' here made handleExit treat the old process's exit as a
+  // real session end and tear down the freshly restarted session (flaky
+  // "!cd should restart Claude CLI" integration test).
+  const state = session.lifecycle.state;
+  if (state !== 'restarting' && state !== 'cancelling') {
+    transitionTo(session, 'active');
+  }
 
   // Update worktree metadata to prevent aggressive cleanup of active worktrees.
   // This is fire-and-forget - we don't want to block session activity on disk I/O.

--- a/src/operations/post-helpers/post-helpers.test.ts
+++ b/src/operations/post-helpers/post-helpers.test.ts
@@ -263,6 +263,29 @@ describe('resetSessionActivity', () => {
     expect(session.lifecycle.state as string).toBe('active');
   });
 
+  it('does not clobber an in-progress restart', () => {
+    // Regression: a late event from the dying Claude process during a
+    // !cd/!permissions/worktree respawn runs resetSessionActivity via
+    // handleEventPreProcessing. Flipping 'restarting' back to 'active' made
+    // handleExit tear down the freshly restarted session (flaky "!cd should
+    // restart Claude CLI" integration test).
+    const session = createMockSession();
+    session.lifecycle.state = 'restarting';
+
+    resetSessionActivity(session);
+
+    expect(session.lifecycle.state as string).toBe('restarting');
+  });
+
+  it('does not clobber an in-progress cancel', () => {
+    const session = createMockSession();
+    session.lifecycle.state = 'cancelling';
+
+    resetSessionActivity(session);
+
+    expect(session.lifecycle.state as string).toBe('cancelling');
+  });
+
   it('calls updateWorktreeActivity when session has worktreeInfo', () => {
     const session = createMockSession({
       sessionOverrides: {

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Session } from '../../session/types.js';
-import type { ClaudeEvent } from '../../claude/cli.js';
+import type { ClaudeCli, ClaudeEvent } from '../../claude/cli.js';
 import type { PlatformClient, PlatformFile } from '../../platform/index.js';
 import type { SessionStore } from '../../persistence/session-store.js';
 import type { GitHubEmailsStore } from '../../persistence/github-emails-store.js';
@@ -173,8 +173,16 @@ export interface SessionOperations {
   /** Handle a Claude CLI event */
   handleEvent(sessionId: string, event: ClaudeEvent): void;
 
-  /** Handle Claude CLI process exit */
-  handleExit(sessionId: string, code: number): Promise<void>;
+  /**
+   * Handle Claude CLI process exit.
+   *
+   * `source` is the ClaudeCli instance that emitted the exit. Pass it so a
+   * late exit from a process that was already replaced (`!cd` /
+   * `!permissions` / worktree respawn) can be told apart from the current
+   * process dying — without it, a stale exit tears down the restarted
+   * session.
+   */
+  handleExit(sessionId: string, code: number, source?: ClaudeCli): Promise<void>;
 
   // ---------------------------------------------------------------------------
   // Session Lifecycle

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Session } from '../../session/types.js';
-import { transitionTo } from '../../session/types.js';
+import { transitionTo, isSessionRestarting } from '../../session/types.js';
 import type { WorktreeMode, PermissionMode } from '../../config/index.js';
 import { effectivePermissionMode } from '../../config/index.js';
 import type { PlatformFile } from '../../platform/index.js';
@@ -538,8 +538,11 @@ export async function createAndSwitchToWorktree(
         newClaude.start();
         // Respawn succeeded — leave 'restarting' explicitly. A late exit
         // from the old process is dropped by handleExit's stale-source
-        // check, so nothing else is guaranteed to reset the state.
-        transitionTo(session, 'active');
+        // check, so nothing else is guaranteed to reset the state. Guarded
+        // so a cancel issued mid-respawn is not clobbered back to 'active'.
+        if (isSessionRestarting(session)) {
+          transitionTo(session, 'active');
+        }
       }
 
       // Update session header
@@ -708,8 +711,11 @@ export async function createAndSwitchToWorktree(
       newClaude.start();
       // Respawn succeeded — leave 'restarting' explicitly. A late exit
       // from the old process is dropped by handleExit's stale-source
-      // check, so nothing else is guaranteed to reset the state.
-      transitionTo(session, 'active');
+      // check, so nothing else is guaranteed to reset the state. Guarded
+      // so a cancel issued mid-respawn is not clobbered back to 'active'.
+      if (isSessionRestarting(session)) {
+        transitionTo(session, 'active');
+      }
     }
 
     // Update session header

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -402,7 +402,7 @@ export async function createAndSwitchToWorktree(
     worktreeMode: WorktreeMode;
     permissionTimeoutMs?: number;
     handleEvent: (sessionId: string, event: ClaudeEvent) => void;
-    handleExit: (sessionId: string, code: number) => Promise<void>;
+    handleExit: (sessionId: string, code: number, source?: ClaudeCli) => Promise<void>;
     updateSessionHeader: (session: Session) => Promise<void>;
     flush: (session: Session) => Promise<void>;
     persistSession: (session: Session) => void;
@@ -527,14 +527,19 @@ export async function createAndSwitchToWorktree(
         // Fresh CLI session (resume: false) — clear accumulated task/tool
         // state so the new session's task ids can't collide with stale ones.
         session.messageManager?.clearClaudeSessionState();
-        session.claude = new ClaudeCli(cliOptions);
+        const newClaude = new ClaudeCli(cliOptions);
+        session.claude = newClaude;
 
         // Rebind event handlers
-        session.claude.on('event', (e: ClaudeEvent) => options.handleEvent(session.sessionId, e));
-        session.claude.on('exit', (code: number) => options.handleExit(session.sessionId, code));
+        newClaude.on('event', (e: ClaudeEvent) => options.handleEvent(session.sessionId, e));
+        newClaude.on('exit', (code: number) => options.handleExit(session.sessionId, code, newClaude));
 
         // Start the new CLI
-        session.claude.start();
+        newClaude.start();
+        // Respawn succeeded — leave 'restarting' explicitly. A late exit
+        // from the old process is dropped by handleExit's stale-source
+        // check, so nothing else is guaranteed to reset the state.
+        transitionTo(session, 'active');
       }
 
       // Update session header
@@ -692,14 +697,19 @@ export async function createAndSwitchToWorktree(
       // Fresh CLI session (resume: false) — clear accumulated task/tool
       // state so the new session's task ids can't collide with stale ones.
       session.messageManager?.clearClaudeSessionState();
-      session.claude = new ClaudeCli(cliOptions);
+      const newClaude = new ClaudeCli(cliOptions);
+      session.claude = newClaude;
 
       // Rebind event handlers (use sessionId which is the composite key)
-      session.claude.on('event', (e: ClaudeEvent) => options.handleEvent(session.sessionId, e));
-      session.claude.on('exit', (code: number) => options.handleExit(session.sessionId, code));
+      newClaude.on('event', (e: ClaudeEvent) => options.handleEvent(session.sessionId, e));
+      newClaude.on('exit', (code: number) => options.handleExit(session.sessionId, code, newClaude));
 
       // Start the new CLI
-      session.claude.start();
+      newClaude.start();
+      // Respawn succeeded — leave 'restarting' explicitly. A late exit
+      // from the old process is dropped by handleExit's stale-source
+      // check, so nothing else is guaranteed to reset the state.
+      transitionTo(session, 'active');
     }
 
     // Update session header

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1112,6 +1112,34 @@ describe('handleExit', () => {
     expect(ctx.ops.unregisterWorktreeUser).toHaveBeenCalledWith('/tmp/wt/abc', session.sessionId);
   });
 
+  it('ignores a stale exit from a replaced Claude process', async () => {
+    // Race seen in CI (slack integration, "!cd should restart Claude CLI"):
+    // the old process's 'exit' event can arrive after restartClaudeSession
+    // already swapped session.claude to the new instance and the session is
+    // back in 'active'. That exit must not tear down the restarted session.
+    const session = createExitTestSession({ hasClaudeResponded: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    const replacedCli = { isPermanentFailure: () => false } as any;
+    await lifecycle.handleExit(session.sessionId, 0, ctx, replacedCli);
+
+    expect(sessions.has(session.sessionId)).toBe(true);
+    expect(ctx.ops.unpersistSession).not.toHaveBeenCalled();
+    expect(ctx.ops.updateStickyMessage).not.toHaveBeenCalled();
+  });
+
+  it('handles the exit normally when source is the current Claude process', async () => {
+    const session = createExitTestSession({ hasClaudeResponded: true });
+    const sessions = new Map([[session.sessionId, session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit(session.sessionId, 0, ctx, session.claude);
+
+    expect(sessions.has(session.sessionId)).toBe(false);
+    expect(ctx.ops.unpersistSession).toHaveBeenCalledWith(session.sessionId);
+  });
+
   it('posts [Exited: code] notification on non-zero exit', async () => {
     const session = createExitTestSession({ hasClaudeResponded: true });
     const mockCreatePost = mock(() => Promise.resolve({

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -1102,7 +1102,7 @@ export async function startSession(
 
   // Bind event handlers (use sessionId which is the composite key)
   claude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(sessionId, e));
-  claude.on('exit', (code: number) => ctx.ops.handleExit(sessionId, code));
+  claude.on('exit', (code: number) => ctx.ops.handleExit(sessionId, code, claude));
   claude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
 
   try {
@@ -1437,7 +1437,7 @@ export async function resumeSession(
 
   // Bind event handlers (use sessionId which is the composite key)
   claude.on('event', (e: ClaudeEvent) => ctx.ops.handleEvent(sessionId, e));
-  claude.on('exit', (code: number) => ctx.ops.handleExit(sessionId, code));
+  claude.on('exit', (code: number) => ctx.ops.handleExit(sessionId, code, claude));
   claude.on('rate-limit', (hit: RateLimitHit) => handleRateLimit(session, hit, ctx));
 
   try {
@@ -1625,7 +1625,8 @@ export async function resumePausedSession(
 export async function handleExit(
   sessionId: string,
   code: number,
-  ctx: SessionContext
+  ctx: SessionContext,
+  source?: ClaudeCli
 ): Promise<void> {
   const session = mutableSessions(ctx).get(sessionId);
   const shortId = sessionId.substring(0, 8);
@@ -1634,6 +1635,18 @@ export async function handleExit(
 
   if (!session) {
     log.debug(`Session ${shortId}... not found (already cleaned up)`);
+    return;
+  }
+
+  // A respawn (!cd, !permissions, worktree switch) replaces session.claude
+  // and kills the old process. kill() can resolve before the old process's
+  // 'exit' event is delivered, so that exit may arrive after the restart
+  // already completed — by which point the 'restarting' state guard below
+  // has been reset to 'active' by the confirmation post. Treating the stale
+  // exit as the current process dying would tear down the freshly restarted
+  // session. Only the session's current CLI may drive exit handling.
+  if (source && session.claude !== source) {
+    sessionLog(session).debug(`Ignoring exit from replaced Claude process`);
     return;
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -14,6 +14,7 @@
 
 import { EventEmitter } from 'events';
 import { ClaudeEvent } from '../claude/cli.js';
+import type { ClaudeCli } from '../claude/cli.js';
 import type { PlatformClient, PlatformUser, PlatformPost, PlatformFile } from '../platform/index.js';
 import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persistence/session-store.js';
 import { GitHubEmailsStore } from '../persistence/github-emails-store.js';
@@ -355,7 +356,7 @@ export class SessionManager extends EventEmitter {
 
       // Event handling
       handleEvent: (sid, e) => this.handleEvent(sid, e),
-      handleExit: (sid, code) => this.handleExit(sid, code),
+      handleExit: (sid, code, source) => this.handleExit(sid, code, source),
 
       // Session lifecycle
       killSession: (tid) => this.killSession(tid),
@@ -567,8 +568,8 @@ export class SessionManager extends EventEmitter {
   // Exit Handling (delegates to lifecycle module)
   // ---------------------------------------------------------------------------
 
-  private async handleExit(sessionId: string, code: number): Promise<void> {
-    await lifecycle.handleExit(sessionId, code, this.getContext());
+  private async handleExit(sessionId: string, code: number, source?: ClaudeCli): Promise<void> {
+    await lifecycle.handleExit(sessionId, code, this.getContext(), source);
   }
 
   // ---------------------------------------------------------------------------
@@ -1365,7 +1366,7 @@ export class SessionManager extends EventEmitter {
       worktreeMode: this.worktreeMode,
       permissionTimeoutMs: this.limits.permissionTimeoutSeconds * 1000,
       handleEvent: (tid, e) => this.handleEvent(tid, e),
-      handleExit: (tid, code) => this.handleExit(tid, code),
+      handleExit: (tid, code, source) => this.handleExit(tid, code, source),
       updateSessionHeader: (s) => this.updateSessionHeader(s),
       flush: async (s) => {
         if (s.messageManager) {

--- a/tests/integration/suites/session-commands.test.ts
+++ b/tests/integration/suites/session-commands.test.ts
@@ -403,12 +403,15 @@ describe.skipIf(SKIP)('Session Commands', () => {
         // Change to /tmp directory
         await sendCommand(ctx, rootPost.id, '!cd /tmp');
 
-        // Wait for cd confirmation
-        await waitForPostMatching(ctx, rootPost.id, /changed|directory|\/tmp/i, { timeout: 10000 });
+        // Wait for cd confirmation. The pattern must only match the bot's
+        // confirmation post — a loose pattern like /\/tmp/ also matches the
+        // user's own "!cd /tmp" message, ending the test while the !cd flow
+        // is still running so afterEach's killAllSessions races the restart.
+        await waitForPostMatching(ctx, rootPost.id, /Working directory changed/i, { timeout: 10000 });
 
         const allPosts = await getThreadPosts(ctx, rootPost.id);
         const cdPost = allPosts.find((p) =>
-          ctx.botUserIds.includes(p.userId) && /changed|directory|\/tmp/i.test(p.message)
+          ctx.botUserIds.includes(p.userId) && /Working directory changed/i.test(p.message)
         );
 
         expect(cdPost).toBeDefined();


### PR DESCRIPTION
## Summary

Main has been intermittently red from two unrelated flakes. Digging into the integration flake uncovered a **real production bug**: a session being respawned (`!cd`, `!permissions`, worktree switch) could be torn down by its own dying Claude process — the bot would post "Working directory changed... restarted" while the session behind it was already dead and removed from persistence.

This PR fixes the race, makes the flaky unit test hermetic, fixes a test-hygiene bug that let cleanup race in-flight restarts, and bumps the version to **1.21.1** so `release.yml` publishes on merge.

## Changes

**The respawn race (production bug):**
- `resetSessionActivity` no longer clobbers an in-progress `restarting`/`cancelling` state. It runs on every Claude event, and the dying process of a respawn can emit one last event during `kill()`; flipping `restarting` back to `active` made `handleExit` treat the old process's exit as a real session end and run full teardown mid-restart.
- `handleExit` now takes the emitting `ClaudeCli` instance (`source`) and ignores exits from a process that is no longer the session's current CLI — the exit event can be delivered after the respawn already swapped in the new instance.
- A successful respawn transitions to `active` explicitly (commands + both worktree respawn sites) instead of relying on the old process's exit side effect.
- `ClaudeCli.kill()` gained an `INTEGRATION_TEST` caller trace mirroring the existing `sendMessage` one — attributing kills is the key question when debugging teardown races in CI logs.

**Flaky unit test (`checkGitHubCli`):**
- The test spawned the real `gh` CLI: two subprocess probes with 5s timeouts against bun's 5s per-test budget. The exec call is now injectable (`execSync` remains the default; no runtime behavior change) and the tests cover installed+authenticated / not installed / not authenticated deterministically.

**Integration test hygiene:**
- The `!cd` confirmation wait matched the user's own `!cd /tmp` message (loose `/changed|directory|\/tmp/i` pattern), ending the test while the respawn was still in flight — `afterEach`'s `killAllSessions` then raced the restart and leaked an orphaned mock CLI into the next test. It now waits for the actual bot confirmation.

**Release:**
- Version 1.21.0 → 1.21.1, CHANGELOG `[Unreleased]` promoted to `[1.21.1] - 2026-08-07`.

## Testing

- New regression tests verified **red-green**: `resetSessionActivity` restart/cancel-clobber tests and the `handleExit` stale-source tests fail with their fixes reverted.
- Full unit suite: 2977 tests, 0 fail. `tsc`, `eslint`, `knip` clean.
- Slack integration `session-commands` suite: **27 consecutive clean local runs** (previously failing ~1 in 5 locally, matching the two Integration Tests failures on main this week). Two full slack suite runs: 124 pass, 0 fail.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PFHDWiRbCyB7zVoytiCd5

---
_Generated by [Claude Code](https://claude.ai/code/session_011PFHDWiRbCyB7zVoytiCd5)_