### PR TITLE
fix: defensive fallback for sessionAllowedUsers on legacy session resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Permission prompts show the full Bash command.** The approval prompt used to hard-truncate commands at 100 characters, so anything past the first pipe or `&&` was invisible at the exact moment the user was asked to approve it — the gate could only be rubber-stamped. The prompt now shows the command up to a generous 1500-character cap (a pathological command is still cut so it cannot blow up the prompt post). The 50-character display truncation in the streaming view is unchanged; only the permission prompt is affected.
+- **Resuming a legacy persisted session no longer drops the owner from `sessionAllowedUsers`.** (#483) A session persisted before the collaboration list existed restored as an empty set, silently removing the owner from their own session — the one restore site without the defensive `[startedBy]` fallback its siblings already had.
 
 ## [1.26.0] - 2026-08-20
 

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1412,6 +1412,41 @@ describe('resumeSessionHeaderMode', () => {
   });
 });
 
+describe('resumeSession backward compatibility', () => {
+  // Persisted sessions written before sessionAllowedUsers existed lack the
+  // field entirely. Restoring them as an empty set silently drops the owner
+  // from their own session — under `approvals: owner` that locks them out of
+  // every approval gate. The rebuild must fall back to [startedBy], like the
+  // restore sites at resumePausedSession and pause-state reconstruction do.
+  it('restores the owner into sessionAllowedUsers when the persisted field is missing (legacy data)', async () => {
+    const platform = createMockPlatform({
+      getPost: mock(() => Promise.resolve({ id: 'thread-legacy' })) as any,
+    });
+    const ctx = createMockSessionContext(new Map());
+    (ctx.state.platforms as Map<string, PlatformClient>).set('test-platform', platform);
+
+    const legacyState = {
+      threadId: 'thread-legacy',
+      platformId: 'test-platform',
+      claudeSessionId: 'claude-session-legacy',
+      workingDir: process.cwd(),
+      startedBy: 'alice',
+      startedAt: new Date().toISOString(),
+      // no sessionAllowedUsers — the legacy shape under test
+    };
+
+    // emitSessionAdd fires with the rebuilt Session after registration and
+    // before the spawn attempt, so the assertion holds even though
+    // claude.start() fails and rolls the session back in this mock harness.
+    await lifecycle.resumeSession(legacyState as never, ctx);
+
+    const calls = (ctx.ops.emitSessionAdd as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const session = calls[0][0] as Session;
+    expect(session.sessionAllowedUsers.has('alice')).toBe(true);
+  });
+});
+
 describe('userAttribution flag seeding', () => {
   // startSession fails at claude.start() in this mock environment and rolls
   // the session back out of the registry, so assertions read the session from

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -1584,7 +1584,7 @@ async function resumeSessionImpl(
     workingDir: state.workingDir,
     claude,
     planApproved: state.planApproved ?? false,
-    sessionAllowedUsers: new Set(state.sessionAllowedUsers),
+    sessionAllowedUsers: new Set(state.sessionAllowedUsers || [state.startedBy].filter(Boolean)),
     forceInteractivePermissions: state.forceInteractivePermissions ?? false,
     respondOnlyWhenMentioned: state.respondOnlyWhenMentioned ?? false,
     userAttribution,


### PR DESCRIPTION
## Summary

Fixes #483: the resume path's Session rebuild (`lifecycle.ts:1465`) restored `sessionAllowedUsers` without the defensive `[startedBy]` fallback that its two sibling restore sites (lines 1390 and 1752) already have — CLAUDE.md's backward-compatibility rules use this exact field as their example. A session persisted before the collaboration list existed came back with an **empty set**, silently dropping the owner from their own session. Under #478's upcoming `approvals: owner` mode that set becomes a security boundary, so the empty-set failure would lock the owner out of every approval gate in their own resumed session.

## Changes

- One-line fix: `new Set(state.sessionAllowedUsers || [state.startedBy].filter(Boolean))`, matching the line-1752 sibling exactly
- Red-green regression test: resumes a legacy-shaped persisted state (no `sessionAllowedUsers` field) and asserts the owner lands in the rebuilt session's set, captured via `emitSessionAdd` so no CLI spawn is needed
- CHANGELOG entry under `[Unreleased]`

## Testing

- Red check performed: with the fix reverted, exactly the new test fails (1 fail); restored, `lifecycle.test.ts` is 86/86
- Full battery locally: `bun test src/` 2965 pass / 0 fail, `tsc --noEmit` clean, eslint clean

## Checklist

- [x] Tests pass (`bun test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG

**Merge sequencing note:** hold this until #478/#479 land — it touches `lifecycle.ts` and the CHANGELOG's `[Unreleased]` section, and #478 was promised no further rebases; this branch is trivial to rebase afterwards instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_