### PR TITLE
release.yml: make a failed npm publish retryable after tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,12 @@ name: Release
 # never publish. publish.yml is deliberately left untouched; it remains the path
 # for a release a human creates with `gh release create`.
 #
-# Safe to re-run: if the tag for the current package.json version already exists,
-# the job exits early without tagging or publishing. That also means an unrelated
-# package.json edit (a dependency bump) is a no-op rather than a bad release.
+# Safe to re-run: tagging and publishing are decided independently. If the
+# current version is already fully released (tag exists AND the version is on
+# npm), the job is a no-op — so an unrelated package.json edit (a dependency
+# bump) can never cut a bad release. If the tag exists but npm is missing the
+# version (a publish that failed after tagging, e.g. an expired NPM_TOKEN),
+# a re-run or workflow_dispatch retries just the publish.
 
 on:
   push:
@@ -48,15 +51,29 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Skip if this version was already released
+      # Two independent decisions, so a publish that failed after the tag was
+      # created (e.g. a dead NPM_TOKEN) can be retried with a plain
+      # workflow_dispatch once the token is fixed: tag exists + version absent
+      # from npm → skip tagging, still verify/build/publish. Tag exists +
+      # version on npm → full no-op (an unrelated package.json edit stays a
+      # non-release, same as before).
+      - name: Decide what this run must do
         id: check
         run: |
-          tag="v${{ steps.version.outputs.version }}"
+          version="${{ steps.version.outputs.version }}"
+          tag="v$version"
           if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists — nothing to release."
+            echo "Tag $tag already exists — will not tag."
+            echo "tag=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $tag does not exist — will tag and release."
+            echo "tag=true" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$(npm view "claude-threads@$version" version 2>/dev/null)" = "$version" ]; then
+            echo "claude-threads@$version is already on npm — will not publish."
             echo "release=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Tag $tag does not exist — releasing."
+            echo "claude-threads@$version is not on npm — will publish."
             echo "release=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -106,7 +123,7 @@ jobs:
 
       # Creates the tag on this commit and the release in one call.
       - name: Create tag and GitHub release
-        if: steps.check.outputs.release == 'true'
+        if: steps.check.outputs.release == 'true' && steps.check.outputs.tag == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

The `NPM_TOKEN` stopped working between the 1.29.0 and 1.29.1 releases: both **1.29.1 and 1.29.2** tagged and created their GitHub releases, then failed at `npm publish` with the registry's masked-auth `E404` — so neither version reached npm (`latest` is still 1.29.0). The identical failure on the clean 1.29.2 retry rules out a transient registry problem: the token is revoked or expired.

The old `release.yml` made this state unrecoverable without burning another version: its tag-exists early exit turned any re-run into a silent no-op, and `publish.yml` never fires for GITHUB_TOKEN-created releases (GitHub suppresses those events).

## Change

Tagging and publishing are now decided independently in the check step:

| Tag exists | Version on npm | Behavior |
|---|---|---|
| no | no | tag + release + publish (normal release, unchanged) |
| yes | no | verify + build + **publish only** (retry after a failed publish) |
| yes | yes | full no-op (unchanged guarantee: an unrelated `package.json` edit can never cut a release) |

After the token is rotated, a plain `workflow_dispatch` of Release publishes the already-tagged 1.29.2.

## Post-merge steps (maintainer)

1. Mint a new npm automation token and update the `NPM_TOKEN` repository secret.
2. Dispatch the Release workflow from the Actions tab (or ask Claude to).

## Checklist

- [x] Tests pass (`bun test`) — workflow-only change
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — behavior documented in the workflow header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oYWi6VCBjsJdrK6CBeNe1

---
_Generated by [Claude Code](https://claude.ai/code/session_012oYWi6VCBjsJdrK6CBeNe1)_