### PR TITLE
Add quickstart section to setup guide

### DIFF
--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -5,10 +5,25 @@
 
 ## Table of Contents
 
-1. [Mattermost Setup](#mattermost-setup) - Create bot account and get credentials
-2. [Slack Setup](#slack-setup) - Create Slack app with Socket Mode
-3. [Running the Onboarding](#running-the-onboarding) - Interactive wizard walkthrough
-4. [Troubleshooting](#troubleshooting) - Common issues and solutions
+1. [Quickstart](#quickstart) - The whole path at a glance
+2. [Mattermost Setup](#mattermost-setup) - Create bot account and get credentials
+3. [Slack Setup](#slack-setup) - Create Slack app with Socket Mode
+4. [Running the Onboarding](#running-the-onboarding) - Interactive wizard walkthrough
+5. [Troubleshooting](#troubleshooting) - Common issues and solutions
+
+---
+
+## Quickstart
+
+The whole path, for either platform:
+
+1. **Install**: `bun install -g claude-threads` (or `npm install -g claude-threads`)
+2. **Create a bot account** in your workspace: [Mattermost](#mattermost-setup) or [Slack](#slack-setup)
+3. **Run the wizard**: `cd /your/project && claude-threads` - it asks for the bot credentials and tests them
+4. **Mention the bot** in the configured channel: `@claude-code fix the failing test in ci.yml`
+5. **Follow the thread**: output streams in live, and permission prompts are approved with a 👍 reaction
+
+Prerequisites: **Bun 1.2.21+** or **Node 20+**, and the **Claude Code CLI** (check with `claude --version`).
 
 ---
 


### PR DESCRIPTION
## Summary

SETUP_GUIDE.md jumped straight into bot-account creation; the install/wizard/first-mention path only appeared in section 3. This adds a short Quickstart at the top showing the whole path in five steps, covering Mattermost and Slack equally.

## Changes

- Add a Quickstart section (install, create bot, run wizard, mention bot, approve with 👍) with links to both platform setup sections
- Add the section to the table of contents

## Testing

Docs-only change; verified the markdown renders and the anchor links match the existing headings.

## Checklist

- [x] Tests pass (`bun test`) - not affected, docs only
- [x] Linting passes (`bun run lint`) - not affected, docs only
- [x] Documentation updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWjzyYVEFiyRDEfxXoAAGh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWjzyYVEFiyRDEfxXoAAGh)_