### PR TITLE
Release 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.28.0] - 2026-08-21
 
 ### Added
 - **Audit trail (`auditLog`)** - Opt-in per platform: an append-only JSONL stream per platform (`~/.claude-threads/audit/`, files `0600` enforced even on pre-existing artifacts, symlink-refusing writer, never deleted by the bot) recording what the bot did — every tool call Claude issued incl. `server_tool_use` and subagent sidechains (with Bash command line / file path / pattern as detail), session lifecycle incl. failure paths with the triggering user, security-relevant `!commands` (`!kill` and paused-session `!stop` included), routine creation, worktree/plugin mutations, and plan approvals with decider. Built for SIEM file ingestion; rotation/retention is the operator's call. Tool-permission allow/deny decisions stay out of scope (they resolve inside the MCP permission server subprocess; the issued request is still recorded).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Minor release for the ackReaction and auditLog features. Merging to `main` triggers `release.yml`, which tags `v1.28.0`, creates the GitHub release, and publishes to npm automatically.

## Changes

- Bump `package.json` / `package-lock.json` to 1.28.0 via `npm version minor` (`bun install` run; `bun.lock` unchanged as expected)
- Promote the CHANGELOG's `## [Unreleased]` to `## [1.28.0] - 2026-08-21`, covering:
  - **`ackReaction`** — opt-in read-receipt reaction on accepted messages (#487), with Unicode-emoji normalization and docs polish (#489)
  - **`auditLog`** — opt-in append-only per-platform JSONL audit trail with precise session-end causes (#488)

## Testing

Version-bump-only change — no code touched. All three constituent PRs merged with CI + Integration Tests green on their final heads, and `release.yml` re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun test`) — validated by CI on this PR and re-run by `release.yml`
- [x] Linting passes (`bun run lint`) — same
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_