### PR TITLE
Release 1.24.2 — dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.2] - 2026-08-13
+
+### Changed
+- **Dependency updates** (#469, #470). Production: `@hono/node-server` 2.0.12 → 2.1.0, `hono` 4.13.0 → 4.13.1, `express-rate-limit` 8.6.1 → 8.6.2, `ws` 8.21.1 → 8.21.3. Dev: `knip` 6.31.0 → 6.32.0 plus lockfile-only bumps within existing ranges. Both lockfiles regenerated and verified in lockstep; full typecheck/lint/test/build battery green on the combined result.
+
 ## [1.24.1] - 2026-08-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.24.1",
+      "version": "1.24.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.24.1",
+  "version": "1.24.2",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.24.2** covering the two Dependabot groups merged to main (#469, #470). Merging this PR triggers `release.yml`, which tags `v1.24.2`, creates the GitHub release, and publishes to npm.

## Changes

- Bump version `1.24.1` → `1.24.2` in `package.json` / `package-lock.json` (`bun.lock` unchanged — it does not record the root version)
- Promote CHANGELOG with a `## [1.24.2]` section listing the dependency updates: `@hono/node-server` 2.0.12 → 2.1.0, `hono` 4.13.0 → 4.13.1, `express-rate-limit` 8.6.1 → 8.6.2, `ws` 8.21.1 → 8.21.3, `knip` 6.31.0 → 6.32.0, plus lockfile-only bumps within existing ranges

## Testing

CI never ran on the Dependabot PRs (the lockfile-sync workflow's `GITHUB_TOKEN` commit suppressed downstream workflow triggers), so the combined result was verified locally before merging: `bun install` (no lockfile drift), `tsc --noEmit`, `bun run lint`, `bun test src/` (2810 pass / 0 fail), `bun run build`, and `knip` — all green. The same battery was re-run on merged main.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yPjKaJQtz7qEVtZxLUR3E

---
_Generated by [Claude Code](https://claude.ai/code/session_016yPjKaJQtz7qEVtZxLUR3E)_