### PR TITLE
fix: show the full Bash command in permission prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Permission prompts show the full Bash command.** The approval prompt used to hard-truncate commands at 100 characters, so anything past the first pipe or `&&` was invisible at the exact moment the user was asked to approve it — the gate could only be rubber-stamped. The prompt now shows the command up to a generous 1500-character cap (a pathological command is still cut so it cannot blow up the prompt post). The 50-character display truncation in the streaming view is unchanged; only the permission prompt is affected.
+
 ## [1.26.0] - 2026-08-20
 
 ### Added

--- a/src/operations/tool-formatters/bash-tools.ts
+++ b/src/operations/tool-formatters/bash-tools.ts
@@ -15,6 +15,10 @@ import { escapeRegExp, escapeCodeBlockContent } from './utils.js';
  * the command up to this cap; anything longer is still cut so a pathological
  * command cannot blow up the prompt post (the platform layer enforces its own
  * overall message-size limits on top).
+ *
+ * The cap counts Unicode code points, not UTF-16 units: an all-astral command
+ * can emit up to twice this many units (~3000), still far under the platform
+ * layer's 16K message split.
  */
 const PERMISSION_COMMAND_MAX = 1500;
 

--- a/src/operations/tool-formatters/bash-tools.ts
+++ b/src/operations/tool-formatters/bash-tools.ts
@@ -9,6 +9,15 @@
 import type { ToolFormatter, ToolFormatResult, ToolInput, ToolFormatOptions } from './types.js';
 import { escapeRegExp } from './utils.js';
 
+/**
+ * The permission prompt is the user's only chance to see what is about to run —
+ * a hard-truncated command turns the approval gate into rubber-stamping. Show
+ * the command up to this cap; anything longer is still cut so a pathological
+ * command cannot blow up the prompt post (the platform layer enforces its own
+ * overall message-size limits on top).
+ */
+const PERMISSION_COMMAND_MAX = 1500;
+
 // ---------------------------------------------------------------------------
 // Bash Formatter
 // ---------------------------------------------------------------------------
@@ -40,7 +49,7 @@ export const bashToolFormatter: ToolFormatter = {
 
     return {
       display: `💻 ${formatter.formatBold('Bash')} ${formatter.formatCode(displayCmd + (truncated ? '...' : ''))}`,
-      permissionText: `💻 ${formatter.formatBold('Bash')} ${formatter.formatCode(cmd.substring(0, 100) + (cmd.length >= 100 ? '...' : ''))}`,
+      permissionText: `💻 ${formatter.formatBold('Bash')} ${formatter.formatCode(cmd.substring(0, PERMISSION_COMMAND_MAX) + (cmd.length > PERMISSION_COMMAND_MAX ? '...' : ''))}`,
       isDestructive: true, // Bash commands can be destructive
     };
   },

--- a/src/operations/tool-formatters/bash-tools.ts
+++ b/src/operations/tool-formatters/bash-tools.ts
@@ -7,7 +7,7 @@
  */
 
 import type { ToolFormatter, ToolFormatResult, ToolInput, ToolFormatOptions } from './types.js';
-import { escapeRegExp } from './utils.js';
+import { escapeRegExp, escapeCodeBlockContent } from './utils.js';
 
 /**
  * The permission prompt is the user's only chance to see what is about to run —
@@ -17,6 +17,17 @@ import { escapeRegExp } from './utils.js';
  * overall message-size limits on top).
  */
 const PERMISSION_COMMAND_MAX = 1500;
+
+/**
+ * Truncate at a Unicode code-point boundary so a cut never lands inside a
+ * surrogate pair (String.prototype.substring counts UTF-16 code units).
+ */
+function truncateAtCodePoint(text: string, max: number): { text: string; truncated: boolean } {
+  if (text.length <= max) return { text, truncated: false };
+  const points = Array.from(text);
+  if (points.length <= max) return { text, truncated: false };
+  return { text: points.slice(0, max).join(''), truncated: true };
+}
 
 // ---------------------------------------------------------------------------
 // Bash Formatter
@@ -47,9 +58,15 @@ export const bashToolFormatter: ToolFormatter = {
     const truncated = cmd.length > maxCommandLength;
     const displayCmd = cmd.substring(0, maxCommandLength);
 
+    // The permission prompt renders the command as a fenced code block: a real
+    // command may contain backticks or newlines, which would break out of an
+    // inline code span and corrupt the prompt (including the reaction legend).
+    const permission = truncateAtCodePoint(cmd, PERMISSION_COMMAND_MAX);
+    const permissionCmd = escapeCodeBlockContent(permission.text) + (permission.truncated ? '\n[... truncated]' : '');
+
     return {
       display: `💻 ${formatter.formatBold('Bash')} ${formatter.formatCode(displayCmd + (truncated ? '...' : ''))}`,
-      permissionText: `💻 ${formatter.formatBold('Bash')} ${formatter.formatCode(cmd.substring(0, PERMISSION_COMMAND_MAX) + (cmd.length > PERMISSION_COMMAND_MAX ? '...' : ''))}`,
+      permissionText: `💻 ${formatter.formatBold('Bash')}\n${formatter.formatCodeBlock(permissionCmd, 'bash')}`,
       isDestructive: true, // Bash commands can be destructive
     };
   },

--- a/src/operations/tool-formatters/tool-formatters.test.ts
+++ b/src/operations/tool-formatters/tool-formatters.test.ts
@@ -301,12 +301,17 @@ describe('Bash Formatter', () => {
   });
 
   it('never cuts inside a surrogate pair when truncating the permission command', () => {
-    const command = '\u{1F600}'.repeat(1600); // astral emoji, 2 UTF-16 units each
+    // The single BMP prefix forces the cut onto an odd UTF-16 index: a naive
+    // substring(0, N) would slice mid-pair and leave a lone high surrogate.
+    const command = 'a' + '\u{1F600}'.repeat(1600); // astral emoji, 2 UTF-16 units each
     const result = bashToolFormatter.format('Bash', { command }, options);
 
     expect(result!.permissionText).toContain('[... truncated]');
-    // A broken surrogate would surface as the replacement char when re-encoded.
-    expect(result!.permissionText!.includes('\uFFFD')).toBe(false);
+    // A mid-pair cut leaves a lone surrogate, making the string ill-formed.
+    // With the /u flag, paired surrogates form a single code point outside
+    // this range, so the class only matches LONE surrogates (equivalent to
+    // !isWellFormed(), which tsconfig's ES2022 target does not know yet).
+    expect(/[\uD800-\uDFFF]/u.test(result!.permissionText!)).toBe(false);
   });
 
   it('shortens worktree paths in commands', () => {

--- a/src/operations/tool-formatters/tool-formatters.test.ts
+++ b/src/operations/tool-formatters/tool-formatters.test.ts
@@ -276,8 +276,28 @@ describe('Bash Formatter', () => {
     const command = 'y'.repeat(5000);
     const result = bashToolFormatter.format('Bash', { command }, options);
 
-    expect(result!.permissionText).toContain('...');
+    expect(result!.permissionText).toContain('[... truncated]');
     expect(result!.permissionText!.length).toBeLessThan(2000);
+  });
+
+  it('renders the permission command as a fenced block so backticks cannot break out', () => {
+    const command = 'echo `whoami` && printf "```"';
+    const result = bashToolFormatter.format('Bash', { command }, options);
+
+    // Triple backticks inside the command are defused; single backticks are
+    // harmless inside a fenced block.
+    expect(result!.permissionText).toContain('```bash');
+    expect(result!.permissionText).not.toContain('printf "```"');
+    expect(result!.permissionText).toContain('echo `whoami`');
+  });
+
+  it('never cuts inside a surrogate pair when truncating the permission command', () => {
+    const command = '\u{1F600}'.repeat(1600); // astral emoji, 2 UTF-16 units each
+    const result = bashToolFormatter.format('Bash', { command }, options);
+
+    expect(result!.permissionText).toContain('[... truncated]');
+    // A broken surrogate would surface as the replacement char when re-encoded.
+    expect(result!.permissionText!.includes('\uFFFD')).toBe(false);
   });
 
   it('shortens worktree paths in commands', () => {

--- a/src/operations/tool-formatters/tool-formatters.test.ts
+++ b/src/operations/tool-formatters/tool-formatters.test.ts
@@ -261,6 +261,25 @@ describe('Bash Formatter', () => {
     expect(result!.display!.length).toBeLessThan(longCommand.length);
   });
 
+  it('shows the full command in the permission prompt (not the 100-char display cut)', () => {
+    // A realistic compound command well over the old 100-char cap: the user
+    // must be able to see the tail (the part that actually matters) before
+    // approving.
+    const command = `npm view claude-threads version 2>/dev/null; echo "---"; ${'x'.repeat(200)}; rm -rf /tmp/scratch`;
+    const result = bashToolFormatter.format('Bash', { command }, options);
+
+    expect(result!.permissionText).toContain(command);
+    expect(result!.permissionText).not.toContain('...');
+  });
+
+  it('still caps a pathological command in the permission prompt', () => {
+    const command = 'y'.repeat(5000);
+    const result = bashToolFormatter.format('Bash', { command }, options);
+
+    expect(result!.permissionText).toContain('...');
+    expect(result!.permissionText!.length).toBeLessThan(2000);
+  });
+
   it('shortens worktree paths in commands', () => {
     const result = bashToolFormatter.format(
       'Bash',

--- a/src/operations/tool-formatters/tool-formatters.test.ts
+++ b/src/operations/tool-formatters/tool-formatters.test.ts
@@ -291,6 +291,15 @@ describe('Bash Formatter', () => {
     expect(result!.permissionText).toContain('echo `whoami`');
   });
 
+  it('defuses arbitrarily long backtick runs (a single pass would recreate a fence)', () => {
+    const command = 'printf "`````" && echo ````';
+    const result = bashToolFormatter.format('Bash', { command }, options);
+
+    // No triple-backtick run may survive inside the fenced block.
+    const inner = result!.permissionText!.split('```bash')[1] ?? '';
+    expect(inner.replace(/```$/, '')).not.toContain('```');
+  });
+
   it('never cuts inside a surrogate pair when truncating the permission command', () => {
     const command = '\u{1F600}'.repeat(1600); // astral emoji, 2 UTF-16 units each
     const result = bashToolFormatter.format('Bash', { command }, options);

--- a/src/operations/tool-formatters/utils.ts
+++ b/src/operations/tool-formatters/utils.ts
@@ -115,5 +115,11 @@ export function truncateWithEllipsis(str: string, maxLength: number): string {
  * @returns Content with escaped backticks
  */
 export function escapeCodeBlockContent(content: string): string {
-  return content.replace(/```/g, '` ``');
+  // A single pass can recreate a fence: '````' -> '` ```'. Repeat until no
+  // triple-backtick run is left — each pass splits runs, so this converges.
+  let result = content;
+  while (result.includes('```')) {
+    result = result.replace(/```/g, '` ``');
+  }
+  return result;
 }


### PR DESCRIPTION
### Problem

The permission prompt hard-truncates Bash commands at 100 characters (display line: 50). Anything past the first pipe or `&&` is invisible at the exact moment the user is asked to approve it:

> ⚠️ **Permission requested**
> 💻 **Bash** `npm view claude-threads version 2>/dev/null; echo "---issues---"; gh search issues --repo anneschuth...`
> 👍 Allow | ✅ Allow all | 👎 Deny

The user approves the *beginning* of a command. The part that matters — what comes after the `...` — is exactly the part they cannot see, so the gate can only be rubber-stamped.

### Change

- The permission prompt renders the command as a fenced ```bash code block, up to a generous 1500-character cap (`PERMISSION_COMMAND_MAX`). A pathological command is still cut (marked `[... truncated]`) so it cannot blow up the prompt post; the platform layer's overall message-size limits still apply on top.
- Fenced rendering also closes an injection surface: a command containing backticks could previously break out of the inline code span and corrupt the prompt, including the reaction legend. `escapeCodeBlockContent` is now convergent (a single pass turned four backticks into a fresh ``` fence; it now repeats until no triple-backtick run remains).
- Truncation cuts at Unicode code-point boundaries, so it can no longer split a surrogate pair.
- The 50-character display truncation in the streaming view is unchanged — only the permission prompt is affected.

### Tests

- full command shown / no ellipsis below the cap
- pathological 5000-char command still capped
- backtick runs (including 5+ backticks) cannot recreate a fence inside the block
- astral-emoji command truncates without producing replacement characters

All verified red-green (each test fails with the fix reverted).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
