### PR TITLE
1.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.3] - 2026-08-19
+
+### Changed
+- **Dependency updates** (#473, #474). Production: `@hono/node-server` 2.1.0 → 2.1.1, `hono` 4.13.1 → 4.13.2. Dev: `knip` 6.32.0 → 6.32.2, pulling `oxc-parser` 0.142.0 → 0.143.0 and `unbash` 4.0.6 → 4.0.10. `typescript-eslint` 8.67.0 landed in `package-lock.json` only — it is a caret-ranged dev dependency, so `bun install` left `bun.lock` (what CI actually installs from) on 8.65.0. Full typecheck/lint/knip/test/build battery green on the combined result.
+
 ## [1.24.2] - 2026-08-13
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.24.2",
+      "version": "1.24.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts patch release 1.24.3, covering the two dependency updates merged just before it (#473, #474). Merging this to `main` is what triggers `release.yml` to tag, release and publish.

## Changes

- Bump version 1.24.2 → 1.24.3 in `package.json` / `package-lock.json`
- Promote the CHANGELOG to `## [1.24.3] - 2026-08-19`, describing the shipped bumps:
  - Production: `@hono/node-server` 2.1.0 → 2.1.1, `hono` 4.13.1 → 4.13.2 (#474)
  - Dev: `knip` 6.32.0 → 6.32.2, pulling `oxc-parser` 0.142.0 → 0.143.0 and `unbash` 4.0.6 → 4.0.10 (#473)

`bun.lock` is unchanged by the bump — it does not record the root version, as documented in CLAUDE.md.

## Testing

Full battery run locally on this exact commit, all green:

- `bun install --frozen-lockfile` — clean, so `bun.lock` and `package.json` agree
- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run knip` — clean
- `bun test src/` — 2810 pass, 0 fail
- `bun run build` + `node dist/index.js --version` → `1.24.3`

The same battery was run on the merged result of both dependency PRs before merging them, since CI never reported on their final heads: the `bun.lock` sync commits were pushed by `github-actions[bot]`, leaving the resulting CI runs in `action_required`.

Note for the record: PR #473 claimed a `typescript-eslint` 8.66.0 → 8.67.0 bump, but that only landed in `package-lock.json`. It is a caret-ranged dev dependency, so `bun install` left `bun.lock` — what CI actually installs from — on 8.65.0. The CHANGELOG says so rather than claiming lockstep. This is one instance of broader drift: 18 of 34 direct dependencies currently resolve to different versions in the two lockfiles.

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG promoted for this release

---
_Generated by [Claude Code](https://claude.ai/code/session_013bX4QBG1kArz5aGs87QFHZ)_