### PR TITLE
Release 1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.31.0] - 2026-08-29
 
 ### Added
 - **Watches and routines now carry an explicit approval posture, chosen at creation.** The confirmation card offers 👍 *save* (each fired run asks for in-thread approval before every tool action) or ✅ *save + run autonomously* (no approval prompts) alongside 👎 *discard*. The choice is persisted per item (`requireApproval`) and enforced at fire time: an approval-required fire runs with interactive permissions even on a `skipPermissions` platform, so a watch triggered by attacker-influenceable channel content cannot silently execute tools with no human in the loop. The safe posture is the default — existing watches/routines and agent-proposed items always require approval (the autonomous option is never offered for agent proposals). Choosing the autonomous posture is owner-gated: a non-owner participant's ✅ is downgraded to approvals-required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.30.2",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.30.2",
+      "version": "1.31.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.30.2",
+  "version": "1.31.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.31.0** — promotes the CHANGELOG's `[Unreleased]` section to `## [1.31.0] - 2026-08-29`. On merge, `release.yml` verifies the tree, tags, creates the GitHub release, and publishes to npm.

Minor (not patch) because the watch/routine approval posture is a user-facing feature: the confirmation card now offers 👍 *save (approval-required fires)* vs ✅ *save + run autonomously*.

## Changes

- `package.json` / `package-lock.json`: 1.30.2 → 1.31.0 (`npm version minor`; `bun install` after — no lockfile changes, as expected)
- `CHANGELOG.md`: `[Unreleased]` promoted

**What ships in 1.31.0** (merged since 1.30.2):
- **Security review fixes** (#512): explicit approval posture for watches/routines chosen at creation and enforced at fire time (approval-required fires run interactive even on `skipPermissions` platforms; safe default for all pre-existing items); distillation skips unattended sessions; owner-gated ✅ invite (non-owner ✅ downgrades to one-shot allow); worktree branch-name validation incl. the Windows `shell:true` injection vector; platform-scoped persisted-session lookups; `update-state.json` 0600; persisted free-text caps.

## Testing

Full CI green on #512 before merge; independent review verified all eight changes with red-green checks (3270/3270 tests, tsc/lint/knip clean). The release workflow re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_