### PR TITLE
Release 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.27.0] - 2026-08-20
 
 ### Changed
 - **Unit-test infrastructure hardening.** `handler.test.ts` no longer probes the real environment (git child processes, battery readouts are mocked, with a correct pre-mock value-snapshot restore — Bun module namespaces are live bindings, so restoring the namespace would restore the mocks; the same hazard is fixed in the plugin suite's `crossSpawn` restore). The per-test budget on all unit-test entry points is raised to 15s: the 5s default was routinely blown by event-loop contention when several processes compete for the machine, killing millisecond-fast tests at exactly the budget.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Minor release covering today's merge wave. Merging to `main` triggers `release.yml`, which tags `v1.27.0`, creates the GitHub release, and publishes to npm automatically.

## Changes

- Bump `package.json` / `package-lock.json` to 1.27.0 via `npm version minor` (`bun install` run; `bun.lock` unchanged as expected)
- Promote the CHANGELOG's `## [Unreleased]` to `## [1.27.0] - 2026-08-20`, covering:
  - **Direct channel mode** (#478) and **DM auto-discovery** (#479) — the features driving the minor bump
  - Platform-level `approvals` option (#478)
  - Full-command permission prompts (#477)
  - Test-infra deflake (#484)
  - `sessionAllowedUsers` resume fallback (#485, fixes #483)

## Testing

Version-bump-only change — no code touched. Every constituent PR merged with CI + Integration Tests green on its final head, and `release.yml` re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun test`) — validated by CI on this PR and re-run by `release.yml`
- [x] Linting passes (`bun run lint`) — same
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_