### PR TITLE
Fix bot-to-bot refusal loops (#491) + agent-tools hardening from the #497 second-pass review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Approval is owner-gated for agent proposals:** an `!invite`d guest can react on the card, but only the session owner or a platform-allowlisted user may decide it — an unauthorized reaction is refused *without consuming the proposal* (and warned about once, not per toggle), so a guest can neither approve nor veto. Card text Claude authors is collapsed to a single line so it cannot restyle the approval card, and a proposal never displaces a pending human confirmation.
   - Tool availability follows the platform's `memory`/`routines`/`watches` config (advisory env gates on the MCP child; authoritative re-checks in the bot). Destructive operations (forget, pause, delete, manual run) are never exposed to Claude.
 
+### Fixed
+- **Bot-to-bot loops are broken at every link (#491).** Two claude-threads bots on one server could lock into an unbounded refusal loop (observed in the wild: 1,941 messages in 37 minutes) because the "not authorized to resume" refusal @-mentioned the bot it was refusing. Three independent fixes, any one of which stops that incident: refusals render the refused user as inline code instead of an @-mention (reads the same, notifies nobody); refusals are rate-limited to once per (thread, user) per 5 minutes instead of once per message; and claude-threads now recognizes another instance's own status posts (refusals, timeout/idle notices, cancellations, emergency shutdowns, resume announcements) and never treats them as a request — even when they carry a mention. A human message that merely starts with one of the status emojis still gets through. Thanks to @theprsi for the excellent incident analysis.
+- A signal death of the Claude process (exit code `null`) can no longer be labeled `exit:null` on the registry-removal path — it's a clean end like code 0, matching every sibling teardown site. (Independently found by @Jadefalkner.)
+
+### Security
+- **Watch prefilter keywords are collapsed to single-line** before rendering into the human-approval card — an embedded newline could otherwise smuggle multi-line markdown past the card's single-line guard (second-pass review follow-up to the agent tools).
+- **The decision bridge drops connections that stream more than 1MB without a newline** instead of buffering indefinitely — closes the cheapest local memory-exhaustion path against the bot process.
+- The single-line sanitizers (memory entries, agent card text, watch keywords) now also collapse U+0085 (NEL), which JS `\s` does not cover.
+
 ## [1.29.3] - 2026-08-28
 
 Re-release of 1.29.2 — no code changes. The 1.29.2 npm publish failed the same

--- a/src/mcp/decision-bridge.test.ts
+++ b/src/mcp/decision-bridge.test.ts
@@ -2,7 +2,7 @@
  * Tests for the decision bridge — real sockets, both halves.
  */
 
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, mock } from 'bun:test';
 import {
   DecisionBridgeServer,
   requestBridgeDecision,
@@ -220,6 +220,47 @@ describe('DecisionBridge - client disconnect aborts the handler', () => {
       const { rm } = await import('node:fs/promises');
       const { join } = await import('node:path');
       await rm(join(path, '..'), { recursive: true, force: true });
+    }
+  });
+});
+
+describe('DecisionBridge - oversize request cap', () => {
+  it('drops a connection that streams more than the request cap without a newline', async () => {
+    const handler = mock(async () => ({ behavior: 'allow' as const }));
+    const server = await DecisionBridgeServer.create(handler);
+    try {
+      const { createConnection } = await import('node:net');
+      // Flood past MAX_BRIDGE_REQUEST_BYTES with no newline, THEN a newline.
+      // With the cap the server severs the connection mid-flood, so no
+      // response can ever arrive; without it the completed giant line would
+      // come back as a "Malformed bridge request" deny. (Bun's client does
+      // not reliably surface the peer destroy while its own write buffer is
+      // full, so the assertion is response-silence, not a close event.)
+      const gotResponse = await new Promise<boolean>((resolve) => {
+        const socket = createConnection(server.path, () => {
+          socket.write('x'.repeat(2 * 1024 * 1024));
+          socket.write('\n');
+        });
+        const timer = setTimeout(() => {
+          socket.destroy();
+          resolve(false);
+        }, 2000);
+        socket.on('data', () => {
+          clearTimeout(timer);
+          socket.destroy();
+          resolve(true);
+        });
+        socket.on('error', () => {});
+      });
+      expect(gotResponse).toBe(false);
+      expect(handler).not.toHaveBeenCalled();
+
+      // The server survives the flood: a well-formed request on a fresh
+      // connection still round-trips.
+      const decision = await requestBridgeDecision(server.path, PLAN_REQUEST, 2000);
+      expect(decision.behavior).toBe('allow');
+    } finally {
+      await server.close();
     }
   });
 });

--- a/src/mcp/decision-bridge.ts
+++ b/src/mcp/decision-bridge.ts
@@ -117,6 +117,9 @@ export function bridgeSocketPath(): string {
  * Bot-side server. One per session; its `path` travels to the MCP child via
  * the DECISION_BRIDGE_PATH env var.
  */
+/** Cap on a single bridge request line; a connection exceeding it is dropped. */
+export const MAX_BRIDGE_REQUEST_BYTES = 1024 * 1024;
+
 export class DecisionBridgeServer {
   private liveSockets: Set<Socket> = new Set();
 
@@ -137,7 +140,18 @@ export class DecisionBridgeServer {
       socket.on('data', (chunk) => {
         buffer += chunk.toString('utf8');
         const newline = buffer.indexOf('\n');
-        if (newline === -1) return;
+        if (newline === -1) {
+          // No legitimate bridge request comes close to 1MB. Without a cap a
+          // same-UID process could grow this buffer until the bot OOMs —
+          // inside the conceded same-UID trust boundary (see
+          // bridgeSocketPath), but the cheap accident/abuse path is closed.
+          if (buffer.length > MAX_BRIDGE_REQUEST_BYTES) {
+            buffer = '';
+            responded = true;
+            socket.destroy();
+          }
+          return;
+        }
         const line = buffer.slice(0, newline);
         buffer = '';
         let request: BridgeRequest | AgentActionRequest;

--- a/src/memory/store.test.ts
+++ b/src/memory/store.test.ts
@@ -536,3 +536,10 @@ describe('supersede authorization (who may replace whose entries)', () => {
     expect(entries.some((e) => e.source === 'user' && e.addedBy === 'anne')).toBe(true);
   });
 });
+
+describe('sanitizeEntryText NEL hardening', () => {
+  test('collapses NEL (U+0085) like a newline — JS \\s does not cover it', () => {
+    const nel = String.fromCharCode(0x85);
+    expect(sanitizeEntryText(`a${nel}# fake header`)).toBe('a; # fake header');
+  });
+});

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -194,7 +194,7 @@ function normalizeForDedupe(text: string): string {
 
 /** Collapse to a single line (newlines become `; `, whitespace runs collapse). */
 function collapseEntryText(text: string): string {
-  return text.replace(/\s*[\r\n]+\s*/g, '; ').replace(/\s+/g, ' ').trim();
+  return text.replace(/\s*[\r\n\u0085]+\s*/g, '; ').replace(/[\s\u0085]+/g, ' ').trim();
 }
 
 /** Collapse to a single line and cap the length. */

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -7,10 +7,14 @@ import { mkdtempSync, rmSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { configureAuditLog, _resetAuditLog } from './persistence/audit-log.js';
-import { handleMessage, type MessageHandlerOptions } from './message-handler.js';
+import { handleMessage, isClaudeThreadsStatusPost, type MessageHandlerOptions } from './message-handler.js';
 import type { PlatformClient, PlatformPost, PlatformUser } from './platform/index.js';
 import type { SessionManager } from './session/index.js';
 import { createMockFormatter } from './test-utils/mock-formatter.js';
+import { resetResumeRefusalLimiter } from './session/refusal-limiter.js';
+
+// The refusal limiter is module-global state; every test starts unthrottled.
+beforeEach(() => resetResumeRefusalLimiter());
 
 // Create mock platform client
 function createMockPlatform(botName = 'claude-bot', platformType = 'slack') {
@@ -2478,5 +2482,135 @@ describe('handleMessage - watch evaluation hook', () => {
 
     expect(session.startSession).not.toHaveBeenCalled();
     expect(session.evaluateWatches).not.toHaveBeenCalled();
+  });
+});
+
+describe('bot-to-bot loop prevention (#491)', () => {
+  let client: PlatformClient & { posts: Map<string, string> };
+  let session: ReturnType<typeof createMockSessionManager>;
+
+  const pausedThreadPost = (overrides: Partial<PlatformPost> = {}): PlatformPost => ({
+    id: 'post1',
+    platformId: 'test',
+    channelId: 'channel1',
+    userId: 'user1',
+    message: 'continue please',
+    rootId: 'thread1',
+    createAt: Date.now(),
+    ...overrides,
+  });
+  const outsider: PlatformUser = { id: 'user1', username: 'outsider', displayName: 'Outsider' };
+
+  beforeEach(() => {
+    client = createMockPlatform();
+    session = createMockSessionManager();
+    (session.registry.getPersistedByThreadId as ReturnType<typeof mock>).mockReturnValue({ sessionAllowedUsers: ['allowed-user'] });
+    (session.getPersistedSession as ReturnType<typeof mock>).mockReturnValue({ sessionAllowedUsers: ['allowed-user'] });
+  });
+
+  test('the resume refusal never @-mentions the refused user', async () => {
+    await handleMessage(client, session, pausedThreadPost(), outsider, { platformId: 'test-platform' });
+
+    expect(session.resumePausedSession).not.toHaveBeenCalled();
+    const posted = [...client.posts.values()].join('\n');
+    expect(posted).toContain('is not authorized to resume this session');
+    // Inline code reads the same to a human and notifies nobody.
+    expect(posted).toContain('`outsider`');
+    expect(posted).not.toContain('@outsider');
+  });
+
+  test('the resume refusal fires once per (thread, user), not once per message', async () => {
+    for (let i = 0; i < 4; i++) {
+      await handleMessage(client, session, pausedThreadPost({ id: `post${i}` }), outsider, { platformId: 'test-platform' });
+    }
+
+    const refusals = [...client.posts.values()].filter((m) => m.includes('is not authorized'));
+    expect(refusals).toHaveLength(1);
+  });
+
+  test('a refusal for a different user in the same thread still posts', async () => {
+    await handleMessage(client, session, pausedThreadPost(), outsider, { platformId: 'test-platform' });
+    const other: PlatformUser = { id: 'user2', username: 'other-bot', displayName: 'Other' };
+    await handleMessage(client, session, pausedThreadPost({ id: 'post2' }), other, { platformId: 'test-platform' });
+
+    const refusals = [...client.posts.values()].filter((m) => m.includes('is not authorized'));
+    expect(refusals).toHaveLength(2);
+  });
+
+  test("another bot's refusal post never engages this bot, even when it @-mentions it", async () => {
+    // The incident shape: bot A's refusal @-mentions bot B, which passes B's
+    // mention gate and would start a session / produce a reply — which
+    // re-triggers A. The status-post guard drops it before any routing.
+    const post = pausedThreadPost({
+      message: '⚠️ @claude-bot is not authorized to resume this session',
+      rootId: '',
+    });
+    (session.registry.getPersistedByThreadId as ReturnType<typeof mock>).mockReturnValue(undefined);
+    (session.getPersistedSession as ReturnType<typeof mock>).mockReturnValue(undefined);
+
+    await handleMessage(client, session, post, outsider, { platformId: 'test-platform' });
+
+    expect(session.startSession).not.toHaveBeenCalled();
+    expect(session.resumePausedSession).not.toHaveBeenCalled();
+    expect(client.createPost).not.toHaveBeenCalled();
+  });
+
+  test('status posts are dropped in DCM before routing to the channel session', async () => {
+    (session.registry.getPersistedByThreadId as ReturnType<typeof mock>).mockReturnValue(undefined);
+    (session.getPersistedSession as ReturnType<typeof mock>).mockReturnValue(undefined);
+    const post = pausedThreadPost({
+      message: '⏱️ **Session idle** - will timeout in ~5 minutes without activity',
+      rootId: '',
+    });
+
+    await handleMessage(client, session, post, outsider, {
+      platformId: 'test-platform',
+      directChannelMode: true,
+    });
+
+    expect(session.startSession).not.toHaveBeenCalled();
+    expect(client.createPost).not.toHaveBeenCalled();
+  });
+
+  test('a human message that merely starts with the warning emoji still gets through', async () => {
+    (session.registry.getPersistedByThreadId as ReturnType<typeof mock>).mockReturnValue(undefined);
+    (session.getPersistedSession as ReturnType<typeof mock>).mockReturnValue(undefined);
+    const user: PlatformUser = { id: 'user1', username: 'allowed-user', displayName: 'User' };
+    const post = pausedThreadPost({
+      message: '⚠️ @claude-bot the staging deploy looks broken, can you check?',
+      rootId: '',
+    });
+
+    await handleMessage(client, session, post, user, { platformId: 'test-platform' });
+
+    expect(session.startSession).toHaveBeenCalled();
+  });
+});
+
+describe('isClaudeThreadsStatusPost (#491)', () => {
+  test.each([
+    ['⚠️ @some-bot is not authorized to resume this session'],
+    ['⚠️ `some-bot` is not authorized to resume this session'],
+    ['⚠️ <@U0BOTB> is not authorized'],
+    ['⚠️ **Too busy** - 5 sessions active. Please try again later.'],
+    ['⚠️ *Too busy* - 5 sessions active. Please try again later.'],
+    ['⏱️ **Session timed out** after 30 minutes of inactivity'],
+    ['⏱️ *Session idle* - will timeout in ~5 minutes without activity'],
+    ['🛑 **Session cancelled** by @someone'],
+    ['🔴 **EMERGENCY SHUTDOWN** initiated by @someone - killing 2 active sessions'],
+    ['🔄 **Session resumed** by @someone'],
+  ])('recognizes the bot status shape: %s', (message) => {
+    expect(isClaudeThreadsStatusPost(message)).toBe(true);
+  });
+
+  test.each([
+    ['⚠️ careful with the prod database'],
+    ['⚠️ @claude-bot the deploy authorization is broken'],
+    ['hello there'],
+    ['🛑 stop the presses, but read this first'],
+    ['is not authorized to resume this session'],
+    ['something ⚠️ @bot is not authorized'],
+  ])('lets ordinary messages through: %s', (message) => {
+    expect(isClaudeThreadsStatusPost(message)).toBe(false);
   });
 });

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -22,8 +22,39 @@ import { logSilentError } from './utils/error-handler/index.js';
 import { dcmThreadId, isDcmThreadId, resolveAckReaction, resolveApprovals, resolveDirectChannelMode, type DirectChannelModeConfig } from './platform/utils.js';
 import { auditLog } from './persistence/audit-log.js';
 import { createLogger } from './utils/logger.js';
+import { shouldPostResumeRefusal } from './session/refusal-limiter.js';
 
 const ackLog = createLogger('ack');
+
+/**
+ * Machine-generated status posts from claude-threads itself (any instance,
+ * any version). When several bots share a server, one bot's status output
+ * must never read as a request to another — a refusal that @-mentioned a
+ * fellow bot once produced an unbounded two-bot loop (#491). Matching is
+ * anchored to the exact emoji + phrase shapes the bot emits (with either
+ * platform's bold markers), so a human message that merely *starts* with one
+ * of these emoji still gets through.
+ */
+const BOLD = String.raw`(?:\*{1,2}|_{1,2})?`;
+const STATUS_POST_PATTERNS: RegExp[] = [
+  // Authorization refusals — the addressee may render as @name, `name`, or a
+  // raw <@U…> token depending on platform and version.
+  /^⚠️\s+\S+ is not authorized\b/u,
+  new RegExp(`^⚠️\\s+${BOLD}Too busy${BOLD} -`, 'u'),
+  new RegExp(`^⏱️\\s+${BOLD}Session (?:timed out|idle)${BOLD}`, 'u'),
+  new RegExp(`^🛑\\s+${BOLD}Session cancelled${BOLD}`, 'u'),
+  new RegExp(`^🔴\\s+${BOLD}EMERGENCY SHUTDOWN${BOLD}`, 'u'),
+  new RegExp(`^🔄\\s+${BOLD}Session resumed${BOLD}`, 'u'),
+];
+
+/**
+ * Whether a message is one of claude-threads' own status posts (#491).
+ * Exported for tests.
+ */
+export function isClaudeThreadsStatusPost(message: string): boolean {
+  const trimmed = message.trim();
+  return STATUS_POST_PATTERNS.some((re) => re.test(trimmed));
+}
 
 /**
  * Logger interface for message handler
@@ -126,6 +157,14 @@ export async function handleMessage(
   const formatter = client.getFormatter();
 
   try {
+    // Another claude-threads instance's status output is machine output,
+    // never a request — dropping it here breaks bot-to-bot loops (#491)
+    // regardless of which refusal or notice shape triggered them.
+    if (isClaudeThreadsStatusPost(message)) {
+      logger?.debug?.(`Ignoring claude-threads status post from @${username}`);
+      return;
+    }
+
     // Check for !kill command (emergency shutdown)
     const lowerMessage = message.trim().toLowerCase();
     if (
@@ -332,11 +371,18 @@ export async function handleMessage(
         const ownerScoped =
           resolveApprovals(client.approvals, isDcmThreadId(threadRoot)) === 'owner';
         if (!allowedUsers.has(username) && (ownerScoped || !client.isUserAllowed(username))) {
-          // Not allowed - could request approval but that would require the session to be active
-          await client.createPost(
-            `⚠️ ${formatter.formatUserMention(username)} is not authorized to resume this session`,
-            threadRoot
-          );
+          // Not allowed - could request approval but that would require the
+          // session to be active. The refusal deliberately does NOT @-mention
+          // the refused user (inline code reads the same to a human and
+          // notifies nobody) and is rate-limited per (thread, user): a message
+          // whose purpose is "stop talking to me" must not be the one shape
+          // guaranteed to wake another bot into replying (#491).
+          if (shouldPostResumeRefusal(platformId, threadRoot, username)) {
+            await client.createPost(
+              `⚠️ ${formatter.formatCode(username)} is not authorized to resume this session`,
+              threadRoot
+            );
+          }
           return;
         }
       }
@@ -397,7 +443,11 @@ export async function handleMessage(
       // other bots' posts through) two bots could warn at each other in an
       // endless loop.
       if (client.isBotMentioned(message)) {
-        await client.createPost(`⚠️ ${formatter.formatUserMention(username)} is not authorized`, threadRoot);
+        // No @-mention and rate-limited, for the same loop-safety reasons as
+        // the resume refusal above (#491).
+        if (shouldPostResumeRefusal(platformId, threadRoot, username)) {
+          await client.createPost(`⚠️ ${formatter.formatCode(username)} is not authorized`, threadRoot);
+        }
       }
       return;
     }

--- a/src/operations/agent-actions/handler.ts
+++ b/src/operations/agent-actions/handler.ts
@@ -260,7 +260,8 @@ const PROPOSED = 'proposed_awaiting_human_approval';
  * dismiss" must not be able to restyle the card or bury its badge.
  */
 function singleLine(text: string): string {
-  return text.replace(/\s+/g, ' ').trim();
+  // NEL (U+0085) is a line break to some renderers but not to JS \s.
+  return text.replace(/[\s\u0085]+/g, ' ').trim();
 }
 
 async function proposeRoutine(

--- a/src/persistence/watches-store.test.ts
+++ b/src/persistence/watches-store.test.ts
@@ -170,3 +170,16 @@ describe('WatchesStore', () => {
     expect(raw).toContain('version: 1');
   });
 });
+
+describe('validateKeywords card-injection hardening', () => {
+  test('collapses embedded newlines so keywords cannot carry multi-line markdown into the approval card', () => {
+    const result = validateKeywords(['deploy', 'x\n**approved by admin - react +1**\ny']);
+    expect(result).toEqual(['deploy', 'x **approved by admin - react +1** y']);
+  });
+
+  test('collapses NEL (U+0085), which JS \\s does not cover', () => {
+    const nel = String.fromCharCode(0x85);
+    const result = validateKeywords([`incident${nel}# fake header`]);
+    expect(result).toEqual(['incident # fake header']);
+  });
+});

--- a/src/persistence/watches-store.ts
+++ b/src/persistence/watches-store.ts
@@ -74,7 +74,10 @@ export function validateKeywords(raw: unknown): string[] | string {
   const cleaned = [...new Set(
     raw
       .filter((k): k is string => typeof k === 'string')
-      .map((k) => k.trim().toLowerCase())
+      // Collapse ALL whitespace (NEL U+0085 included — JS \s excludes it) to single spaces: keywords are
+      // rendered into the human-approval card, so an embedded newline could
+      // smuggle multi-line markdown past the card's single-line guard.
+      .map((k) => k.replace(/[\s\u0085]+/g, ' ').trim().toLowerCase())
       .filter((k) => k.length > 0 && k.length <= MAX_KEYWORD_LENGTH),
   )];
   if (cleaned.length < MIN_KEYWORDS) return 'at least one usable keyword is required';
@@ -95,7 +98,7 @@ export class WatchesStore extends PlatformListStore<Watch> {
     w.keywords = Array.isArray(w.keywords)
       ? w.keywords
         .filter((k): k is string => typeof k === 'string')
-        .map((k) => k.trim().toLowerCase())
+        .map((k) => k.replace(/[\s\u0085]+/g, ' ').trim().toLowerCase())
         .filter((k) => k.length > 0)
       : [];
   }

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -2063,8 +2063,10 @@ export async function handleExit(
     ctx.ops.unregisterWorktreeUser(session.worktreeInfo.worktreePath, session.sessionId);
   }
 
-  // Clean up session from maps and notify keep-alive
-  removeFromRegistry(session, ctx, code === 0 ? 'exit' : `exit:${code}`);
+  // Clean up session from maps and notify keep-alive. A signal death
+  // (code null) is a clean end like code 0 — matching closeThreadLogger and
+  // the unpersist branch below, so no path can label it 'exit:null'.
+  removeFromRegistry(session, ctx, code === 0 || code === null ? 'exit' : `exit:${code}`);
 
   // Only unpersist for normal exits
   if (code === 0 || code === null) {

--- a/src/session/reaction-router.test.ts
+++ b/src/session/reaction-router.test.ts
@@ -14,8 +14,12 @@
  * that `handleReaction` presents to platform clients.
  */
 
-import { describe, test, expect, mock } from 'bun:test';
+import { describe, test, expect, mock, beforeEach } from 'bun:test';
 import { handleReaction, type ReactionRouterDeps } from './reaction-router.js';
+import { resetResumeRefusalLimiter } from './refusal-limiter.js';
+
+// The refusal limiter is module-global state; every test starts unthrottled.
+beforeEach(() => resetResumeRefusalLimiter());
 import type { Session } from './types.js';
 import type { PlatformClient } from '../platform/index.js';
 import type { SessionRegistry } from './registry.js';
@@ -148,6 +152,7 @@ describe('ReactionRouter.handleReaction', () => {
       const platform = {
         isUserAllowed: mock((u: string) => u === 'alice'),
         createPost,
+        getFormatter: mock(() => ({ formatCode: (s: string) => `\`${s}\`` })),
       } as unknown as PlatformClient;
       const deps = makeDeps(null, {
         sessionStore: {
@@ -164,6 +169,33 @@ describe('ReactionRouter.handleReaction', () => {
         expect.stringContaining('not authorized'),
         'thread-paused',
       );
+      // The refusal must not @-mention the refused user — when that user is
+      // another claude-threads bot, the mention wakes it into replying and
+      // the two bots loop (#491). Inline code notifies nobody.
+      const refusal = (createPost.mock.calls[0] as unknown as string[])[0];
+      expect(refusal).toContain('`mallory`');
+      expect(refusal).not.toContain('@mallory');
+    });
+
+    test('repeat unauthorized reactions post the refusal only once per window (#491)', async () => {
+      const createPost = mock(() => Promise.resolve({ id: 'p' }));
+      const platform = {
+        isUserAllowed: mock((u: string) => u === 'alice'),
+        createPost,
+        getFormatter: mock(() => ({ formatCode: (s: string) => `\`${s}\`` })),
+      } as unknown as PlatformClient;
+      const deps = makeDeps(null, {
+        sessionStore: {
+          findByPostId: mock(() => persistedFixture()),
+        } as unknown as SessionStore,
+        platforms: new Map([['test', platform]]),
+      });
+
+      for (let i = 0; i < 3; i++) {
+        await handleReaction(deps, 'test', 'header-post', 'arrows_counterclockwise', 'mallory', 'added');
+      }
+
+      expect(createPost).toHaveBeenCalledTimes(1);
     });
 
     test('lets the session owner past the resume gate (no rejection post)', async () => {
@@ -236,7 +268,7 @@ describe('DCM approvals scoping (reaction gate)', () => {
     const platform = {
       isUserAllowed: mock(() => true), // bob is platform-allowed…
       createPost,
-      getFormatter: mock(() => ({ formatBold: (t: string) => t })),
+      getFormatter: mock(() => ({ formatBold: (t: string) => t, formatCode: (t: string) => `\`${t}\`` })),
       directChannelMode: { enabled: true, respondTo: 'all_messages' },
     } as unknown as PlatformClient;
     const deps = makeDeps(null, {

--- a/src/session/reaction-router.ts
+++ b/src/session/reaction-router.ts
@@ -37,6 +37,7 @@ import {
 } from '../utils/emoji.js';
 import { normalizeEmojiName } from '../platform/utils.js';
 import { isAuthorizedForSession, sessionAllowedUserSet } from './authorization.js';
+import { shouldPostResumeRefusal } from './refusal-limiter.js';
 import * as lifecycle from './lifecycle.js';
 import * as commands from '../operations/commands/index.js';
 import * as worktreeModule from '../operations/worktree/index.js';
@@ -166,9 +167,13 @@ async function tryResumeFromReaction(
       ? sessionAllowedUsers.has(username)
       : isAuthorizedForSession({ username, platform, sessionAllowedUsers }));
   if (!platform || !resumeAuthorized) {
-    if (platform) {
+    // No @-mention (inline code reads the same and notifies nobody) and
+    // rate-limited per (thread, user) — a refusal that mentioned another
+    // claude-threads bot once produced an unbounded reply loop (#491).
+    if (platform && shouldPostResumeRefusal(platformId, persistedSession.threadId, username)) {
+      const fmt = platform.getFormatter();
       await platform.createPost(
-        `⚠️ @${username} is not authorized to resume this session`,
+        `⚠️ ${fmt.formatCode(username)} is not authorized to resume this session`,
         persistedSession.threadId,
       );
     }

--- a/src/session/refusal-limiter.test.ts
+++ b/src/session/refusal-limiter.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the resume-refusal rate limiter (#491).
+ */
+
+import { describe, it, expect, beforeEach } from 'bun:test';
+import {
+  shouldPostResumeRefusal,
+  resetResumeRefusalLimiter,
+  REFUSAL_WINDOW_MS,
+} from './refusal-limiter.js';
+
+describe('shouldPostResumeRefusal', () => {
+  beforeEach(() => resetResumeRefusalLimiter());
+
+  it('allows the first refusal and blocks repeats inside the window', () => {
+    const t0 = 1_000_000;
+    expect(shouldPostResumeRefusal('p', 'thread', 'bot-b', t0)).toBe(true);
+    expect(shouldPostResumeRefusal('p', 'thread', 'bot-b', t0 + 1_000)).toBe(false);
+    expect(shouldPostResumeRefusal('p', 'thread', 'bot-b', t0 + REFUSAL_WINDOW_MS - 1)).toBe(false);
+  });
+
+  it('allows again once the window has elapsed', () => {
+    const t0 = 1_000_000;
+    expect(shouldPostResumeRefusal('p', 'thread', 'bot-b', t0)).toBe(true);
+    expect(shouldPostResumeRefusal('p', 'thread', 'bot-b', t0 + REFUSAL_WINDOW_MS)).toBe(true);
+  });
+
+  it('tracks (platform, thread, user) keys independently', () => {
+    const t0 = 1_000_000;
+    expect(shouldPostResumeRefusal('p', 'thread', 'bot-b', t0)).toBe(true);
+    expect(shouldPostResumeRefusal('p', 'thread', 'human', t0)).toBe(true);
+    expect(shouldPostResumeRefusal('p', 'other-thread', 'bot-b', t0)).toBe(true);
+    expect(shouldPostResumeRefusal('p2', 'thread', 'bot-b', t0)).toBe(true);
+    // ...and each of those is now throttled.
+    expect(shouldPostResumeRefusal('p', 'thread', 'human', t0 + 1)).toBe(false);
+  });
+
+  it('sweeps expired entries instead of growing without bound', () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < 600; i++) {
+      shouldPostResumeRefusal('p', `thread-${i}`, 'bot-b', t0);
+    }
+    // Far past the window: every old entry is sweepable; new keys keep working
+    // and old keys are refusable again.
+    const t1 = t0 + REFUSAL_WINDOW_MS * 2;
+    expect(shouldPostResumeRefusal('p', 'thread-0', 'bot-b', t1)).toBe(true);
+    expect(shouldPostResumeRefusal('p', 'thread-0', 'bot-b', t1 + 1)).toBe(false);
+  });
+});

--- a/src/session/refusal-limiter.ts
+++ b/src/session/refusal-limiter.ts
@@ -1,0 +1,47 @@
+/**
+ * Rate limiter for session-resume refusal posts (#491).
+ *
+ * The refusal carries the same information every time it fires: when two bots
+ * get into a refusal loop the posts repeat seconds apart, while a human who
+ * wanders back later still deserves to be told why nothing happened. One
+ * refusal per (platform, thread, user) per window covers both.
+ */
+
+const lastRefusalAt = new Map<string, number>();
+
+/** One refusal per (platform, thread, user) per this window. */
+export const REFUSAL_WINDOW_MS = 5 * 60 * 1000;
+
+/** Cleanup threshold — expired entries are swept when the map grows past this. */
+const CLEANUP_THRESHOLD = 500;
+
+/**
+ * Whether a resume-refusal post should be made for this (platform, thread,
+ * user) right now. Returns true at most once per REFUSAL_WINDOW_MS per key
+ * and records the attempt.
+ */
+export function shouldPostResumeRefusal(
+  platformId: string,
+  threadId: string,
+  username: string,
+  now: number = Date.now()
+): boolean {
+  const key = `${platformId}:${threadId}:${username}`;
+  const last = lastRefusalAt.get(key);
+  if (last !== undefined && now - last < REFUSAL_WINDOW_MS) {
+    return false;
+  }
+  // Opportunistic sweep keeps the map bounded without a timer.
+  if (lastRefusalAt.size >= CLEANUP_THRESHOLD) {
+    for (const [k, t] of lastRefusalAt) {
+      if (now - t >= REFUSAL_WINDOW_MS) lastRefusalAt.delete(k);
+    }
+  }
+  lastRefusalAt.set(key, now);
+  return true;
+}
+
+/** Test hook: forget all recorded refusals. */
+export function resetResumeRefusalLimiter(): void {
+  lastRefusalAt.clear();
+}


### PR DESCRIPTION
## Summary

Two batches of fixes, both verified red-green:

**Bot-to-bot loop prevention (#491).** Two claude-threads bots on one server locked into an unbounded refusal loop (1,941 messages in 37 minutes in @theprsi's incident report) because the "not authorized to resume" refusal @-mentions the bot it refuses. This lands all three of the suggested fixes — any one alone stops the incident:

1. Refusals render the refused user as **inline code** instead of an @-mention (`src/message-handler.ts`, `src/session/reaction-router.ts`) — reads the same to a human, notifies nobody.
2. Refusals are **rate-limited** to once per (platform, thread, user) per 5 minutes (`src/session/refusal-limiter.ts`).
3. A **status-post guard** at the top of `handleMessage` recognizes another claude-threads instance's own machine output (refusals, timeout/idle notices, cancellations, emergency shutdowns, resume announcements) and never treats it as a request — even when it carries a mention. Anchored to the exact emoji+phrase shapes (both platforms' bold markers), so a human message that merely *starts* with ⚠️ still gets through.

Also folds in the `exit:null` consistency fix on the registry-removal path (a signal death is a clean end like code 0; masked in practice by `auditSessionEnd`'s first-writer-wins guard) — independently found by @Jadefalkner on their fork.

**Agent-tools hardening** (follow-ups promised in the #497 second-pass review):

- `validateKeywords` collapses ALL whitespace to single spaces (confirmed finding: an embedded newline in a model-controlled watch keyword could smuggle multi-line markdown into the human-approval card past the `singleLine` guard).
- The decision bridge **destroys a connection that streams >1MB without a newline** instead of buffering unboundedly (confirmed: a same-UID flood grew bot RSS ~394MB in testing).
- The single-line sanitizers (memory entries, agent card text, watch keywords) also collapse **U+0085 (NEL)**, which JS `\s` does not cover.

## Changes

- `src/session/refusal-limiter.ts` (new) — per-(platform, thread, user) refusal rate limiter, bounded map, test hook
- `src/message-handler.ts` — status-post guard (`isClaudeThreadsStatusPost`, exported for tests); both refusal sites de-mentioned + rate-limited
- `src/session/reaction-router.ts` — reaction-resume refusal de-mentioned + rate-limited
- `src/session/lifecycle.ts` — `exit:null` → `exit` on the `removeFromRegistry` call
- `src/persistence/watches-store.ts` — keyword whitespace collapse (validate + hand-edit normalization paths)
- `src/operations/agent-actions/handler.ts`, `src/memory/store.ts` — NEL in the single-line collapses
- `src/mcp/decision-bridge.ts` — `MAX_BRIDGE_REQUEST_BYTES` (1MB) cap on the request line buffer
- Tests: new `refusal-limiter.test.ts`; loop-prevention + status-shape suites in `message-handler.test.ts`; refusal shape/rate-limit tests in `reaction-router.test.ts`; keyword/NEL/flood tests in the respective suites

## Testing

- Full unit suite: **3239 pass / 0 fail** (34 new tests), `tsc --noEmit` clean, `eslint` clean.
- **Red-verified**: with the source fixes stashed, the new tests fail (7 failures across all fix domains + the status-guard suite failing at the missing export); restored, everything is green.
- The bridge flood test asserts response-silence + server-survival rather than a client close event (Bun does not reliably surface a peer destroy while the client's write buffer is full).

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_