### PR TITLE
Release 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.30.0] - 2026-08-28
 
 ### Added
 - **Agent tools — Claude can now use the bot's own features from inside a session.** Six new MCP tools, executed in the bot process over the session's decision bridge:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.29.3",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.29.3",
+      "version": "1.30.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.29.3",
+  "version": "1.30.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.30.0** — promotes the CHANGELOG's `[Unreleased]` section to `## [1.30.0] - 2026-08-28`. On merge, `release.yml` verifies the tree, tags `v1.30.0`, creates the GitHub release, and publishes to npm.

## Changes

- `package.json` / `package-lock.json`: 1.29.3 → 1.30.0 (`npm version minor`; `bun install` run afterwards — `bun.lock` unchanged as expected, it does not record the root version)
- `CHANGELOG.md`: `[Unreleased]` promoted to `1.30.0`

**What ships in 1.30.0** (all merged since 1.29.3):
- **Agent tools** (#497): Claude can use memory, routines and watches from inside a session — six MCP tools over the decision bridge, human-👍-gated proposals, announced/capped memory writes, unattended-session loop prevention
- **Bot-to-bot loop fixes** (#508, fixes #491): de-mentioned + rate-limited refusals, status-post guard
- **Agent-tools hardening** (#508, from the #497 second-pass review): keyword single-lining, 1MB bridge request cap, NEL sanitization; plus the `exit:null` audit-reason consistency fix
- **Worktree fix** (#501, thanks @kaza): sessions started inside a worktree satisfy `worktreeMode` without prompting; fixes a pre-existing worktree refcount leak
- **Dependency bumps** (#503, #504): hono 4.13.3, dev-dependency group

## Testing

Full CI (typecheck, lint, security, unit, integration ×2, build, node-smoke ×3) was green on every merged PR above; the release workflow re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_