### PR TITLE
Release 1.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.25.1] - 2026-08-20
 
 ### Fixed
-- **Keep-alive inhibitors no longer outlive the bot process.** The sleep-prevention child processes are now tied to the bot's lifetime at the OS level: on Linux `systemd-inhibit` runs `cat` on a pipe held by the bot (EOF on bot death releases the lock, even after SIGKILL), on macOS `caffeinate -w <pid>` watches the bot pid natively, and the xdg-screensaver/PowerShell fallbacks poll the parent pid. Previously a hard death of the bot (SIGKILL, crashed test runner) orphaned `systemd-inhibit sleep infinity` processes to init, permanently blocking system sleep/hibernate until they were killed by hand.
+- **Keep-alive inhibitors no longer outlive the bot process.** (#480, thanks @Jadefalkner) The sleep-prevention child processes are now tied to the bot's lifetime at the OS level: on Linux `systemd-inhibit` runs `cat` on a pipe held by the bot (EOF on bot death releases the lock, even after SIGKILL), on macOS `caffeinate -w <pid>` watches the bot pid natively, and the xdg-screensaver/PowerShell fallbacks poll the parent pid. Previously a hard death of the bot (SIGKILL, crashed test runner) orphaned `systemd-inhibit sleep infinity` processes to init, permanently blocking system sleep/hibernate until they were killed by hand.
 
 ## [1.25.0] - 2026-08-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release for the keep-alive inhibitor leak fix (#480). Merging this to `main` triggers `release.yml`, which tags `v1.25.1`, creates the GitHub release, and publishes to npm automatically.

## Changes

- Bump `package.json` (and `package-lock.json`) to 1.25.1 via `npm version patch`; `bun install` run afterwards — `bun.lock` unchanged, as expected (it does not record the root version)
- Promote the CHANGELOG's `## [Unreleased]` heading to `## [1.25.1] - 2026-08-20` and credit #480

## Testing

Version-bump-only change — no code touched. #480 itself went in with CI and Integration Tests green on the merged head, and `release.yml` re-runs the full battery (typecheck/lint/knip/tests/build) before tagging and publishing.

## Checklist

- [x] Tests pass (`bun test`) — validated by CI on this PR and re-run by `release.yml` before publish
- [x] Linting passes (`bun run lint`) — same
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_