### PR TITLE
Slack: shared event source — one Socket Mode connection per app

### DIFF
--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -117,16 +117,26 @@ export class SlackClient extends BasePlatformClient {
    * A secondary's only event feed is the parent's socket, so the parent's
    * connection state IS the secondary's connection state — mirror it.
    *
-   * Re-armed after `disconnect()`, whose base teardown detaches every
-   * listener including this one.
+   * Stable handler identities, so re-arming is idempotent: overlapping
+   * `disconnect()` calls each clear the listeners and each re-arm, and a
+   * fresh closure per install would leave the mirror stacked and every
+   * later event duplicated into the secondaries.
    */
-  private installStateMirror(): void {
-    for (const state of ['connected', 'disconnected', 'reconnecting'] as const) {
-      this.on(state, (...args: unknown[]) => {
+  private readonly stateMirrors = (['connected', 'disconnected', 'reconnecting'] as const).map(
+    (state) => ({
+      state,
+      handler: (...args: unknown[]) => {
         for (const secondary of this.channelClients.values()) {
           secondary.emit(state, ...args);
         }
-      });
+      },
+    })
+  );
+
+  private installStateMirror(): void {
+    for (const { state, handler } of this.stateMirrors) {
+      this.off(state, handler);
+      this.on(state, handler);
     }
   }
 
@@ -180,20 +190,20 @@ export class SlackClient extends BasePlatformClient {
     this.handleSlackEvent(event);
   }
 
-  override async disconnect(): Promise<void> {
+  override disconnect(): Promise<void> {
     // A secondary must stop receiving injected events when it goes away;
     // the base teardown is still safe to run (it has no socket to close).
     if (this.sharedEventSource) {
       this.sharedEventSource.unregisterChannelClient(this.channelId, this);
     }
-    try {
-      await super.disconnect();
-    } finally {
-      // Base teardown calls removeAllListeners(), which takes the state mirror
-      // with it. Without re-arming, a parent that goes intentional-disconnect
-      // → reconnect never tells its secondaries about a connection again.
-      this.installStateMirror();
-    }
+    // Base teardown calls removeAllListeners() synchronously and then returns
+    // the socket-close promise, which can stay pending. Re-arm here rather
+    // than after awaiting it: without the mirror, a parent that reconnects
+    // while the close is still settling emits 'connected' into nothing and
+    // its secondaries miss it permanently.
+    const closed = super.disconnect();
+    this.installStateMirror();
+    return closed;
   }
 
   // ============================================================================

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -197,13 +197,20 @@ export class SlackClient extends BasePlatformClient {
       this.sharedEventSource.unregisterChannelClient(this.channelId, this);
     }
     // Base teardown calls removeAllListeners() synchronously and then returns
-    // the socket-close promise, which can stay pending. Re-arm here rather
-    // than after awaiting it: without the mirror, a parent that reconnects
-    // while the close is still settling emits 'connected' into nothing and
-    // its secondaries miss it permanently.
-    const closed = super.disconnect();
-    this.installStateMirror();
-    return closed;
+    // the socket-close promise, which can stay pending. Re-arm before that
+    // promise settles: without the mirror, a parent that reconnects while the
+    // close is still in flight emits 'connected' into nothing and its
+    // secondaries miss it permanently.
+    //
+    // Synchronous try/finally, not async: the base promise is returned
+    // unchanged (a synchronous throw stays synchronous) and the mirror is
+    // re-armed on the throwing path too — a failed close must not also leave
+    // the parent permanently mute.
+    try {
+      return super.disconnect();
+    } finally {
+      this.installStateMirror();
+    }
   }
 
   // ============================================================================

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -83,8 +83,26 @@ export class SlackClient extends BasePlatformClient {
 
   private readonly formatter = new SlackFormatter();
 
-  constructor(platformConfig: SlackPlatformConfig) {
+  // Shared event source: when several SlackClient instances serve one Slack
+  // app, Slack round-robins Socket Mode envelopes across their connections.
+  // Instead, exactly one client (the parent) holds the socket and routes
+  // events for other channels into registered secondary clients.
+  private readonly channelClients = new Map<string, SlackClient>();
+  private sharedEventSource?: SlackClient;
+  private socketConnected = false;
+
+  constructor(platformConfig: SlackPlatformConfig, sharedEventSource?: SlackClient) {
     super();
+    this.sharedEventSource = sharedEventSource;
+    // A secondary's only event feed is the parent's socket, so the parent's
+    // connection state IS the secondary's connection state — mirror it.
+    for (const state of ['connected', 'disconnected', 'reconnecting'] as const) {
+      this.on(state, (...args: unknown[]) => {
+        for (const secondary of this.channelClients.values()) {
+          secondary.emit(state, ...args);
+        }
+      });
+    }
     this.platformId = platformConfig.id;
     this.displayName = platformConfig.displayName;
     this.botToken = platformConfig.botToken;
@@ -97,6 +115,52 @@ export class SlackClient extends BasePlatformClient {
     this.directChannelMode = resolveDirectChannelMode(platformConfig.directChannelMode);
     this.approvals = platformConfig.approvals;
     this.ackReaction = normalizeAckReaction(platformConfig.ackReaction, `platforms[${platformConfig.id}].ackReaction`);
+  }
+
+  // ============================================================================
+  // Shared event source plumbing
+  // ============================================================================
+
+  /**
+   * Parent-side: route events for `channelId` into a secondary client.
+   *
+   * Register secondaries (or call their `connect()`) BEFORE connecting the
+   * parent: events arriving between the parent's socket going live and a
+   * secondary's registration hit the unregistered-channel drop path.
+   */
+  registerChannelClient(channelId: string, client: SlackClient): void {
+    if (channelId === this.channelId) {
+      // Routing requires eventChannel !== this.channelId, so a same-channel
+      // secondary would register fine and then never receive anything.
+      throw new Error(
+        `registerChannelClient: ${channelId} is the parent's own channel — a secondary there can never receive events`
+      );
+    }
+    this.channelClients.set(channelId, client);
+  }
+
+  /**
+   * Parent-side: stop routing events for `channelId`. When `client` is given,
+   * the registration is removed only if it still belongs to that instance —
+   * an old secondary's teardown must not evict its replacement.
+   */
+  unregisterChannelClient(channelId: string, client?: SlackClient): void {
+    if (client && this.channelClients.get(channelId) !== client) return;
+    this.channelClients.delete(channelId);
+  }
+
+  /** Secondary-side: receive an event injected by the parent's socket. */
+  _injectSlackEvent(event: Parameters<SlackClient['handleSlackEvent']>[0]): void {
+    this.handleSlackEvent(event);
+  }
+
+  override disconnect(): Promise<void> {
+    // A secondary must stop receiving injected events when it goes away;
+    // the base teardown is still safe to run (it has no socket to close).
+    if (this.sharedEventSource) {
+      this.sharedEventSource.unregisterChannelClient(this.channelId, this);
+    }
+    return super.disconnect();
   }
 
   // ============================================================================
@@ -279,6 +343,25 @@ export class SlackClient extends BasePlatformClient {
    * 4. Receive events and ACK within 3 seconds
    */
   async connect(): Promise<void> {
+    // Secondary instance on a shared event source: NEVER open a second Socket
+    // Mode connection — Slack round-robins envelopes across an app's
+    // connections, so a second socket steals events from the parent. The
+    // parent injects events via _injectSlackEvent; Web API calls (which are
+    // plain HTTPS) work independently.
+    if (this.sharedEventSource) {
+      await this.fetchBotUser();
+      // disconnect() may have run while fetchBotUser was in flight — a stale
+      // continuation must not resurrect the registration.
+      if (this.isIntentionalDisconnect) return;
+      this.sharedEventSource.registerChannelClient(this.channelId, this);
+      // Only claim connected while the parent's socket actually is; otherwise
+      // the state mirror emits 'connected' when the parent's hello arrives.
+      if (this.sharedEventSource.socketConnected) {
+        this.emit('connected');
+      }
+      return;
+    }
+
     // First, get bot user info
     await this.fetchBotUser();
     wsLogger.debug(`Slack bot user ID: ${this.botUserId}`);
@@ -339,13 +422,23 @@ export class SlackClient extends BasePlatformClient {
           // Connection established on 'hello'
           if (envelope.type === 'hello') {
             clearTimeout(connectionTimeout);
+            this.socketConnected = true;
             this.onConnectionEstablished();
 
-            // Recover missed messages if reconnecting
-            if (this.isReconnecting && this.lastProcessedTs) {
-              this.recoverMissedMessages().catch((err) => {
-                log.warn(`Failed to recover missed messages: ${err}`);
-              });
+            // Recover missed messages if reconnecting — for this channel and
+            // for every registered secondary, whose only feed is this socket
+            // (each recovery no-ops without its own lastProcessedTs).
+            if (this.isReconnecting) {
+              if (this.lastProcessedTs) {
+                this.recoverMissedMessages().catch((err) => {
+                  log.warn(`Failed to recover missed messages: ${err}`);
+                });
+              }
+              for (const secondary of this.channelClients.values()) {
+                secondary.recoverMissedMessages().catch((err) => {
+                  log.warn(`Failed to recover missed messages for ${secondary.platformId}: ${err}`);
+                });
+              }
             }
 
             doResolve();
@@ -356,6 +449,7 @@ export class SlackClient extends BasePlatformClient {
       };
 
       this.ws.onclose = (event) => {
+        this.socketConnected = false;
         clearTimeout(connectionTimeout);
         wsLogger.info(
           `Socket Mode: WebSocket disconnected (code: ${event.code}, reason: ${event.reason || 'none'}, clean: ${event.wasClean})`
@@ -447,6 +541,19 @@ export class SlackClient extends BasePlatformClient {
     bot_id?: string;
     files?: SlackFile[];
   }): void {
+    // Shared event source: this socket may carry events for channels owned by
+    // registered secondary clients — hand those over before any own-channel
+    // filtering. Events for unregistered foreign channels keep the existing
+    // behavior (dropped below by the own-channel checks).
+    const eventChannel = event.channel || event.item?.channel;
+    if (eventChannel && eventChannel !== this.channelId) {
+      const secondary = this.channelClients.get(eventChannel);
+      if (secondary) {
+        secondary._injectSlackEvent(event);
+        return;
+      }
+    }
+
     // Handle message events
     // Note: file_share subtype is used when a user uploads a file with a message
     if (event.type === 'message' && (!event.subtype || event.subtype === 'file_share')) {

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -94,15 +94,7 @@ export class SlackClient extends BasePlatformClient {
   constructor(platformConfig: SlackPlatformConfig, sharedEventSource?: SlackClient) {
     super();
     this.sharedEventSource = sharedEventSource;
-    // A secondary's only event feed is the parent's socket, so the parent's
-    // connection state IS the secondary's connection state — mirror it.
-    for (const state of ['connected', 'disconnected', 'reconnecting'] as const) {
-      this.on(state, (...args: unknown[]) => {
-        for (const secondary of this.channelClients.values()) {
-          secondary.emit(state, ...args);
-        }
-      });
-    }
+    this.installStateMirror();
     this.platformId = platformConfig.id;
     this.displayName = platformConfig.displayName;
     this.botToken = platformConfig.botToken;
@@ -120,6 +112,40 @@ export class SlackClient extends BasePlatformClient {
   // ============================================================================
   // Shared event source plumbing
   // ============================================================================
+
+  /**
+   * A secondary's only event feed is the parent's socket, so the parent's
+   * connection state IS the secondary's connection state — mirror it.
+   *
+   * Re-armed after `disconnect()`, whose base teardown detaches every
+   * listener including this one.
+   */
+  private installStateMirror(): void {
+    for (const state of ['connected', 'disconnected', 'reconnecting'] as const) {
+      this.on(state, (...args: unknown[]) => {
+        for (const secondary of this.channelClients.values()) {
+          secondary.emit(state, ...args);
+        }
+      });
+    }
+  }
+
+  /**
+   * The parent's socket is every secondary's feed too, so a reconnect means
+   * each of them missed messages as well. `super` clears `isReconnecting`
+   * (after recovering this client's own), so capture it first.
+   */
+  protected override onConnectionEstablished(): void {
+    const wasReconnecting = this.isReconnecting;
+    super.onConnectionEstablished();
+    if (!wasReconnecting) return;
+
+    for (const secondary of this.channelClients.values()) {
+      secondary.recoverMissedMessages().catch((err) => {
+        log.warn(`Failed to recover missed messages for ${secondary.platformId}: ${err}`);
+      });
+    }
+  }
 
   /**
    * Parent-side: route events for `channelId` into a secondary client.
@@ -154,13 +180,20 @@ export class SlackClient extends BasePlatformClient {
     this.handleSlackEvent(event);
   }
 
-  override disconnect(): Promise<void> {
+  override async disconnect(): Promise<void> {
     // A secondary must stop receiving injected events when it goes away;
     // the base teardown is still safe to run (it has no socket to close).
     if (this.sharedEventSource) {
       this.sharedEventSource.unregisterChannelClient(this.channelId, this);
     }
-    return super.disconnect();
+    try {
+      await super.disconnect();
+    } finally {
+      // Base teardown calls removeAllListeners(), which takes the state mirror
+      // with it. Without re-arming, a parent that goes intentional-disconnect
+      // → reconnect never tells its secondaries about a connection again.
+      this.installStateMirror();
+    }
   }
 
   // ============================================================================
@@ -423,23 +456,10 @@ export class SlackClient extends BasePlatformClient {
           if (envelope.type === 'hello') {
             clearTimeout(connectionTimeout);
             this.socketConnected = true;
+            // Recovery for this channel and for every secondary happens in
+            // onConnectionEstablished — a block here would run after the base
+            // has already cleared isReconnecting, i.e. never.
             this.onConnectionEstablished();
-
-            // Recover missed messages if reconnecting — for this channel and
-            // for every registered secondary, whose only feed is this socket
-            // (each recovery no-ops without its own lastProcessedTs).
-            if (this.isReconnecting) {
-              if (this.lastProcessedTs) {
-                this.recoverMissedMessages().catch((err) => {
-                  log.warn(`Failed to recover missed messages: ${err}`);
-                });
-              }
-              for (const secondary of this.channelClients.values()) {
-                secondary.recoverMissedMessages().catch((err) => {
-                  log.warn(`Failed to recover missed messages for ${secondary.platformId}: ${err}`);
-                });
-              }
-            }
 
             doResolve();
           }

--- a/src/platform/slack/shared-event-source.test.ts
+++ b/src/platform/slack/shared-event-source.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Shared event source tests
+ *
+ * Several SlackClient instances serving one Slack app must not each open a
+ * Socket Mode connection: Slack round-robins envelopes across an app's
+ * connections, so every extra socket silently steals events from the others.
+ * These tests cover the alternative: one parent client owns the socket and
+ * routes events for other channels into registered secondary clients.
+ */
+
+import { installFetchHarness, jsonResponse, type FetchResponder } from '../test-helpers/fetch-harness.js';
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
+import { SlackClient } from './client.js';
+import type { SlackPlatformConfig } from '../../config/types.js';
+
+let fetchResponder: FetchResponder = () => jsonResponse({ ok: true });
+const harness = installFetchHarness(() => fetchResponder);
+
+const ok = (body: Record<string, unknown> = {}) => jsonResponse({ ok: true, ...body });
+
+function makeConfig(overrides: Partial<SlackPlatformConfig> = {}): SlackPlatformConfig {
+  return {
+    type: 'slack',
+    id: overrides.id ?? 'parent',
+    displayName: 'Test',
+    botToken: 'xoxb-x',
+    appToken: 'xapp-x',
+    channelId: overrides.channelId ?? 'C-PARENT',
+    botName: 'claude',
+    allowedUsers: [],
+    ...overrides,
+  } as SlackPlatformConfig;
+}
+
+function makeParent(): SlackClient {
+  return new SlackClient(makeConfig());
+}
+
+function makeSecondary(parent: SlackClient, channelId: string): SlackClient {
+  return new SlackClient(makeConfig({ id: `parent--ch-${channelId}`, channelId }), parent);
+}
+
+function messageEvent(channel: string, text = 'hello', ts = '111.222') {
+  return { type: 'message', channel, ts, user: 'U-HUMAN', text };
+}
+
+beforeEach(() => {
+  fetchResponder = (url) => {
+    if (String(url).endsWith('auth.test')) return ok({ user_id: 'U-BOT', url: 'https://team.slack.com/' });
+    if (String(url).includes('users.info')) {
+      return ok({ user: { id: 'U-BOT', name: 'claude', real_name: 'Claude', profile: {} } });
+    }
+    return ok();
+  };
+});
+
+describe('secondary connect()', () => {
+  it('registers with the parent and never opens a Socket Mode connection', async () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+
+    let connected = false;
+    secondary.on('connected', () => { connected = true; });
+    await secondary.connect();
+
+    expect(connected).toBe(true);
+    expect(harness.calls.some((c) => c.url.includes('apps.connections.open'))).toBe(false);
+
+    // Registration is live: parent routes an event for the secondary's channel.
+    const inject = spyOn(secondary, '_injectSlackEvent');
+    parent._injectSlackEvent(messageEvent('C-TASK'));
+    expect(inject).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('parent-side routing', () => {
+  it('hands events for a registered channel to that secondary, including reaction items', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+    const inject = spyOn(secondary, '_injectSlackEvent');
+
+    parent._injectSlackEvent(messageEvent('C-TASK'));
+    parent._injectSlackEvent({
+      type: 'reaction_added',
+      user: 'U-HUMAN',
+      reaction: 'eyes',
+      item: { type: 'message', channel: 'C-TASK', ts: '111.222' },
+    });
+
+    expect(inject).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps handling its own channel itself', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+    const inject = spyOn(secondary, '_injectSlackEvent');
+
+    parent._injectSlackEvent(messageEvent('C-PARENT'));
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it('leaves events for unregistered foreign channels to the existing drop path', () => {
+    const parent = makeParent();
+    let emitted = 0;
+    parent.on('message', () => { emitted += 1; });
+
+    // No throw, no message emission — same as before the routing existed.
+    parent._injectSlackEvent(messageEvent('C-UNKNOWN'));
+    expect(emitted).toBe(0);
+  });
+
+  it('stops routing after unregisterChannelClient', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+    parent.unregisterChannelClient('C-TASK');
+    const inject = spyOn(secondary, '_injectSlackEvent');
+
+    parent._injectSlackEvent(messageEvent('C-TASK'));
+    expect(inject).not.toHaveBeenCalled();
+  });
+});
+
+describe('lifecycle and safety', () => {
+  it('mirrors the parent connection state onto registered secondaries', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+
+    const seen: string[] = [];
+    secondary.on('disconnected', () => seen.push('disconnected'));
+    secondary.on('connected', () => seen.push('connected'));
+
+    parent.emit('disconnected');
+    parent.emit('connected');
+    expect(seen).toEqual(['disconnected', 'connected']);
+  });
+
+  it("an old secondary's disconnect does not evict its replacement", async () => {
+    const parent = makeParent();
+    const old = makeSecondary(parent, 'C-TASK');
+    await old.connect();
+    const replacement = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', replacement);
+
+    await old.disconnect();
+    const inject = spyOn(replacement, '_injectSlackEvent');
+    parent._injectSlackEvent(messageEvent('C-TASK'));
+    expect(inject).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects registering a secondary for the parent\'s own channel', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-PARENT');
+    expect(() => parent.registerChannelClient('C-PARENT', secondary)).toThrow(/own channel/);
+  });
+
+  it('injected messages flow through the secondary\'s own pipeline to a message emission', async () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+
+    const post = new Promise<{ message: string }>((resolve) => {
+      secondary.on('message', (p: { message: string }) => resolve(p));
+    });
+    parent._injectSlackEvent(messageEvent('C-TASK', 'through the pipe'));
+    const received = await post;
+    expect(received.message).toContain('through the pipe');
+
+    // Dedup still applies on the injected path: same ts again → no second emit.
+    const emitSpy = spyOn(secondary, 'emit');
+    parent._injectSlackEvent(messageEvent('C-TASK', 'through the pipe'));
+    expect(emitSpy.mock.calls.filter((c) => c[0] === 'message')).toHaveLength(0);
+  });
+});
+
+describe('secondary disconnect()', () => {
+  it('unregisters itself from the parent', async () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    await secondary.connect();
+    const inject = spyOn(secondary, '_injectSlackEvent');
+
+    await secondary.disconnect();
+    parent._injectSlackEvent(messageEvent('C-TASK'));
+    expect(inject).not.toHaveBeenCalled();
+  });
+});

--- a/src/platform/slack/shared-event-source.test.ts
+++ b/src/platform/slack/shared-event-source.test.ts
@@ -44,6 +44,30 @@ function messageEvent(channel: string, text = 'hello', ts = '111.222') {
   return { type: 'message', channel, ts, user: 'U-HUMAN', text };
 }
 
+/** Let queued microtasks (e.g. getUser().then(...)) run before asserting. */
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// The shared-event-source contract lives on protected/private members; these
+// reach them deliberately rather than widening the production API for tests.
+function setSocketConnected(client: SlackClient, value: boolean): void {
+  (client as unknown as { socketConnected: boolean }).socketConnected = value;
+}
+
+function setReconnecting(client: SlackClient, value: boolean): void {
+  (client as unknown as { isReconnecting: boolean }).isReconnecting = value;
+}
+
+function fireConnectionEstablished(client: SlackClient): void {
+  (client as unknown as { onConnectionEstablished: () => void }).onConnectionEstablished();
+}
+
+function stubRecovery(client: SlackClient) {
+  return spyOn(
+    client as unknown as { recoverMissedMessages: () => Promise<void> },
+    'recoverMissedMessages'
+  ).mockResolvedValue(undefined);
+}
+
 beforeEach(() => {
   fetchResponder = (url) => {
     if (String(url).endsWith('auth.test')) return ok({ user_id: 'U-BOT', url: 'https://team.slack.com/' });
@@ -63,13 +87,32 @@ describe('secondary connect()', () => {
     secondary.on('connected', () => { connected = true; });
     await secondary.connect();
 
-    expect(connected).toBe(true);
+    // The parent's socket is not live yet, so the secondary must NOT claim to
+    // be connected — its only feed does not exist. The state mirror delivers
+    // 'connected' when the parent's hello arrives.
+    expect(connected).toBe(false);
     expect(harness.calls.some((c) => c.url.includes('apps.connections.open'))).toBe(false);
 
     // Registration is live: parent routes an event for the secondary's channel.
     const inject = spyOn(secondary, '_injectSlackEvent');
     parent._injectSlackEvent(messageEvent('C-TASK'));
     expect(inject).toHaveBeenCalledTimes(1);
+
+    // ...and the deferred 'connected' lands with the parent's.
+    parent.emit('connected');
+    expect(connected).toBe(true);
+  });
+
+  it("emits 'connected' immediately when the parent's socket is already live", async () => {
+    const parent = makeParent();
+    setSocketConnected(parent, true);
+    const secondary = makeSecondary(parent, 'C-TASK');
+
+    let connected = false;
+    secondary.on('connected', () => { connected = true; });
+    await secondary.connect();
+
+    expect(connected).toBe(true);
   });
 });
 
@@ -170,9 +213,66 @@ describe('lifecycle and safety', () => {
     expect(received.message).toContain('through the pipe');
 
     // Dedup still applies on the injected path: same ts again → no second emit.
+    // The emission is deferred through getUser().then(...), so flush the
+    // microtask queue first — asserting synchronously passes even with the
+    // dedup guard removed.
     const emitSpy = spyOn(secondary, 'emit');
     parent._injectSlackEvent(messageEvent('C-TASK', 'through the pipe'));
+    await flush();
     expect(emitSpy.mock.calls.filter((c) => c[0] === 'message')).toHaveLength(0);
+  });
+
+  it('keeps mirroring parent state after the parent disconnects and reconnects', async () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+
+    // Base teardown detaches every listener, the state mirror included.
+    await parent.disconnect();
+    parent.prepareForReconnect();
+
+    const seen: string[] = [];
+    secondary.on('connected', () => seen.push('connected'));
+    parent.emit('connected');
+
+    expect(seen).toEqual(['connected']);
+  });
+});
+
+describe('reconnect recovery', () => {
+  it('recovers missed messages for every registered secondary', async () => {
+    const parent = makeParent();
+    const first = makeSecondary(parent, 'C-ONE');
+    const second = makeSecondary(parent, 'C-TWO');
+    parent.registerChannelClient('C-ONE', first);
+    parent.registerChannelClient('C-TWO', second);
+
+    const firstRecovery = stubRecovery(first);
+    const secondRecovery = stubRecovery(second);
+
+    // A reconnect: the parent's socket dropped and came back, so every
+    // secondary missed whatever arrived in the gap — their only feed is here.
+    setReconnecting(parent, true);
+    fireConnectionEstablished(parent);
+
+    expect(firstRecovery).toHaveBeenCalledTimes(1);
+    expect(secondRecovery).toHaveBeenCalledTimes(1);
+
+    await parent.disconnect();
+  });
+
+  it('does not recover for secondaries on a first connect', async () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+    const recovery = stubRecovery(secondary);
+
+    setReconnecting(parent, false);
+    fireConnectionEstablished(parent);
+
+    expect(recovery).not.toHaveBeenCalled();
+
+    await parent.disconnect();
   });
 });
 

--- a/src/platform/slack/shared-event-source.test.ts
+++ b/src/platform/slack/shared-event-source.test.ts
@@ -273,6 +273,29 @@ describe('lifecycle and safety', () => {
 
     expect(seen).toEqual(['connected']);
   });
+
+  it('re-arms the mirror even when the socket close throws synchronously', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+
+    spyOn(
+      parent as unknown as { forceCloseConnection: () => Promise<void> },
+      'forceCloseConnection'
+    ).mockImplementation(() => {
+      throw new Error('close blew up');
+    });
+
+    // The failure must still propagate — but it must not also leave the parent
+    // permanently mute towards its secondaries.
+    expect(() => parent.disconnect()).toThrow('close blew up');
+
+    const seen: string[] = [];
+    secondary.on('connected', () => seen.push('connected'));
+    parent.emit('connected');
+
+    expect(seen).toEqual(['connected']);
+  });
 });
 
 describe('reconnect recovery', () => {

--- a/src/platform/slack/shared-event-source.test.ts
+++ b/src/platform/slack/shared-event-source.test.ts
@@ -237,6 +237,42 @@ describe('lifecycle and safety', () => {
 
     expect(seen).toEqual(['connected']);
   });
+
+  it('re-arms the mirror before the socket close settles', () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+
+    const seen: string[] = [];
+    secondary.on('connected', () => seen.push('connected'));
+
+    // Base teardown drops the listeners synchronously but the socket close is
+    // a promise that can stay pending. A reconnect landing inside that window
+    // must not emit into a mirror-less parent — the secondaries would miss it
+    // permanently. Deliberately not awaited: that IS the window.
+    const closing = parent.disconnect();
+    parent.emit('connected');
+
+    expect(seen).toEqual(['connected']);
+    return closing;
+  });
+
+  it('does not stack mirror listeners when disconnects overlap', async () => {
+    const parent = makeParent();
+    const secondary = makeSecondary(parent, 'C-TASK');
+    parent.registerChannelClient('C-TASK', secondary);
+
+    // Both calls clear the listeners before either re-arms; a non-idempotent
+    // install leaves two mirrors, so every later event reaches the secondary
+    // twice.
+    await Promise.all([parent.disconnect(), parent.disconnect()]);
+
+    const seen: string[] = [];
+    secondary.on('connected', () => seen.push('connected'));
+    parent.emit('connected');
+
+    expect(seen).toEqual(['connected']);
+  });
 });
 
 describe('reconnect recovery', () => {


### PR DESCRIPTION
The second PR invited in #490: the single-socket event-injection layer, extracted standalone — routing + tests, none of the dynamic-channels semantics.

## Problem

Slack round-robins Socket Mode envelopes across **all** of an app's open connections. Any second `SlackClient` on the same app token therefore silently steals events from the first — the reason #479's DM auto-discovery excludes Slack today.

## Design

Exactly one client (the parent) owns the socket; other clients become **secondaries**:

- a secondary is constructed with the parent as an optional constructor argument; its `connect()` registers with the parent and opens no socket (Web API calls, which are plain HTTPS, work independently)
- the parent's `handleSlackEvent` hands events for registered channels (`event.channel` or `event.item.channel`) to the owning secondary via `_injectSlackEvent` **before** its own-channel filtering; the injected event then flows through the secondary's normal pipeline (bot-message filter, dedup, emission)
- events for unregistered channels keep today's behavior byte-for-byte; a config without secondaries has an empty routing map — **zero behavior change for existing deployments**

Lifecycle, from the pre-submission review rounds (Gemini, CodeRabbit, Codex):

- the parent mirrors `connected` / `disconnected` / `reconnecting` onto secondaries — its socket state IS their state
- on parent reconnect, missed-message recovery runs for the parent **and** every registered secondary
- `disconnect()` unregisters with an identity check, so an old instance's teardown can't evict its replacement; a disconnect racing `connect()`'s `fetchBotUser` await can't resurrect a dead registration
- registering a secondary for the parent's own channel throws (it could never receive events)
- documented ordering: register secondaries before connecting the parent, so no events fall in the gap

## Deliberately not included

No production consumer is wired — per the scoping in #490 this is the mechanism; DM auto-discovery on Slack (or any multi-channel feature) would be the consumer.

## Pre-existing caveat worth knowing (not introduced here)

`getMcpConfig()` hands the app token to the MCP permission server, which opens its own Socket Mode connection during permission prompts (`mcp-platform-api.ts`) — while that socket is open, Slack round-robins events to it too. Making the one-socket invariant absolute would mean routing those through the parent as well; happy to look at that as a follow-up.

## Tests

`shared-event-source.test.ts`, 10 cases: no-socket connect, routing (messages + reaction items), own-channel unaffected, unregistered-channel drop path unchanged, unregister stops routing, state mirroring, replacement-eviction guard, same-channel rejection, end-to-end emission with dedup on the injected path, disconnect unregisters. Full suite green (3,454).