### PR TITLE
feat: auditLog — append-only per-platform audit trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Audit trail (`auditLog`)** - Opt-in per platform: an append-only JSONL stream per platform (`~/.claude-threads/audit/`, files `0600` enforced even on pre-existing artifacts, symlink-refusing writer, never deleted by the bot) recording what the bot did — every tool call Claude issued incl. `server_tool_use` and subagent sidechains (with Bash command line / file path / pattern as detail), session lifecycle incl. failure paths with the triggering user, security-relevant `!commands` (`!kill` and paused-session `!stop` included), routine creation, worktree/plugin mutations, and plan approvals with decider. Built for SIEM file ingestion; rotation/retention is the operator's call. Tool-permission allow/deny decisions stay out of scope (they resolve inside the MCP permission server subprocess; the issued request is still recorded).
+
 ## [1.27.0] - 2026-08-20
 
 ### Added

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -205,7 +205,7 @@ The approval set is fixed when the Claude CLI is spawned; a later `!invite` exte
 
 Notes for operators:
 
-- **The bot never deletes audit files.** An audit trail that expires itself is not one — rotation and retention are yours (logrotate, or let your SIEM's file collector ingest and rotate).
+- **The bot never deletes audit files.** An audit trail that expires itself is not one — rotation and retention are yours (logrotate, or let your SIEM's file collector ingest and rotate). The writer holds the file descriptor open across writes, so use **`copytruncate`** (or restart the bot after rotating): a rename-based rotate never errors the cached fd, and the bot would keep appending to the rotated file until restart.
 - **Entries contain command lines verbatim** (that is the point); files are `0600` in a `0700` directory — enforced on every start, including pre-existing files, and the writer refuses symlinked audit paths. Treat the directory with the same care as the thread logs.
 - **Actor attribution is best effort**: the username whose (authorized) message triggered the current turn — resumes are attributed to the resuming user — falling back to the session starter. In fast multi-user threads a tool call can be attributed to the previous sender.
 - **Tool-permission decisions (allow/deny of individual tool calls) are not recorded** — they are resolved inside the MCP permission server subprocess, which the bot process does not observe. Plan approvals and the audited commands cover the decisions that flow through the bot itself.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -132,6 +132,7 @@ stickyMessage:
 | `directChannelMode` | No | Direct channel mode: the whole channel is one session, and the bot replies with top-level channel posts instead of thread replies. `true` for defaults, or an options object (`respondTo`). See [Direct Channel Mode](#direct-channel-mode). |
 | `approvals` | No | Who may answer tool-permission prompts and other reaction gates: `owner` (session participants) or `all_users` (everyone on `allowedUsers`). Unset keeps the historical default per mode — `all_users` for thread sessions, `owner` for direct channel mode. See [Approvals](#approvals). |
 | `ackReaction` | No | Read receipt: react to every accepted message (session start, follow-up, resume) the instant it is accepted, before Claude produces output. `true` uses 👀 (`eyes`), a string names a custom emoji. Persistent, unlike the typing indicator — useful in busy channels and for messages queued behind an in-flight session start. The receipt means *accepted*, not *delivered*: a later failure (capacity limit, Claude not coming up) is still reported by its own post. `!commands` are not acked — they have their own immediate feedback. Note: in direct channel mode this is one reaction API call per accepted message. Default off. |
+| `auditLog` | No | Append-only audit trail of what the bot executed for this platform — tool calls (incl. subagents), session lifecycle, security-relevant commands, plan approvals. One JSONL stream per platform under `~/.claude-threads/audit/` (override: `CLAUDE_THREADS_AUDIT_DIR`), files `0600`. The bot never deletes it — rotation/retention is the operator's job (logrotate, SIEM ingestion). See [Audit log](#audit-log). Default off. |
 | `directMessages` | No | Mattermost only: DM auto-discovery. A direct message from a user on `allowedUsers` spawns a derived direct-channel-mode instance for that DM conversation — no per-DM entry needed. See [DM auto-discovery](#dm-auto-discovery). |
 
 ### Slack
@@ -154,6 +155,7 @@ stickyMessage:
 | `directChannelMode` | No | Direct channel mode: the whole channel is one session, and the bot replies with top-level channel posts instead of thread replies. `true` for defaults, or an options object (`respondTo`). See [Direct Channel Mode](#direct-channel-mode). |
 | `approvals` | No | Who may answer tool-permission prompts and other reaction gates: `owner` (session participants) or `all_users` (everyone on `allowedUsers`). Unset keeps the historical default per mode — `all_users` for thread sessions, `owner` for direct channel mode. See [Approvals](#approvals). |
 | `ackReaction` | No | Read receipt: react to every accepted message (session start, follow-up, resume) the instant it is accepted, before Claude produces output. `true` uses 👀 (`eyes`), a string names a custom emoji. Persistent, unlike the typing indicator — useful in busy channels and for messages queued behind an in-flight session start. The receipt means *accepted*, not *delivered*: a later failure (capacity limit, Claude not coming up) is still reported by its own post. `!commands` are not acked — they have their own immediate feedback. Note: in direct channel mode this is one reaction API call per accepted message. Default off. |
+| `auditLog` | No | Append-only audit trail of what the bot executed for this platform — tool calls (incl. subagents), session lifecycle, security-relevant commands, plan approvals. One JSONL stream per platform under `~/.claude-threads/audit/` (override: `CLAUDE_THREADS_AUDIT_DIR`), files `0600`. The bot never deletes it — rotation/retention is the operator's job (logrotate, SIEM ingestion). See [Audit log](#audit-log). Default off. |
 
 ### Direct Channel Mode
 
@@ -191,6 +193,22 @@ Unset keeps the historical default per mode, so existing setups are unaffected: 
 Under effective `owner` mode the scoping is enforced consistently across every path, so the boundary cannot be talked around: the text alternatives (`!approve`, message-based resume) apply the same participant check as their reaction counterparts, and the owner-gated session commands (`!invite`, `!kick`, `!cd`, `!permissions`, …) additionally require the caller to be a session participant — a platform-allowlisted non-participant can neither approve directly nor `!invite` themselves into the approval set.
 
 The approval set is fixed when the Claude CLI is spawned; a later `!invite` extends message access immediately but reaches the approval set on the next CLI respawn (e.g. via `!cd` or `!permissions`).
+
+### Audit log
+
+`auditLog: true` writes an append-only JSONL stream per platform to `~/.claude-threads/audit/<platformId>.jsonl` (override the directory with `CLAUDE_THREADS_AUDIT_DIR`). One line per event:
+
+- `tool_use` — every tool call Claude **issued** (including `server_tool_use` blocks), with the audit-relevant detail (Bash command line, file path, search pattern); subagent sidechain calls are included and marked `subagent: true`. Note the semantics: the audit records the *request* at the moment Claude emits it — an interactive permission denial can still stop the execution, and the denied attempt is exactly what an auditor wants to see.
+- `session_start` / `session_resume` / `session_end` — lifecycle with the triggering user.
+- `command` — security-relevant `!commands` with actor: `!cd`, `!invite`, `!kick`, `!permissions`, `!stop` (active and paused sessions), `!kill`, `!memory forget`, `!routines` management, routine creation, `!worktree remove`, `!plugin install`/`uninstall`.
+- `plan_approval` — plan approved/denied, by whom, via reaction or `!approve`.
+
+Notes for operators:
+
+- **The bot never deletes audit files.** An audit trail that expires itself is not one — rotation and retention are yours (logrotate, or let your SIEM's file collector ingest and rotate).
+- **Entries contain command lines verbatim** (that is the point); files are `0600` in a `0700` directory — enforced on every start, including pre-existing files, and the writer refuses symlinked audit paths. Treat the directory with the same care as the thread logs.
+- **Actor attribution is best effort**: the username whose (authorized) message triggered the current turn — resumes are attributed to the resuming user — falling back to the session starter. In fast multi-user threads a tool call can be attributed to the previous sender.
+- **Tool-permission decisions (allow/deny of individual tool calls) are not recorded** — they are resolved inside the MCP permission server subprocess, which the bot process does not observe. Plan approvals and the audited commands cover the decisions that flow through the bot itself.
 
 ### Direct messages (DM)
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,6 +29,7 @@ export {
   MEMORY_DISABLED,
   resolveMemoryConfig,
   resolveRoutinesEnabled,
+  resolveAuditLogEnabled,
   LIMITS_DEFAULTS,
   resolveLimits,
   resolvePermissionMode,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -164,6 +164,20 @@ export function resolveRoutinesEnabled(value: unknown, fieldPath?: string): bool
 }
 
 /**
+ * Normalize the per-platform `auditLog` field. Only `true` enables it;
+ * malformed values warn and stay off — an audit trail that half-works is
+ * worse than none, the operator should notice at startup.
+ */
+export function resolveAuditLogEnabled(value: unknown, fieldPath?: string): boolean {
+  if (value === true) return true;
+  if (value === undefined || value === null || value === false) return false;
+  console.warn(
+    `Invalid ${fieldPath ?? 'auditLog'} config: expected boolean, got ${JSON.stringify(value)} — audit log stays off`,
+  );
+  return false;
+}
+
+/**
  * Thread logging configuration
  */
 export interface ThreadLogsConfig {
@@ -375,6 +389,14 @@ export interface PlatformInstanceConfig {
    * `true` uses 👀 (`eyes`); a string names a custom emoji. Default off.
    */
   ackReaction?: boolean | string;
+  /**
+   * Append-only audit trail of what the bot executed for this platform:
+   * tool calls, session lifecycle, security-relevant commands, plan
+   * approvals. One JSONL stream per platform under
+   * `~/.claude-threads/audit/` (override: `CLAUDE_THREADS_AUDIT_DIR`),
+   * never deleted by the bot. Default off.
+   */
+  auditLog?: boolean;
   /**
    * Per-thread session header visibility. Default `'full'`.
    * `'minimal'` keeps only the one-line status bar; `'hidden'` skips the

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   resolvePermissionMode,
   resolveOverheadVisibility,
   resolveMemoryConfig,
+  resolveAuditLogEnabled,
   resolveRoutinesEnabled,
   isOverheadVisibility,
   OVERHEAD_VISIBILITY_VALUES,
@@ -24,6 +25,7 @@ import { runOnboarding } from './onboarding.js';
 import { MattermostClient, SlackClient, type PlatformClient, type PlatformPost, type PlatformUser } from './platform/index.js';
 import { SessionManager } from './session/index.js';
 import { SessionStore } from './persistence/session-store.js';
+import { configureAuditLog } from './persistence/audit-log.js';
 import { checkForUpdates } from './update-notifier.js';
 import { VERSION } from './version.js';
 import { keepAlive } from './utils/keep-alive.js';
@@ -676,6 +678,7 @@ async function startWithoutDaemon() {
     // Create platform client using factory
     const client = createPlatformClient(platformConfig);
     platforms.set(platformConfig.id, client);
+    configureAuditLog(platformConfig.id, resolveAuditLogEnabled(platformConfig.auditLog, `platforms[${platformConfig.id}].auditLog`));
 
     // Register with session manager (passes per-platform overhead visibility)
     session.addPlatform(platformConfig.id, client, {
@@ -719,6 +722,7 @@ async function startWithoutDaemon() {
         platformType: 'mattermost',
         enabled: true,
       });
+      configureAuditLog(dmConfig.id, resolveAuditLogEnabled(dmConfig.auditLog, `dm[${dmConfig.id}].auditLog`));
       session.addPlatform(dmConfig.id, dmClient, {
         sessionHeader: resolveOverheadVisibility(dmConfig.sessionHeader, `dm[${dmConfig.id}].sessionHeader`),
         stickyMessage: 'hidden',

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -2,7 +2,11 @@
  * Tests for message-handler.ts - Core message handling logic
  */
 
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { configureAuditLog, _resetAuditLog } from './persistence/audit-log.js';
 import { handleMessage, type MessageHandlerOptions } from './message-handler.js';
 import type { PlatformClient, PlatformPost, PlatformUser } from './platform/index.js';
 import type { SessionManager } from './session/index.js';
@@ -2052,6 +2056,71 @@ describe('handleMessage', () => {
   });
 });
 
+describe('audit command taps', () => {
+  let auditDir: string;
+  let prevAuditDir: string | undefined;
+
+  beforeEach(() => {
+    auditDir = mkdtempSync(join(tmpdir(), 'ct-audit-mh-'));
+    prevAuditDir = process.env.CLAUDE_THREADS_AUDIT_DIR;
+    process.env.CLAUDE_THREADS_AUDIT_DIR = auditDir;
+    _resetAuditLog();
+  });
+
+  afterEach(() => {
+    if (prevAuditDir === undefined) delete process.env.CLAUDE_THREADS_AUDIT_DIR;
+    else process.env.CLAUDE_THREADS_AUDIT_DIR = prevAuditDir;
+    _resetAuditLog();
+    rmSync(auditDir, { recursive: true, force: true });
+  });
+
+  test('!kill from an authorized user is recorded', async () => {
+    const client = createMockPlatform();
+    const session = createMockSessionManager();
+    const options = { platformId: 'test-platform', logger: { error: mock(() => {}) }, onKill: mock(() => {}) };
+    configureAuditLog('test-platform', true);
+
+    const post: PlatformPost = {
+      id: 'post-kill',
+      platformId: 'test',
+      channelId: 'channel1',
+      userId: 'user1',
+      message: '!kill',
+      rootId: '',
+      createAt: Date.now(),
+    };
+    const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+
+    await handleMessage(client as never, session as never, post, user, options as never);
+
+    const rec = JSON.parse(readFileSync(join(auditDir, 'test-platform.jsonl'), 'utf-8').trim());
+    expect(rec.kind).toBe('command');
+    expect(rec.tool).toBe('kill');
+    expect(rec.actor).toBe('allowed-user');
+  });
+
+  test('!kill from an unauthorized user is not recorded', async () => {
+    const client = createMockPlatform();
+    const session = createMockSessionManager();
+    const options = { platformId: 'test-platform', logger: { error: mock(() => {}) }, onKill: mock(() => {}) };
+    configureAuditLog('test-platform', true);
+
+    const post: PlatformPost = {
+      id: 'post-kill2',
+      platformId: 'test',
+      channelId: 'channel1',
+      userId: 'user1',
+      message: '!kill',
+      rootId: '',
+      createAt: Date.now(),
+    };
+    const user: PlatformUser = { id: 'user1', username: 'outsider', displayName: 'X' };
+
+    await handleMessage(client as never, session as never, post, user, options as never);
+
+    expect(readdirSync(auditDir)).toHaveLength(0);
+  });
+});
 
 describe('direct channel mode (DCM)', () => {
   let client: PlatformClient & { posts: Map<string, string> };

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -19,6 +19,7 @@ import {
 import type { InitialSessionOptions } from './session/types.js';
 import { logSilentError } from './utils/error-handler/index.js';
 import { dcmThreadId, isDcmThreadId, resolveAckReaction, resolveApprovals, resolveDirectChannelMode, type DirectChannelModeConfig } from './platform/utils.js';
+import { auditLog } from './persistence/audit-log.js';
 import { createLogger } from './utils/logger.js';
 
 const ackLog = createLogger('ack');
@@ -104,6 +105,12 @@ export async function handleMessage(
         await client.createPost(`⛔ Only authorized users can use ${formatter.formatCode('!kill')}`, threadRoot);
         return;
       }
+      auditLog(platformId, {
+        threadId: threadRoot,
+        actor: username,
+        kind: 'command',
+        tool: 'kill',
+      });
       // Post confirmation to the channel where !kill was issued
       const activeCount = session.registry.getActiveThreadIds().length;
       try {
@@ -266,6 +273,13 @@ export async function handleMessage(
           if (persistedSession) {
             const allowedUsers = new Set(persistedSession.sessionAllowedUsers);
             if (allowedUsers.has(username) || client.isUserAllowed(username)) {
+              auditLog(platformId, {
+                threadId: threadRoot,
+                actor: username,
+                kind: 'command',
+                tool: 'stop',
+                detail: 'paused session cancelled',
+              });
               session.cancelPausedSession(threadRoot);
               await client.createPost(
                 `🛑 ${formatter.formatBold('Session cancelled')} by ${formatter.formatUserMention(username)}`,

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -41,6 +41,7 @@ import type { PlatformFile } from '../../platform/types.js';
 import { formatBatteryStatus } from '../../utils/battery.js';
 import { formatUptime } from '../../utils/uptime.js';
 import { keepAlive } from '../../utils/keep-alive.js';
+import { auditLog } from '../../persistence/audit-log.js';
 import { logAndNotify } from '../../utils/error-handler/index.js';
 import {
   post,
@@ -182,6 +183,19 @@ export async function restartClaudeSession(
  * Posts warning message if not authorized.
  * Returns true if authorized, false otherwise.
  */
+
+/** Audit a security-relevant command execution (no-op unless enabled). */
+function auditCommand(session: Session, command: string, detail: string | undefined, username: string): void {
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: username,
+    kind: 'command',
+    tool: command,
+    detail,
+  });
+}
+
 async function requireSessionOwner(
   session: Session,
   username: string,
@@ -253,6 +267,7 @@ export async function cancelSession(
   ctx: SessionContext
 ): Promise<void> {
   sessionLog(session).info(`🛑 Cancelled by @${username}`);
+  auditCommand(session, 'stop', undefined, username);
   session.threadLogger?.logCommand('stop', undefined, username);
 
   // Mark as cancelling BEFORE killing to prevent re-persistence in handleExit
@@ -322,6 +337,14 @@ export async function approvePendingPlan(
   }
 
   const { postId } = pendingApproval;
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: username,
+    kind: 'plan_approval',
+    approved: true,
+    detail: 'via !approve',
+  });
   sessionLog(session).info(`✅ Plan approved by @${username} via command`);
 
   // On modern CLIs ExitPlanMode is BLOCKED on the MCP permission prompt with
@@ -458,6 +481,7 @@ export async function changeDirectory(
     : undefined;
   const shortDir = shortenPath(absoluteDir, undefined, worktreeContext);
   sessionLog(session).info(`📂 Changing directory to ${shortDir}`);
+  auditCommand(session, 'cd', absoluteDir, username);
   session.threadLogger?.logCommand('cd', absoluteDir, username);
 
   // Generate summary of previous work before switching directories
@@ -642,6 +666,7 @@ export async function inviteUser(
   session.sessionAllowedUsers.add(invitedUser);
   await post(session, 'success', `${formatter.formatUserMention(invitedUser)} can now participate in this session (invited by ${formatter.formatUserMention(invitedBy)})`);
   sessionLog(session).info(`👋 @${invitedUser} invited by @${invitedBy}`);
+  auditCommand(session, 'invite', invitedUser, invitedBy);
   session.threadLogger?.logCommand('invite', invitedUser, invitedBy);
   await updateSessionHeader(session, ctx);
   // Persist FIRST so a failure in the chat-side notices below doesn't leave
@@ -693,6 +718,7 @@ export async function kickUser(
   if (session.sessionAllowedUsers.delete(kickedUser)) {
     await post(session, 'user', `${formatter.formatUserMention(kickedUser)} removed from this session by ${formatter.formatUserMention(kickedBy)}`);
     sessionLog(session).info(`🚫 @${kickedUser} kicked by @${kickedBy}`);
+    auditCommand(session, 'kick', kickedUser, kickedBy);
     session.threadLogger?.logCommand('kick', kickedUser, kickedBy);
     await updateSessionHeader(session, ctx);
     // Persist FIRST, mirror of inviteUser: a network failure on the
@@ -1008,6 +1034,7 @@ export async function forgetMemory(
       `🧠 Channel memory cleared (${count} ${count === 1 ? 'entry' : 'entries'} removed). Running sessions keep their copy until their next restart.`,
     );
     sessionLog(session).info(`🧠 @${username} cleared channel memory (${count} entries)`);
+    auditCommand(session, 'memory', 'forget all', username);
     session.threadLogger?.logCommand('memory', 'forget all', username);
     return;
   }
@@ -1021,6 +1048,7 @@ export async function forgetMemory(
   if (result.ok) {
     await post(session, 'success', `🧠 Forgot: ${formatter.formatItalic(result.removed.text)}`);
     sessionLog(session).info(`🧠 @${username} removed a channel memory entry`);
+    auditCommand(session, 'memory', 'forget', username);
     session.threadLogger?.logCommand('memory', 'forget', username);
     return;
   }
@@ -1235,6 +1263,7 @@ export async function manageRoutines(
     }
   }
   sessionLog(session).info(`🕘 @${username}: !routines ${lowered} ${indexArg} ("${routine.name}")`);
+  auditCommand(session, 'routines', `${lowered} ${indexArg}`, username);
   session.threadLogger?.logCommand('routines', `${lowered} ${indexArg}`, username);
 }
 
@@ -1270,6 +1299,7 @@ export async function setSessionPermissionMode(
   session.forceInteractivePermissions = mode === 'default';
 
   sessionLog(session).info(`🔐 Setting permission mode to "${mode}"`);
+  auditCommand(session, 'permissions', mode, username);
   session.threadLogger?.logCommand('permissions', mode, username);
 
   // If Claude has never responded (user ran `!permissions` before the first

--- a/src/operations/events/handler.test.ts
+++ b/src/operations/events/handler.test.ts
@@ -6,7 +6,11 @@
  * wrap the MessageManager.
  */
 
-import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { configureAuditLog, _resetAuditLog } from '../../persistence/audit-log.js';
 import {
   handleEventPreProcessing,
   handleEventPostProcessing,
@@ -184,6 +188,78 @@ function createSessionContext(): SessionContext {
     },
   };
 }
+
+describe('handleEventPreProcessing audit tap', () => {
+  let dir: string;
+  let prevDir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ct-audit-tap-'));
+    prevDir = process.env.CLAUDE_THREADS_AUDIT_DIR;
+    process.env.CLAUDE_THREADS_AUDIT_DIR = dir;
+    _resetAuditLog();
+  });
+
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CLAUDE_THREADS_AUDIT_DIR;
+    else process.env.CLAUDE_THREADS_AUDIT_DIR = prevDir;
+    _resetAuditLog();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('records tool_use blocks from assistant events when enabled', () => {
+    const platform = createMockPlatform();
+    const session = createTestSession(platform);
+    const ctx = createSessionContext();
+    configureAuditLog(session.platformId, true);
+
+    handleEventPreProcessing(session, {
+      type: 'assistant',
+      message: { content: [
+        { type: 'text', text: 'running' },
+        { type: 'tool_use', name: 'Bash', input: { command: 'ls -la' } },
+      ] },
+    } as never, ctx);
+
+    const lines = readFileSync(join(dir, `${session.platformId}.jsonl`), 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const rec = JSON.parse(lines[0]);
+    expect(rec.kind).toBe('tool_use');
+    expect(rec.tool).toBe('Bash');
+    expect(rec.detail).toBe('ls -la');
+    expect(rec.actor).toBe(session.startedBy);
+    expect(rec.subagent).toBeUndefined();
+  });
+
+  test('marks subagent sidechain tool calls', () => {
+    const platform = createMockPlatform();
+    const session = createTestSession(platform);
+    const ctx = createSessionContext();
+    configureAuditLog(session.platformId, true);
+
+    handleEventPreProcessing(session, {
+      type: 'assistant',
+      parent_tool_use_id: 'toolu_parent',
+      message: { content: [{ type: 'tool_use', name: 'Read', input: { file_path: '/x' } }] },
+    } as never, ctx);
+
+    const rec = JSON.parse(readFileSync(join(dir, `${session.platformId}.jsonl`), 'utf-8').trim());
+    expect(rec.subagent).toBe(true);
+  });
+
+  test('writes nothing when the platform is not enabled', () => {
+    const platform = createMockPlatform();
+    const session = createTestSession(platform);
+    const ctx = createSessionContext();
+
+    handleEventPreProcessing(session, {
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'Bash', input: { command: 'ls' } }] },
+    } as never, ctx);
+
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+});
 
 describe('handleEventPreProcessing', () => {
   let platform: PlatformClient;

--- a/src/operations/events/handler.ts
+++ b/src/operations/events/handler.ts
@@ -178,32 +178,38 @@ export function handleEventPreProcessing(
 
   // Audit trail (opt-in per platform): record every tool call, including
   // subagent sidechains — an auditor wants the full execution record even
-  // when the thread display skips it.
-  if (isAuditEnabled(session.platformId)) {
-    const subagent = isSidechainEvent(event) || undefined;
-    const record = (name: string, input: Record<string, unknown> | undefined) =>
-      auditLog(session.platformId, {
-        threadId: session.threadId,
-        sessionId: session.sessionId,
-        actor: session.lastActorUsername ?? session.startedBy,
-        kind: 'tool_use',
-        tool: name,
-        detail: auditDetailForTool(name, input),
-        subagent,
-      });
-    if (event.type === 'assistant') {
-      const msg = event.message as { content?: Array<{ type: string; name?: string; input?: Record<string, unknown> }> };
-      if (Array.isArray(msg?.content)) {
-        for (const block of msg.content) {
-          if ((block.type === 'tool_use' || block.type === 'server_tool_use') && block.name) {
-            record(block.name, block.input);
+  // when the thread display skips it. The whole tap is wrapped so a
+  // pathological event shape can never throw past it and skip message
+  // handling — auditing must never take the message path down.
+  try {
+    if (isAuditEnabled(session.platformId)) {
+      const subagent = isSidechainEvent(event) || undefined;
+      const record = (name: string, input: Record<string, unknown> | undefined) =>
+        auditLog(session.platformId, {
+          threadId: session.threadId,
+          sessionId: session.sessionId,
+          actor: session.lastActorUsername ?? session.startedBy,
+          kind: 'tool_use',
+          tool: name,
+          detail: auditDetailForTool(name, input),
+          subagent,
+        });
+      if (event.type === 'assistant') {
+        const msg = event.message as { content?: Array<{ type: string; name?: string; input?: Record<string, unknown> }> };
+        if (Array.isArray(msg?.content)) {
+          for (const block of msg.content) {
+            if ((block.type === 'tool_use' || block.type === 'server_tool_use') && block.name) {
+              record(block.name, block.input);
+            }
           }
         }
+      } else if (event.type === 'tool_use') {
+        const tool = event.tool_use as { name: string; input?: Record<string, unknown> };
+        if (tool?.name) record(tool.name, tool.input);
       }
-    } else if (event.type === 'tool_use') {
-      const tool = event.tool_use as { name: string; input?: Record<string, unknown> };
-      if (tool?.name) record(tool.name, tool.input);
     }
+  } catch {
+    // Swallowed by design — see the comment above.
   }
 
   // Reset activity and clear timeout tracking (prevents updating stale posts in long threads)

--- a/src/operations/events/handler.ts
+++ b/src/operations/events/handler.ts
@@ -16,6 +16,7 @@ import { withErrorHandling } from '../../utils/error-handler/index.js';
 import { resetSessionActivity, post, postError, updatePost } from '../post-helpers/index.js';
 import type { SessionContext } from '../session-context/index.js';
 import { createLogger } from '../../utils/logger.js';
+import { auditDetailForTool, auditLog, isAuditEnabled } from '../../persistence/audit-log.js';
 import { createSessionLog } from '../../utils/session-log.js';
 import { extractPullRequestUrl } from '../../utils/pr-detector.js';
 import { changeDirectory, reportBug } from '../commands/index.js';
@@ -174,6 +175,36 @@ export function handleEventPreProcessing(
 ): void {
   // Log raw event to thread logger (first thing, before any processing)
   session.threadLogger?.logEvent(event);
+
+  // Audit trail (opt-in per platform): record every tool call, including
+  // subagent sidechains — an auditor wants the full execution record even
+  // when the thread display skips it.
+  if (isAuditEnabled(session.platformId)) {
+    const subagent = isSidechainEvent(event) || undefined;
+    const record = (name: string, input: Record<string, unknown> | undefined) =>
+      auditLog(session.platformId, {
+        threadId: session.threadId,
+        sessionId: session.sessionId,
+        actor: session.lastActorUsername ?? session.startedBy,
+        kind: 'tool_use',
+        tool: name,
+        detail: auditDetailForTool(name, input),
+        subagent,
+      });
+    if (event.type === 'assistant') {
+      const msg = event.message as { content?: Array<{ type: string; name?: string; input?: Record<string, unknown> }> };
+      if (Array.isArray(msg?.content)) {
+        for (const block of msg.content) {
+          if ((block.type === 'tool_use' || block.type === 'server_tool_use') && block.name) {
+            record(block.name, block.input);
+          }
+        }
+      }
+    } else if (event.type === 'tool_use') {
+      const tool = event.tool_use as { name: string; input?: Record<string, unknown> };
+      if (tool?.name) record(tool.name, tool.input);
+    }
+  }
 
   // Reset activity and clear timeout tracking (prevents updating stale posts in long threads)
   resetSessionActivity(session);

--- a/src/operations/executors/question-approval.ts
+++ b/src/operations/executors/question-approval.ts
@@ -9,6 +9,7 @@
  */
 
 import { NUMBER_EMOJIS, APPROVAL_EMOJIS, DENIAL_EMOJIS, isApprovalEmoji, isDenialEmoji, getNumberEmojiIndex } from '../../utils/emoji.js';
+import { auditLog } from '../../persistence/audit-log.js';
 import { formatShortId } from '../../utils/format.js';
 import type { QuestionOp, ApprovalOp } from '../types.js';
 import type { ExecutorContext, QuestionApprovalState } from './types.js';
@@ -413,14 +414,28 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
 
     // Check pending approval
     if (this.state.pendingApproval?.postId === postId) {
+      const approvalType = this.state.pendingApproval.type;
+      const auditDecision = (approved: boolean) => {
+        if (approvalType !== 'plan') return;
+        auditLog(ctx.platform.platformId, {
+          threadId: ctx.threadId,
+          sessionId: ctx.sessionId,
+          actor: user,
+          kind: 'plan_approval',
+          approved,
+          detail: 'via reaction',
+        });
+      };
       if (isApprovalEmoji(emoji)) {
         ctx.logger.debug(`Approval reaction from @${user}: approved`);
+        auditDecision(true);
         const handled = await this.handleApprovalResponse(postId, true, ctx);
         ctx.logger.debug(`QuestionApprovalExecutor: approval outcome=approved, handled=${handled}`);
         return handled;
       }
       if (isDenialEmoji(emoji)) {
         ctx.logger.debug(`Approval reaction from @${user}: denied`);
+        auditDecision(false);
         const handled = await this.handleApprovalResponse(postId, false, ctx);
         ctx.logger.debug(`QuestionApprovalExecutor: approval outcome=denied, handled=${handled}`);
         return handled;

--- a/src/operations/plugin/handler.ts
+++ b/src/operations/plugin/handler.ts
@@ -6,6 +6,7 @@
  */
 
 import { crossSpawn } from '../../utils/spawn.js';
+import { auditLog } from '../../persistence/audit-log.js';
 import type { Session } from '../../session/types.js';
 import type { SessionContext } from '../session-context/index.js';
 import type { ClaudeCliOptions } from '../../claude/cli.js';
@@ -168,6 +169,14 @@ export async function handlePluginInstall(
 
   await post(session, 'info', `📦 Installing plugin: ${formatter.formatCode(pluginName)}...`);
   sessionLog(session).info(`Installing plugin: ${pluginName} (requested by @${username})`);
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: username,
+    kind: 'command',
+    tool: 'plugin install',
+    detail: pluginName,
+  });
   session.threadLogger?.logCommand('plugin install', pluginName, username);
 
   const result = await runPluginCommand(['install', pluginName], session.workingDir);
@@ -215,6 +224,14 @@ export async function handlePluginUninstall(
 
   await post(session, 'info', `🗑️ Uninstalling plugin: ${formatter.formatCode(pluginName)}...`);
   sessionLog(session).info(`Uninstalling plugin: ${pluginName} (requested by @${username})`);
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: username,
+    kind: 'command',
+    tool: 'plugin uninstall',
+    detail: pluginName,
+  });
   session.threadLogger?.logCommand('plugin uninstall', pluginName, username);
 
   const result = await runPluginCommand(['uninstall', pluginName], session.workingDir);

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Session } from '../../session/types.js';
+import { auditLog } from '../../persistence/audit-log.js';
 import { transitionTo, isSessionRestarting } from '../../session/types.js';
 import type { WorktreeMode, PermissionMode, ResolvedMemoryConfig } from '../../config/index.js';
 import { effectivePermissionMode } from '../../config/index.js';
@@ -1019,6 +1020,14 @@ export async function removeWorktreeCommand(
 
   try {
     await removeGitWorktree(repoRoot, target.path);
+    auditLog(session.platformId, {
+      threadId: session.threadId,
+      sessionId: session.sessionId,
+      actor: username,
+      kind: 'command',
+      tool: 'worktree remove',
+      detail: target.path,
+    });
 
     const shortPath = shortenPath(target.path, undefined, { path: target.path, branch: target.branch });
     await post(session, 'success', `Removed worktree \`${target.branch}\` at \`${shortPath}\``);

--- a/src/persistence/audit-log.test.ts
+++ b/src/persistence/audit-log.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  configureAuditLog,
+  isAuditEnabled,
+  auditLog,
+  auditDetailForTool,
+  _resetAuditLog,
+} from './audit-log.js';
+
+describe('audit log', () => {
+  let dir: string;
+  let prevDir: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ct-audit-test-'));
+    prevDir = process.env.CLAUDE_THREADS_AUDIT_DIR;
+    process.env.CLAUDE_THREADS_AUDIT_DIR = dir;
+    _resetAuditLog();
+  });
+
+  afterEach(() => {
+    if (prevDir === undefined) delete process.env.CLAUDE_THREADS_AUDIT_DIR;
+    else process.env.CLAUDE_THREADS_AUDIT_DIR = prevDir;
+    _resetAuditLog();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const entry = () => ({
+    threadId: 'thread-1',
+    sessionId: 'p1:thread-1',
+    actor: 'alice',
+    kind: 'tool_use' as const,
+    tool: 'Bash',
+    detail: 'ls -la',
+  });
+
+  it('writes nothing for platforms that are not configured', () => {
+    auditLog('p1', entry());
+    expect(readdirSync(dir)).toHaveLength(0);
+  });
+
+  it('appends JSONL entries with timestamp and platform id', () => {
+    configureAuditLog('p1', true);
+    auditLog('p1', entry());
+    auditLog('p1', { ...entry(), tool: 'Edit', detail: '/etc/passwd' });
+
+    const lines = readFileSync(join(dir, 'p1.jsonl'), 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first.platformId).toBe('p1');
+    expect(first.actor).toBe('alice');
+    expect(first.tool).toBe('Bash');
+    expect(first.detail).toBe('ls -la');
+    expect(new Date(first.ts).getTime()).toBeGreaterThan(0);
+  });
+
+  it('creates the audit file with owner-only permissions', () => {
+    configureAuditLog('p1', true);
+    auditLog('p1', entry());
+    expect(statSync(join(dir, 'p1.jsonl')).mode & 0o777).toBe(0o600);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  it('caps oversized details', () => {
+    configureAuditLog('p1', true);
+    auditLog('p1', { ...entry(), detail: 'x'.repeat(2000) });
+    const line = JSON.parse(readFileSync(join(dir, 'p1.jsonl'), 'utf-8').trim());
+    expect(line.detail).toHaveLength(500);
+  });
+
+  it('encodes platform ids collision-free for filenames', () => {
+    configureAuditLog('a/b', true);
+    configureAuditLog('a_b', true);
+    auditLog('a/b', entry());
+    auditLog('a_b', entry());
+    expect(readdirSync(dir).sort()).toEqual(['a%2Fb.jsonl', 'a_b.jsonl']);
+  });
+
+  it('refuses to write through a symlinked audit file', () => {
+    configureAuditLog('p1', true);
+    const victim = join(dir, 'victim.txt');
+    writeFileSync(victim, 'do not touch');
+    mkdirSync(join(dir), { recursive: true });
+    symlinkSync(victim, join(dir, 'p1.jsonl'));
+
+    auditLog('p1', entry());
+
+    expect(readFileSync(victim, 'utf-8')).toBe('do not touch');
+  });
+
+  it('re-tightens permissions on pre-existing files and directories', () => {
+    configureAuditLog('p1', true);
+    // Simulate a leftover world-readable file + dir from a sloppy restore.
+    writeFileSync(join(dir, 'p1.jsonl'), '', { mode: 0o644 });
+    chmodSync(join(dir, 'p1.jsonl'), 0o644);
+    chmodSync(dir, 0o755);
+
+    auditLog('p1', entry());
+
+    expect(statSync(join(dir, 'p1.jsonl')).mode & 0o777).toBe(0o600);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  it('configure(false) disables a previously enabled platform', () => {
+    configureAuditLog('p1', true);
+    expect(isAuditEnabled('p1')).toBe(true);
+    configureAuditLog('p1', false);
+    expect(isAuditEnabled('p1')).toBe(false);
+  });
+});
+
+describe('auditDetailForTool', () => {
+  it('extracts the audit-relevant field per tool', () => {
+    expect(auditDetailForTool('Bash', { command: 'rm -rf /tmp/x' })).toBe('rm -rf /tmp/x');
+    expect(auditDetailForTool('Edit', { file_path: '/a/b.ts' })).toBe('/a/b.ts');
+    expect(auditDetailForTool('Grep', { pattern: 'secret' })).toBe('secret');
+    expect(auditDetailForTool('WebFetch', { url: 'https://x.test' })).toBe('https://x.test');
+  });
+
+  it('falls back to compact JSON for unknown tools and handles absence', () => {
+    expect(auditDetailForTool('CustomTool', { a: 1 })).toBe('{"a":1}');
+    expect(auditDetailForTool('Bash', undefined)).toBeUndefined();
+  });
+});

--- a/src/persistence/audit-log.ts
+++ b/src/persistence/audit-log.ts
@@ -1,0 +1,184 @@
+/**
+ * Audit Log
+ *
+ * Append-only, per-platform JSONL record of what the bot actually executed:
+ * tool calls, session lifecycle, security-relevant commands, plan approvals.
+ *
+ * Distinct from thread logs (per-thread debug artifacts with retention): the
+ * audit trail is one flat stream per platform, spans sessions, and is NEVER
+ * deleted by the bot — rotation/retention is the operator's call (logrotate,
+ * SIEM ingestion). Files are 0600 in a 0700 directory; entries may contain
+ * command lines verbatim, which is the point of an audit trail and the same
+ * confidentiality level as thread logs.
+ *
+ * Opt-in per platform via `auditLog: true`. Disabled platforms pay one map
+ * lookup per call.
+ */
+
+import { chmodSync, closeSync, constants as fsConstants, fchmodSync, lstatSync, mkdirSync, openSync, writeSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { createLogger } from '../utils/logger.js';
+
+const log = createLogger('audit');
+
+export type AuditKind =
+  | 'tool_use'
+  | 'session_start'
+  | 'session_resume'
+  | 'session_end'
+  | 'command'
+  | 'plan_approval';
+
+export interface AuditEntry {
+  ts: string;
+  platformId: string;
+  threadId: string;
+  sessionId?: string;
+  /** Username that triggered the audited action (best effort; see docs). */
+  actor?: string;
+  kind: AuditKind;
+  /** Tool name for kind 'tool_use'. */
+  tool?: string;
+  /** Compact human-relevant detail: command line, file path, pattern, ... */
+  detail?: string;
+  /** True when the tool call ran inside a subagent sidechain. */
+  subagent?: boolean;
+  /** For 'plan_approval': whether the plan was approved. */
+  approved?: boolean;
+}
+
+/** Cap per-entry detail so a pathological command can't bloat the trail. */
+const DETAIL_MAX = 500;
+
+const enabledPlatforms = new Set<string>();
+const preparedDirs = new Set<string>();
+// One long-lived fd per platform file: avoids per-write open/close and lets
+// us enforce modes once, including on pre-existing files.
+const openFds = new Map<string, number>();
+
+function auditDir(): string {
+  return process.env.CLAUDE_THREADS_AUDIT_DIR || join(homedir(), '.claude-threads', 'audit');
+}
+
+/** Enable/disable the audit trail for a platform (called at registration). */
+export function configureAuditLog(platformId: string, enabled: boolean): void {
+  if (enabled) enabledPlatforms.add(platformId);
+  else enabledPlatforms.delete(platformId);
+}
+
+export function isAuditEnabled(platformId: string): boolean {
+  return enabledPlatforms.has(platformId);
+}
+
+/** Test hook: clear all configured platforms and close cached files. */
+export function _resetAuditLog(): void {
+  enabledPlatforms.clear();
+  preparedDirs.clear();
+  for (const fd of openFds.values()) {
+    try { closeSync(fd); } catch { /* already closed */ }
+  }
+  openFds.clear();
+}
+
+/**
+ * Open (once) the platform's audit file with hardening that also covers
+ * PRE-EXISTING artifacts: refuse symlinks and non-regular files, open with
+ * O_NOFOLLOW where the platform supports it, and enforce 0600 via fchmod —
+ * `mkdir`/`open` modes only apply at creation and would silently reuse a
+ * world-readable leftover otherwise.
+ */
+function openAuditFd(platformId: string): number {
+  const cached = openFds.get(platformId);
+  if (cached !== undefined) return cached;
+
+  const dir = auditDir();
+  if (!preparedDirs.has(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    chmodSync(dir, 0o700);
+    preparedDirs.add(dir);
+  }
+  // encodeURIComponent is filename-safe and collision-free (unlike lossy
+  // separator replacement); platform ids are operator-controlled config.
+  const file = join(dir, `${encodeURIComponent(platformId)}.jsonl`);
+  try {
+    const st = lstatSync(file);
+    if (st.isSymbolicLink() || !st.isFile()) {
+      throw new Error(`audit path exists but is not a regular file: ${file}`);
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  const noFollow = typeof fsConstants.O_NOFOLLOW === 'number' ? fsConstants.O_NOFOLLOW : 0;
+  const fd = openSync(file, fsConstants.O_WRONLY | fsConstants.O_APPEND | fsConstants.O_CREAT | noFollow, 0o600);
+  try {
+    fchmodSync(fd, 0o600);
+  } catch {
+    // Windows: fchmod is a no-op territory; POSIX platforms enforce.
+  }
+  openFds.set(platformId, fd);
+  return fd;
+}
+
+/**
+ * Append one entry to the platform's audit file. Failures are logged and
+ * swallowed: auditing must never take message handling down. Writes are
+ * synchronous appends on a cached fd — a write is one `write(2)` on an
+ * already-open descriptor (microseconds), and a buffered trail that loses
+ * its tail on crash defeats the purpose of an audit log.
+ */
+export function auditLog(
+  platformId: string,
+  entry: Omit<AuditEntry, 'ts' | 'platformId'>
+): void {
+  if (!enabledPlatforms.has(platformId)) return;
+  try {
+    const full: AuditEntry = {
+      ts: new Date().toISOString(),
+      platformId,
+      ...entry,
+      ...(entry.detail !== undefined ? { detail: entry.detail.slice(0, DETAIL_MAX) } : {}),
+    };
+    writeSync(openAuditFd(platformId), JSON.stringify(full) + '\n');
+  } catch (err) {
+    // Drop the cached fd so the next write retries a fresh open (the file may
+    // have been rotated away underneath us).
+    const fd = openFds.get(platformId);
+    if (fd !== undefined) {
+      openFds.delete(platformId);
+      try { closeSync(fd); } catch { /* already closed */ }
+    }
+    log.warn(`audit write failed for ${platformId}: ${err}`);
+  }
+}
+
+/**
+ * Compact, audit-relevant detail for a tool call. Mirrors what a reviewer
+ * actually asks: which command, which file, which pattern.
+ */
+export function auditDetailForTool(tool: string, input: Record<string, unknown> | undefined): string | undefined {
+  if (!input) return undefined;
+  const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined);
+  switch (tool) {
+    case 'Bash':
+      return str(input.command);
+    case 'Edit':
+    case 'Write':
+    case 'Read':
+    case 'NotebookEdit':
+      return str(input.file_path);
+    case 'Grep':
+    case 'Glob':
+      return str(input.pattern);
+    case 'WebFetch':
+    case 'WebSearch':
+      return str(input.url) ?? str(input.query);
+    default: {
+      try {
+        return JSON.stringify(input);
+      } catch {
+        return undefined;
+      }
+    }
+  }
+}

--- a/src/platform/dm-discovery-runtime.ts
+++ b/src/platform/dm-discovery-runtime.ts
@@ -12,6 +12,7 @@
  */
 
 import type { MattermostPlatformConfig, PlatformInstanceConfig } from '../config/types.js';
+import { configureAuditLog } from '../persistence/audit-log.js';
 import type { PlatformClient, PlatformPost, PlatformUser } from './index.js';
 import type { SessionManager } from '../session/index.js';
 import type { PersistedSession } from '../persistence/session-store.js';
@@ -130,6 +131,7 @@ export function createDmDiscoveryRuntime(deps: DmDiscoveryDeps): DmDiscoveryRunt
     platforms.delete(dmId);
     session.removePlatform(dmId);
     if (client) void Promise.resolve(client.disconnect()).catch(() => {});
+    configureAuditLog(dmId, false);
     // Drop the UI row — except for disabled instances, whose row is the only
     // handle to re-enable them.
     if (deps.isEnabled?.(dmId) !== false) deps.removeUiRow?.(dmId);

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import * as lifecycle from './lifecycle.js';
 import type { SessionContext } from '../operations/session-context/index.js';
@@ -7,6 +9,7 @@ import type { Session } from './types.js';
 import { createSessionTimers, createSessionLifecycle, createResumedLifecycle } from './types.js';
 import type { PlatformClient } from '../platform/index.js';
 import { createMockFormatter } from '../test-utils/mock-formatter.js';
+import { configureAuditLog, _resetAuditLog } from '../persistence/audit-log.js';
 
 // =============================================================================
 // Test Utilities
@@ -1872,5 +1875,165 @@ describe('_inFlightSessionStarts (start dedup and retry hand-off)', () => {
       'User Name'
     );
     lifecycle._inFlightSessionStarts.delete(session.sessionId);
+  });
+});
+
+// =============================================================================
+// Session-end audit causes — regression tests
+// =============================================================================
+// closeThreadLogger runs before removeFromRegistry on every teardown path, and
+// auditSessionEnd's exactly-once guard makes the first writer win. Without the
+// auditReason override the trail recorded the generic logger action ('kill',
+// 'exit') and the precise cause ('timeout', 'exit:<code>', 'pause') was
+// unreachable — exactly the distinction an audit log exists for.
+
+describe('session end audit causes', () => {
+  let auditDir: string;
+  let prevAuditDir: string | undefined;
+
+  beforeEach(() => {
+    auditDir = mkdtempSync(join(tmpdir(), 'ct-audit-lc-'));
+    prevAuditDir = process.env.CLAUDE_THREADS_AUDIT_DIR;
+    process.env.CLAUDE_THREADS_AUDIT_DIR = auditDir;
+    _resetAuditLog();
+    configureAuditLog('test-platform', true);
+  });
+
+  afterEach(() => {
+    if (prevAuditDir === undefined) delete process.env.CLAUDE_THREADS_AUDIT_DIR;
+    else process.env.CLAUDE_THREADS_AUDIT_DIR = prevAuditDir;
+    _resetAuditLog();
+    rmSync(auditDir, { recursive: true, force: true });
+  });
+
+  /** All session_end entries — every test asserts exactly one is recorded. */
+  function sessionEndEntries(): Array<{ kind: string; detail?: string }> {
+    const file = join(auditDir, 'test-platform.jsonl');
+    if (!existsSync(file)) return [];
+    return readFileSync(file, 'utf-8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line))
+      .filter(entry => entry.kind === 'session_end');
+  }
+
+  function expectSingleEndCause(detail: string): void {
+    const ends = sessionEndEntries();
+    expect(ends).toHaveLength(1);
+    expect(ends[0].detail).toBe(detail);
+  }
+
+  /** An 'active' session as production creates it once Claude responded. */
+  function activeSession(overrides?: Parameters<typeof createMockSession>[0]) {
+    return createMockSession({
+      platformId: 'test-platform',
+      lifecycle: { state: 'active', resumeFailCount: 0, hasClaudeResponded: true },
+      claude: {
+        isRunning: mock(() => true),
+        kill: mock(() => Promise.resolve()),
+        start: mock(() => {}),
+        sendMessage: mock(() => {}),
+        on: mock(() => {}),
+        interrupt: mock(() => {}),
+        isPermanentFailure: mock(() => false),
+        getPermanentFailureReason: mock(() => undefined),
+      } as any,
+      ...overrides,
+    });
+  }
+
+  it('idle timeout records "timeout", not the generic "kill"', async () => {
+    const session = activeSession({ lastActivityAt: new Date(Date.now() - 10_000) });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.cleanupIdleSessions(1_000, 500, ctx);
+
+    expectSingleEndCause('timeout');
+  });
+
+  it('a non-zero exit of an active session records the exit code', async () => {
+    const session = activeSession();
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit('test-platform:thread-123', 2, ctx);
+
+    expectSingleEndCause('exit:2');
+  });
+
+  it('a clean exit of an active session records plain "exit"', async () => {
+    const session = activeSession();
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit('test-platform:thread-123', 0, ctx);
+
+    expectSingleEndCause('exit');
+  });
+
+  it('a signal death (code null) records plain "exit", not "exit:null"', async () => {
+    const session = activeSession();
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit('test-platform:thread-123', null as unknown as number, ctx);
+
+    expectSingleEndCause('exit');
+  });
+
+  it('a user kill still records "kill"', async () => {
+    const session = createMockSession({ platformId: 'test-platform' });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.killSession(session, true, ctx);
+
+    expectSingleEndCause('kill');
+  });
+
+  it('an interrupt-pause records "pause"', async () => {
+    const session = createMockSession({
+      platformId: 'test-platform',
+      wasInterrupted: true,
+      hasClaudeResponded: true,
+    });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit('test-platform:thread-123', 0, ctx);
+
+    expectSingleEndCause('pause');
+  });
+
+  it('a graceful shutdown records "shutdown", not "exit"', async () => {
+    const session = activeSession();
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+    (ctx.state as { isShuttingDown: boolean }).isShuttingDown = true;
+
+    await lifecycle.handleExit('test-platform:thread-123', 0, ctx);
+
+    expectSingleEndCause('shutdown');
+  });
+
+  it('an exit before Claude responded records "early-exit"', async () => {
+    const session = createMockSession({ platformId: 'test-platform' });
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.handleExit('test-platform:thread-123', 1, ctx);
+
+    expectSingleEndCause('early-exit');
+  });
+
+  it('emergency killAllSessions records "kill" per session', async () => {
+    const session = activeSession();
+    const sessions = new Map([['test-platform:thread-123', session]]);
+    const ctx = createMockSessionContext(sessions);
+
+    await lifecycle.killAllSessions(ctx);
+
+    expectSingleEndCause('kill');
   });
 });

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -132,9 +132,12 @@ function auditSessionEnd(session: Session, reason: string): void {
   });
 }
 
-async function closeThreadLogger(session: Session, action?: string, details?: Record<string, unknown>): Promise<void> {
-  if (action) {
-    auditSessionEnd(session, action);
+async function closeThreadLogger(session: Session, action?: string, details?: Record<string, unknown>, auditReason?: string): Promise<void> {
+  // The audit reason can be more specific than the logger action (e.g. action
+  // 'kill' with reason 'timeout') — without the override, the exactly-once
+  // guard makes this first write win and the precise cause is lost.
+  if (auditReason ?? action) {
+    auditSessionEnd(session, (auditReason ?? action) as string);
   }
   if (session.threadLogger) {
     // Log the lifecycle event before closing
@@ -184,6 +187,8 @@ interface CleanupSessionOptions {
   closeLogger?: boolean;
   /** Whether to clean up post index entries (default: true) */
   cleanupPostIndex?: boolean;
+  /** Audit-trail cause when it is more specific than `action` (e.g. 'shutdown') */
+  auditReason?: string;
 }
 
 /**
@@ -206,14 +211,15 @@ async function cleanupSession(
     details,
     closeLogger: doCloseLogger = true,
     cleanupPostIndex: doCleanupPostIndex = true,
+    auditReason,
   } = options;
 
   ctx.ops.stopTyping(session);
   cleanupSessionTimers(session);
   if (doCloseLogger) {
-    await closeThreadLogger(session, action, details);
-  } else if (action) {
-    auditSessionEnd(session, action);
+    await closeThreadLogger(session, action, details, auditReason);
+  } else if (auditReason ?? action) {
+    auditSessionEnd(session, (auditReason ?? action) as string);
   }
   session.messageManager?.dispose();
   void session.decisionBridge?.close();
@@ -2015,6 +2021,7 @@ export async function handleExit(
       action: 'exit',
       details: { reason: 'shutdown', exitCode: code },
       cleanupPostIndex: false,  // Preserve for faster shutdown
+      auditReason: 'shutdown',
     });
     return;
   }
@@ -2024,7 +2031,7 @@ export async function handleExit(
     sessionLog(session).debug(`Exited after interrupt, preserving for resume`);
     ctx.ops.stopTyping(session);
     cleanupSessionTimers(session);
-    await closeThreadLogger(session, 'interrupt', { exitCode: code });
+    await closeThreadLogger(session, 'interrupt', { exitCode: code }, 'pause');
 
     // Notify user first, then persist with the lifecyclePostId
     // This ensures the session won't auto-resume on bot restart
@@ -2060,6 +2067,7 @@ export async function handleExit(
     await cleanupSession(session, ctx, {
       action: 'exit',
       details: { reason: 'early_exit', exitCode: code },
+      auditReason: 'early-exit',
     });
     // Notify user (session object still valid, just removed from map)
     const earlyExitFormatter = session.platform.getFormatter();
@@ -2084,7 +2092,11 @@ export async function handleExit(
     sessionLog(session).debug(`Resumed session failed with code ${code}, attempt ${session.lifecycle.resumeFailCount}/${MAX_RESUME_FAILURES}, permanent=${isPermanent}`);
     // Skip closeLogger (session is already persisted, logger may be closed)
     // Skip cleanupPostIndex (was already cleaned on original session end)
-    auditSessionEnd(session, `resume-exit:${code}`);
+    // Every non-starting session lands here on a non-zero exit ('wasResumed'
+    // is a proxy, not a real resume marker), so the audit trail records the
+    // plain fact — exit with this code — not a guessed resume history. A
+    // signal death (code null) matches the normal-exit path's plain 'exit'.
+    auditSessionEnd(session, code === null ? 'exit' : `exit:${code}`);
     await cleanupSession(session, ctx, {
       closeLogger: false,
       cleanupPostIndex: false,
@@ -2143,7 +2155,7 @@ export async function handleExit(
 
   ctx.ops.stopTyping(session);
   cleanupSessionTimers(session);
-  await closeThreadLogger(session, 'exit', { exitCode: code });
+  await closeThreadLogger(session, 'exit', { exitCode: code }, code === 0 || code === null ? 'exit' : `exit:${code}`);
 
   // Unpin task post on session exit (get from MessageManager, source of truth)
   const exitTaskState = session.messageManager?.getTaskListState();
@@ -2203,7 +2215,7 @@ export async function killSession(
   }
 
   ctx.ops.stopTyping(session);
-  await closeThreadLogger(session, 'kill', { unpersist });
+  await closeThreadLogger(session, 'kill', { unpersist }, auditCause);
   session.claude.kill();
 
   // Unpin task post on session kill (get from MessageManager, source of truth)
@@ -2246,6 +2258,10 @@ export async function killAllSessions(ctx: SessionContext): Promise<void> {
     if (ctx.state.isShuttingDown) {
       ctx.ops.persistSession(session);
     }
+    // Record the cause before the raw kill: the per-session exit handlers
+    // only see a generic exit and may even be skipped when the registry is
+    // cleared below first — the exactly-once guard makes their write a no-op.
+    auditSessionEnd(session, ctx.state.isShuttingDown ? 'shutdown' : 'kill');
     killPromises.push(session.claude.kill());
   }
 

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -55,6 +55,7 @@ import {
 import { detectWorktreeInfo } from '../git/worktree.js';
 import { resolveSessionMemory, activeWorktreeRepoRoot } from '../memory/store.js';
 import { scheduleDistillation } from '../memory/distiller.js';
+import { auditLog } from '../persistence/audit-log.js';
 
 const log = createLogger('lifecycle');
 const sessionLog = createSessionLog(log);
@@ -114,7 +115,27 @@ function cleanupSessionTimers(session: Session): void {
  * Close the thread logger for a session.
  * Call this before removing a session from the map.
  */
+/**
+ * Record the session's end in the audit trail exactly once, no matter which
+ * cleanup path(s) run (cleanupSession, removeFromRegistry, inline failure
+ * cleanups can overlap).
+ */
+function auditSessionEnd(session: Session, reason: string): void {
+  if (session.auditEndRecorded) return;
+  session.auditEndRecorded = true;
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: session.lastActorUsername ?? session.startedBy,
+    kind: 'session_end',
+    detail: reason,
+  });
+}
+
 async function closeThreadLogger(session: Session, action?: string, details?: Record<string, unknown>): Promise<void> {
+  if (action) {
+    auditSessionEnd(session, action);
+  }
   if (session.threadLogger) {
     // Log the lifecycle event before closing
     if (action) {
@@ -191,6 +212,8 @@ async function cleanupSession(
   cleanupSessionTimers(session);
   if (doCloseLogger) {
     await closeThreadLogger(session, action, details);
+  } else if (action) {
+    auditSessionEnd(session, action);
   }
   session.messageManager?.dispose();
   void session.decisionBridge?.close();
@@ -230,7 +253,8 @@ function releaseAccountIfHeld(session: Session, ctx: SessionContext): void {
  * @param session - The session to remove from registry
  * @param ctx - Session context for state access
  */
-function removeFromRegistry(session: Session, ctx: SessionContext): void {
+function removeFromRegistry(session: Session, ctx: SessionContext, auditReason?: string): void {
+  if (auditReason) auditSessionEnd(session, auditReason);
   session.messageManager?.dispose();
   void session.decisionBridge?.close();
   session.decisionBridge = undefined;
@@ -419,6 +443,14 @@ function createMessageManager(
   });
 
   messageManager.events.on('routine-prompt:complete', async ({ approved, parsed, requestedBy, postId }) => {
+    auditLog(session.platformId, {
+      threadId: session.threadId,
+      sessionId: session.sessionId,
+      actor: requestedBy,
+      kind: 'command',
+      tool: 'routine',
+      detail: `${approved ? 'created' : 'discarded'}: ${parsed.name}`,
+    });
     session.threadLogger?.logCommand('routine', approved ? 'created' : 'discarded', requestedBy);
     if (!approved) {
       sessionLog(session).info(`🕘 Routine "${parsed.name}" discarded before saving`);
@@ -1254,6 +1286,12 @@ async function startSessionImpl(
   bridgeSessionRef.current = session;
 
   // Log session start
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: session.startedBy,
+    kind: 'session_start',
+  });
   session.threadLogger?.logLifecycle('start', {
     username,
     workingDir: ctx.config.workingDir,
@@ -1294,6 +1332,7 @@ async function startSessionImpl(
     claude.start();
   } catch (err) {
     await logAndNotify(err, { action: 'Start Claude', session });
+    auditSessionEnd(session, 'start-failed');
     ctx.ops.stopTyping(session);
     session.messageManager?.dispose();
     void session.decisionBridge?.close();
@@ -1374,7 +1413,8 @@ async function startSessionImpl(
  */
 export async function resumeSession(
   state: PersistedSession,
-  ctx: SessionContext
+  ctx: SessionContext,
+  resumedBy?: string
 ): Promise<void> {
   // Idempotency guard: a resume can be triggered from two sides at once
   // (startup resume-all and an incoming message via resumePausedSession).
@@ -1395,7 +1435,7 @@ export async function resumeSession(
       await inFlight.catch(() => {});
       return;
     }
-    const attempt = resumeSessionImpl(state, ctx);
+    const attempt = resumeSessionImpl(state, ctx, resumedBy);
     _inFlightSessionStarts.set(sessionKey, attempt);
     try {
       await attempt;
@@ -1404,12 +1444,13 @@ export async function resumeSession(
     }
     return;
   }
-  await resumeSessionImpl(state, ctx);
+  await resumeSessionImpl(state, ctx, resumedBy);
 }
 
 async function resumeSessionImpl(
   state: PersistedSession,
-  ctx: SessionContext
+  ctx: SessionContext,
+  resumedBy?: string
 ): Promise<void> {
   // Validate required fields - skip gracefully if critical data is missing
   if (!state.threadId || !state.platformId || !state.claudeSessionId || !state.workingDir) {
@@ -1686,6 +1727,13 @@ async function resumeSessionImpl(
   }
 
   // Log session resume
+  if (resumedBy) session.lastActorUsername = resumedBy;
+  auditLog(session.platformId, {
+    threadId: session.threadId,
+    sessionId: session.sessionId,
+    actor: resumedBy ?? session.startedBy,
+    kind: 'session_resume',
+  });
   session.threadLogger?.logLifecycle('resume', {
     username: state.startedBy,
     workingDir: state.workingDir,
@@ -1755,6 +1803,7 @@ async function resumeSessionImpl(
     ctx.ops.persistSession(session);
   } catch (err) {
     log.error(`Failed to resume session ${shortId}`, err instanceof Error ? err : undefined);
+    auditSessionEnd(session, 'resume-failed');
     session.messageManager?.dispose();
     void session.decisionBridge?.close();
     session.decisionBridge = undefined;
@@ -1822,6 +1871,10 @@ export async function sendFollowUp(
       return;
     }
   }
+
+  // Audit-actor attribution only AFTER the gate — a rejected follow-up must
+  // not poison the attribution of subsequent tool calls.
+  if (username && !options?.system) session.lastActorUsername = username;
 
   // Check if we need to offer context prompt (e.g., after !cd)
   // This must happen BEFORE MessageManager handles the message
@@ -1893,7 +1946,7 @@ export async function resumePausedSession(
   log.info(`🔄 Resuming paused session ${shortId}... for new message`);
 
   // Resume the session
-  await resumeSession(state, ctx);
+  await resumeSession(state, ctx, username);
 
   // Wait a moment for the session to be ready, then send the message
   const session = ctx.ops.findSessionByThreadId(threadId);
@@ -1993,7 +2046,7 @@ export async function handleExit(
       }
       ctx.ops.persistSession(session);
     }
-    removeFromRegistry(session, ctx);
+    removeFromRegistry(session, ctx, 'pause');
     sessionLog(session).info(`⏸ Session paused`);
     // Update sticky channel message after session pause
     await ctx.ops.updateStickyMessage();
@@ -2031,6 +2084,7 @@ export async function handleExit(
     sessionLog(session).debug(`Resumed session failed with code ${code}, attempt ${session.lifecycle.resumeFailCount}/${MAX_RESUME_FAILURES}, permanent=${isPermanent}`);
     // Skip closeLogger (session is already persisted, logger may be closed)
     // Skip cleanupPostIndex (was already cleaned on original session end)
+    auditSessionEnd(session, `resume-exit:${code}`);
     await cleanupSession(session, ctx, {
       closeLogger: false,
       cleanupPostIndex: false,
@@ -2113,7 +2167,7 @@ export async function handleExit(
   }
 
   // Clean up session from maps and notify keep-alive
-  removeFromRegistry(session, ctx);
+  removeFromRegistry(session, ctx, code === 0 ? 'exit' : `exit:${code}`);
 
   // Only unpersist for normal exits
   if (code === 0 || code === null) {
@@ -2134,7 +2188,8 @@ export async function handleExit(
 export async function killSession(
   session: Session,
   unpersist: boolean,
-  ctx: SessionContext
+  ctx: SessionContext,
+  auditCause: string = 'kill'
 ): Promise<void> {
   // Set restarting state to prevent handleExit from also unpersisting
   if (!unpersist) {
@@ -2164,7 +2219,7 @@ export async function killSession(
   }
 
   // Clean up session from maps and notify keep-alive
-  removeFromRegistry(session, ctx);
+  removeFromRegistry(session, ctx, auditCause);
 
   // Explicitly unpersist if requested
   if (unpersist) {
@@ -2257,7 +2312,7 @@ export async function cleanupIdleSessions(
       scheduleDistillation(session, ctx, 'timeout');
 
       // Kill without unpersisting to allow resume
-      await killSession(session, false, ctx);
+      await killSession(session, false, ctx, 'timeout');
       continue;
     }
 

--- a/src/session/reaction-router.ts
+++ b/src/session/reaction-router.ts
@@ -192,7 +192,7 @@ async function tryResumeFromReaction(
   const shortId = persistedSession.threadId.substring(0, 8);
   log.info(`🔄 Resuming session ${shortId}... via emoji reaction by @${username}`);
 
-  await lifecycle.resumeSession(persistedSession, deps.getContext());
+  await lifecycle.resumeSession(persistedSession, deps.getContext(), username);
   return true;
 }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -418,6 +418,14 @@ export interface Session {
   // Thread logging
   threadLogger?: ThreadLogger;            // Logger for persisting events to disk
 
+  // Best-effort actor attribution for the audit trail: the username whose
+  // message triggered the current turn (fallback: startedBy).
+  lastActorUsername?: string;
+
+  // Idempotency guard: the audit trail records exactly one session_end no
+  // matter which cleanup path(s) run.
+  auditEndRecorded?: boolean;
+
   // Side conversation tracking
   // Messages from approved users that are directed at other users (not the bot).
   // These are included as context with the next message sent to Claude.


### PR DESCRIPTION
## What

Opt-in per-platform option `auditLog: true`: one append-only JSONL stream per platform under `~/.claude-threads/audit/<platformId>.jsonl` (override: `CLAUDE_THREADS_AUDIT_DIR`) recording what the bot did:

- `tool_use` — every tool call Claude **issued**, incl. `server_tool_use` and subagent sidechains (marked `subagent: true`), with the audit-relevant detail: Bash command line, file path, search pattern (capped at 500 chars).
- `session_start` / `session_resume` / `session_end` — full lifecycle incl. failure paths (`start-failed`, `resume-failed`, `resume-exit:<code>`, `timeout`, `pause`, `exit:<code>`, `kill`), exactly one end per session via an idempotency guard.
- `command` — security-relevant `!commands` with actor: `!cd`, `!invite`, `!kick`, `!permissions`, `!stop` (active and paused), `!kill`, `!memory forget`, `!routines` management, routine creation, `!worktree remove`, `!plugin install`/`uninstall`.
- `plan_approval` — approved/denied, by whom, via reaction or `!approve`.

```yaml
platforms:
  - id: mattermost-main
    type: mattermost
    auditLog: true
```

## Why

Thread logs are debugging artifacts: per-thread, raw events, deleted after 30 days. An audit trail is the opposite: one flat greppable stream per platform, spanning sessions, that the bot **never deletes** — built for SIEM file ingestion (Wazuh/Splunk file collectors read JSONL natively). For a multi-user bot the question "who ran what, when, in which thread" deserves a first-class answer.

## Design notes

- **Semantics: the trail records the request** at the moment Claude emits it. An interactive permission denial can still stop the execution — and the denied attempt is exactly what an auditor wants to see. Per-tool allow/deny decisions themselves are out of scope: they resolve inside the MCP permission server subprocess, which the bot process does not observe (documented; plan approvals and audited commands cover the decisions that flow through the bot).
- **Writes are synchronous on a cached fd** — one `write(2)` per entry, no open/close per write. Deliberately unbuffered: a trail that loses its tail on crash defeats the purpose, and the volume (tool calls, commands) stays far below where batching would matter.
- **Hardened against leftover artifacts**: `0600`/`0700` enforced via `fchmod`/`chmod` even on pre-existing files and directories (creation modes alone silently reuse a world-readable leftover), the writer refuses symlinked audit paths (`lstat` + `O_NOFOLLOW`), filenames are collision-free via `encodeURIComponent`.
- **Actor attribution is best effort and documented**: the username whose authorized message triggered the current turn (resumes attribute to the resuming user; attribution is assigned only after the authorization gate), falling back to the session starter.
- Derived DM platforms inherit the parent's `auditLog` and clean up their registry entry on teardown.

## Verification

- 15 new tests: module behavior (JSONL shape, permissions incl. pre-existing-file re-tightening, symlink refusal, detail cap, collision-free encoding, enable/disable), event-tap coverage (tool_use, subagent marking, disabled no-op), and the `!kill` command tap (recorded for authorized, absent for unauthorized). Red-green verified per tap by temporarily removing the wiring.
- `tsc --noEmit`, eslint, and all affected suites (402 tests) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
