### PR TITLE
fix: sessions started inside a worktree satisfy worktreeMode without prompting

### DIFF
--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -335,8 +335,18 @@ export async function detectWorktreeInfo(
     // Get the branch name from git
     const branchOutput = await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], workingDir);
     const branch = branchOutput?.trim();
-    if (!branch) {
+    // A detached HEAD reports the literal string "HEAD" — not a branch name;
+    // downstream (findWorktreeByBranch, list markers) would treat it as one.
+    if (!branch || branch === 'HEAD') {
       log.debug(`Could not detect branch for worktree at ${workingDir}`);
+      return null;
+    }
+
+    // The worktree root, not workingDir: a session may start in a nested
+    // subdirectory, and reference counting / `git worktree remove` must see
+    // the actual worktree path.
+    const toplevel = (await execGit(['rev-parse', '--show-toplevel'], workingDir))?.trim();
+    if (!toplevel || !isValidWorktreePath(toplevel)) {
       return null;
     }
 
@@ -347,9 +357,9 @@ export async function detectWorktreeInfo(
     log.debug(`Detected worktree: path=${workingDir}, branch=${branch}, repoRoot=${repoRoot}`);
 
     return {
-      worktreePath: workingDir,
+      worktreePath: toplevel,
       branch,
-      repoRoot: repoRoot || workingDir,
+      repoRoot: repoRoot || toplevel,
     };
   } catch (err) {
     log.debug(`Failed to detect worktree info for ${workingDir}: ${err}`);

--- a/src/operations/worktree/handler.test.ts
+++ b/src/operations/worktree/handler.test.ts
@@ -11,6 +11,8 @@ import { join } from 'path';
 
 // Mock the git/worktree module
 const mockIsGitRepository = mock(() => Promise.resolve(true));
+const mockDetectWorktreeInfo = mock(() =>
+  Promise.resolve(null as { repoRoot: string; worktreePath: string; branch: string } | null));
 const mockGetRepositoryRoot = mock(() => Promise.resolve('/repo'));
 const mockFindWorktreeByBranch = mock(() => Promise.resolve(null as { path: string; branch: string; isMain: boolean } | null));
 const mockCreateWorktree = mock(() => Promise.resolve());
@@ -21,6 +23,7 @@ const mockWriteWorktreeMetadata = mock(() => Promise.resolve());
 
 mock.module('../../git/worktree.js', () => ({
   isGitRepository: mockIsGitRepository,
+  detectWorktreeInfo: mockDetectWorktreeInfo,
   getRepositoryRoot: mockGetRepositoryRoot,
   findWorktreeByBranch: mockFindWorktreeByBranch,
   createWorktree: mockCreateWorktree,
@@ -899,6 +902,43 @@ describe('Worktree Module', () => {
       const session = createMockSession();
       const result = await worktree.shouldPromptForWorktree(session, 'require', () => false);
       expect(result).toBe('require');
+    });
+
+    it('records the worktree and skips the prompt when the session starts inside one', async () => {
+      mockDetectWorktreeInfo.mockResolvedValueOnce({
+        repoRoot: '/repo',
+        worktreePath: '/repo-worktrees/task-1',
+        branch: 'task-1',
+      });
+      const mockSetWorktreeInfo = mock(() => {});
+      const session = createMockSession({
+        messageManager: { setWorktreeInfo: mockSetWorktreeInfo } as never,
+      });
+      const result = await worktree.shouldPromptForWorktree(session, 'require', () => false);
+      expect(result).toBeNull();
+      expect(session.worktreeInfo).toEqual({
+        repoRoot: '/repo',
+        worktreePath: '/repo-worktrees/task-1',
+        branch: 'task-1',
+      });
+      expect(mockSetWorktreeInfo).toHaveBeenCalledWith('/repo-worktrees/task-1', 'task-1');
+    });
+
+    it('does not run detection when worktreeMode is off', async () => {
+      mockDetectWorktreeInfo.mockClear();
+      const session = createMockSession();
+      const result = await worktree.shouldPromptForWorktree(session, 'off', () => false);
+      expect(result).toBeNull();
+      expect(mockDetectWorktreeInfo).not.toHaveBeenCalled();
+      expect(session.worktreeInfo).toBeUndefined();
+    });
+
+    it('still prompts in require mode when the working dir is not a worktree', async () => {
+      mockDetectWorktreeInfo.mockResolvedValueOnce(null);
+      const session = createMockSession();
+      const result = await worktree.shouldPromptForWorktree(session, 'require', () => false);
+      expect(result).toBe('require');
+      expect(session.worktreeInfo).toBeUndefined();
     });
   });
 

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -26,6 +26,7 @@ import {
   isValidBranchName,
   writeWorktreeMetadata,
   isValidWorktreePath,
+  detectWorktreeInfo,
 } from '../../git/worktree.js';
 import type { ClaudeCliOptions, ClaudeEvent } from '../../claude/cli.js';
 import { ClaudeCli } from '../../claude/cli.js';
@@ -152,6 +153,20 @@ export async function shouldPromptForWorktree(
 
   // Skip if already in a worktree
   if (session.worktreeInfo) return null;
+
+  // Started directly inside a worktree (e.g. a dynamic-channel session whose
+  // channel IS the worktree): the isolation requirement is already satisfied.
+  // Detect and record it instead of prompting for a worktree-in-a-worktree.
+  const detected = await detectWorktreeInfo(session.workingDir);
+  if (detected) {
+    session.worktreeInfo = {
+      repoRoot: detected.repoRoot,
+      worktreePath: detected.worktreePath,
+      branch: detected.branch,
+    };
+    session.messageManager?.setWorktreeInfo(detected.worktreePath, detected.branch);
+    return null;
+  }
 
   // Check if we're in a git repository
   const isRepo = await isGitRepository(session.workingDir);

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -307,6 +307,13 @@ async function cleanupSession(
   }
   keepAlive.sessionEnded();
   releaseAccountIfHeld(session, ctx);
+  // One-place rule, like releaseAccountIfHeld: every exit path must drop the
+  // worktree reference or early exits leak it and block cleanup until restart.
+  // unregisterWorktreeUser is set-based, so paths that already unregistered
+  // are unaffected.
+  if (session.worktreeInfo) {
+    ctx.ops.unregisterWorktreeUser(session.worktreeInfo.worktreePath, session.sessionId);
+  }
   await cleanupSessionUploads(session.platformId, session.threadId);
 }
 
@@ -1145,7 +1152,12 @@ async function startSessionImpl(
 
   // Check if we should prompt for worktree
   // Skip if explicitly disabled (e.g., when branch was specified in initial message via !worktree)
-  const shouldPrompt = options.skipWorktreePrompt ? null : await ctx.ops.shouldPromptForWorktree(session);
+  // Always run the check — it also detects (and records) an existing worktree
+  // around workingDir. skipWorktreePrompt suppresses only the prompt itself,
+  // otherwise unattended starts inside a worktree would miss worktreeInfo and
+  // its reference-count protection.
+  const worktreePromptReason = await ctx.ops.shouldPromptForWorktree(session);
+  const shouldPrompt = options.skipWorktreePrompt ? null : worktreePromptReason;
   if (shouldPrompt) {
     session.queuedPrompt = options.prompt;
     session.queuedByUsername = username;   // owner — used when the worktree prompt later re-sends
@@ -1155,6 +1167,14 @@ async function startSessionImpl(
     ctx.ops.persistSession(session);
     await ctx.ops.updateStickyMessage();
     return;
+  }
+
+  // shouldPromptForWorktree may have detected that workingDir already IS a
+  // worktree and recorded it on the session; register it for reference
+  // counting like every other path that sets worktreeInfo, or another
+  // session's cleanup can remove the directory under this live session.
+  if (session.worktreeInfo) {
+    ctx.ops.registerWorktreeUser(session.worktreeInfo.worktreePath, session.sessionId);
   }
 
   // Build message content


### PR DESCRIPTION
The first of the two PRs invited in #490 ("the worktree-in-worktree fix — please open that as its own small PR right away").

## Problem

A session whose `workingDir` already **is** a managed worktree (started there deliberately, or by an orchestration layer) still gets the worktree prompt under `worktreeMode: prompt`/`require` — offering to create a worktree inside a worktree. The isolation the mode exists for is already satisfied.

## Change

`shouldPromptForWorktree` now runs `detectWorktreeInfo(session.workingDir)` (after the existing early-outs, before the repo check — detection is a pure path-prefix check first, so no extra git spawns on the common path) and, when it detects one, records it on the session and skips the prompt.

Review hardening rounds (Gemini, CodeRabbit, Codex reviews before submitting) surfaced adjacent gaps this PR also closes:

- the detected worktree is **registered for reference counting** at the lifecycle call site, mirroring the resume path — otherwise another session's cleanup could `git worktree remove` it under a live session
- `messageManager.setWorktreeInfo` is synced like every other `worktreeInfo` assignment
- `detectWorktreeInfo` now resolves the **worktree root** (`rev-parse --show-toplevel`) instead of recording a nested working subdirectory as the worktree path, and treats a detached HEAD (`"HEAD"`) as no-branch
- detection runs even when the prompt is skipped (`skipWorktreePrompt` — e.g. unattended starts) so those sessions also get `worktreeInfo` and reference-count protection; the flag now suppresses only the prompt
- `cleanupSession` drops the worktree reference on **every** exit path (one-place rule, like account release) — pre-existing leak: an early Claude exit left a stale reference that blocked worktree cleanup until restart; this affected all registration paths, not just the new one

## Tests

New cases in `handler.test.ts`: detection records + skips prompt (require mode), messageManager sync, null-detection still prompts, off-mode runs no detection. Full suite green.