### PR TITLE
Release 1.29.2: retry the npm publish that failed for 1.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.29.2] - 2026-08-24
+
+Re-release of 1.29.1 — no code changes. The 1.29.1 npm publish step failed
+(the registry rejected the publish with npm's masked-auth E404); the v1.29.1
+tag and GitHub release exist, but the package never reached npm. This version
+re-runs the publish.
+
 ## [1.29.1] - 2026-08-24
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.29.1",
+      "version": "1.29.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Re-release with **no code changes**. The 1.29.1 release run tagged `v1.29.1` and created the GitHub release, but the `npm publish` step failed with the registry's masked-auth `E404` (`404 Not Found - PUT https://registry.npmjs.org/claude-threads`), so 1.29.1 never reached npm — `latest` is still 1.29.0.

There is no safe re-run path for the existing version: `release.yml` early-exits when the tag already exists, `publish.yml` has no manual trigger (and GITHUB_TOKEN-created releases don't emit `release: published`), and the v1.29.1 release is immutable. Bumping to 1.29.2 through the normal flow re-runs the publish.

npm's status page reports all systems operational and the same `NPM_TOKEN` published 1.29.0 a few hours earlier, so this is a single clean retry. If this publish fails with the same `E404`, the token is dead (revoked/expired) and needs rotating in the repository secrets before re-dispatching `release.yml`.

## Changes

- CHANGELOG: `1.29.2` section documenting the re-release
- `package.json` / `package-lock.json`: 1.29.1 → 1.29.2 (`bun.lock` unaffected, verified in lockstep)

## Checklist

- [x] Tests pass (`bun test`) — no code changes; CI re-verifies
- [x] Linting passes (`bun run lint`) — no code changes; CI re-verifies
- [x] Documentation updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oYWi6VCBjsJdrK6CBeNe1

---
_Generated by [Claude Code](https://claude.ai/code/session_012oYWi6VCBjsJdrK6CBeNe1)_