### PR TITLE
1.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.29.3] - 2026-08-28
+
+Re-release of 1.29.2 — no code changes. The 1.29.2 npm publish failed the same
+way as 1.29.1 (npm masked-auth E404): the NPM_TOKEN repository secret had
+expired. The token has been rotated and this version ships what 1.29.2 was
+meant to ship, plus the release.yml retry fix (#496).
+
 ## [1.29.2] - 2026-08-24
 
 Re-release of 1.29.1 — no code changes. The 1.29.1 npm publish step failed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.29.2",
+      "version": "1.29.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.29.3** — a re-release of 1.29.2, no code changes. The 1.29.2 npm publish failed on the expired `NPM_TOKEN` (npm's masked-auth E404); the token has now been rotated, but the workflow-dispatch retry path isn't reachable from this session's GitHub integration (403 on `workflow_dispatch`). Landing this bump on `main` triggers `release.yml` by its push path, which tags `v1.29.3` and publishes with the rotated token.

Contents: `package.json` + `package-lock.json` version bump (npm version patch; `bun install` confirmed `bun.lock` unchanged) and a CHANGELOG entry.

## Checklist

- [x] Tests pass (`bun test`) — no code changes; CI verifies
- [x] Linting passes (`bun run lint`) — no code changes; CI verifies
- [x] Documentation updated (CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oYWi6VCBjsJdrK6CBeNe1

---
_Generated by [Claude Code](https://claude.ai/code/session_012oYWi6VCBjsJdrK6CBeNe1)_