### PR TITLE
Release 1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.30.1] - 2026-08-28
 
 ### Security
 - **The card-injection guard now also covers the haiku-parsed `!watch`/`!routine` paths and the store-level gates.** 1.30.0 collapsed watch *keywords*; model-authored names, conditions and prompts from the natural-language parsers — and the stores' own name/condition normalization, the gate no caller can bypass — now go through the same shared `singleLine` helper (`utils/format.ts`), which replaces the two inline copies of the whitespace-collapse regex.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.30.1** — promotes the CHANGELOG's `[Unreleased]` section to `## [1.30.1] - 2026-08-28`. On merge, `release.yml` verifies the tree, tags `v1.30.1`, creates the GitHub release, and publishes to npm.

## Changes

- `package.json` / `package-lock.json`: 1.30.0 → 1.30.1 (`npm version patch`; `bun install` run afterwards — no changes, as expected)
- `CHANGELOG.md`: `[Unreleased]` promoted to `1.30.1`

**What ships in 1.30.1** (merged since 1.30.0):
- **Card-injection guard completion** (#507): the haiku-parsed `!watch`/`!routine` paths and the store-level name/condition gates now collapse model-authored text through one shared NEL-aware `singleLine` helper — closing the last confirmed finding from the #497 second-pass security review.

## Testing

Full CI was green on #507 before merge (independent verification: 3245/3245 unit tests, red spot-check on the parser guard); the release workflow re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_