### PR TITLE
1.31.1: regression guard for cross-platform resume scoping + two display fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.31.1] - 2026-08-29
+
+### Security
+- **Regression guard for the cross-platform resume scoping (1.31.0).** The `resumePausedSession` sink is now covered by a test that fails if the `platformId` scope is removed — a message on one platform must never resume a session persisted under another platform whose thread id collides. The fix shipped correct in 1.31.0 but without this guard.
+
+### Fixed
+- **A rejected branch name can no longer break its own error message.** An invalid `!worktree <name>` whose name contains a backtick or newline is sanitized for display, so it stays inside its markdown code span in the error post.
+- **A downgraded "✅ Invite to session" reaction is no longer silent.** When a non-owner participant's ✅ is downgraded to a one-shot allow (only the owner may grant standing membership), the bot now says so, instead of leaving the reactor to assume the invite succeeded.
+
 ## [1.31.0] - 2026-08-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.31.0",
+      "version": "1.31.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",

--- a/src/operations/executors/message-approval.test.ts
+++ b/src/operations/executors/message-approval.test.ts
@@ -249,6 +249,9 @@ describe('MessageApprovalExecutor', () => {
       // Downgraded: message allowed once, but NO standing invite granted.
       expect(messageApprovalCompleted!.decision).toBe('allow');
       expect(messageApprovalCompleted!.fromUser).toBe('mallory');
+      // The reactor is told the invite was declined (not left to assume it worked).
+      const posts = [...(platform as unknown as { posts: Map<string, { content: string }> }).posts.values()];
+      expect(posts.some((p) => p.content.includes('Only the session owner can invite'))).toBe(true);
     });
 
     it('honors ✅ invite from the session owner', async () => {

--- a/src/operations/executors/message-approval.ts
+++ b/src/operations/executors/message-approval.ts
@@ -190,6 +190,13 @@ export class MessageApprovalExecutor extends BaseExecutor<MessageApprovalState> 
           ctx.logger.info(
             `Message approval invite (✅) from @${user} downgraded to allow-once: only the session owner may invite`
           );
+          // Tell the reactor their invite was declined and only a one-shot
+          // allow was granted, so a guest who reacted ✅ doesn't wrongly believe
+          // they added the user to the session.
+          await ctx.createPost(
+            `ℹ️ Only the session owner can invite ${ctx.formatter.formatUserMention(pending.fromUser)} to the session — allowing this one message instead.`,
+            { type: 'system' },
+          );
           const handled = await this.handleMessageApprovalResponse(postId, 'allow', user, ctx);
           ctx.logger.debug(`MessageApprovalExecutor: outcome=allow (invite downgraded), handled=${handled}`);
           return handled;

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -54,6 +54,17 @@ const log = createLogger('worktree');
 const sessionLog = createSessionLog(log);
 
 /**
+ * Make a rejected branch name safe to show inside a markdown code span. The
+ * name failed validation precisely because it contains something unusual — a
+ * backtick would otherwise break out of the `code` span in the error post, and
+ * a newline would break the line. Strip both for display only (the rejection
+ * itself already happened on the raw value).
+ */
+function displayBranchName(name: string): string {
+  return name.replace(/[`\r\n]/g, '').slice(0, 100);
+}
+
+/**
  * Parse git worktree errors and return a user-friendly message.
  * Common errors include:
  * - Branch already checked out in another worktree
@@ -331,7 +342,7 @@ export async function handleWorktreeBranchResponse(
 
   // Validate branch name
   if (!isValidBranchName(branchName)) {
-    await postError(session, `Invalid branch name: \`${branchName}\`. Please provide a valid git branch name.`);
+    await postError(session, `Invalid branch name: \`${displayBranchName(branchName)}\`. Please provide a valid git branch name.`);
     sessionLog(session).warn(`🌿 Invalid branch name: ${branchName}`);
     return true; // We handled it, but need another response
   }
@@ -454,7 +465,7 @@ export async function createAndSwitchToWorktree(
   // injection (a leading `-`) and — on Windows, where the spawn wrapper adds
   // `shell:true` — cmd.exe command injection.
   if (!isValidBranchName(branch)) {
-    await postError(session, `Invalid branch name: \`${branch}\`. Please provide a valid git branch name.`);
+    await postError(session, `Invalid branch name: \`${displayBranchName(branch)}\`. Please provide a valid git branch name.`);
     sessionLog(session).warn(`🌿 Rejected invalid branch name: ${branch}`);
     return;
   }

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1306,6 +1306,35 @@ describe('authorization gate at sinks (#388)', () => {
 
       expect(ctx.ops.acquireClaudeAccount).toHaveBeenCalled();
     });
+
+    it('does not resume a session from another platform (cross-platform threadId collision)', async () => {
+      // SECURITY regression: a session lives under platform-a. A message
+      // arrives on platform-b whose threadId collides. The resume sink must be
+      // scoped to the message's platform — without scoping, platform-b's
+      // message would resume platform-a's session (importing its allowlist,
+      // working dir, worktree and Claude account), and the authorization check
+      // would run against platform-a's allowlist instead of platform-b's.
+      const platformA = createMockPlatform({
+        isUserAllowed: mock((u: string) => u === 'alice') as any,
+        getPost: mock(() => Promise.resolve({ id: 'shared-thread' })) as any,
+      });
+      const ctx = createMockSessionContext(new Map());
+      (ctx.state.platforms as Map<string, PlatformClient>).set('platform-a', platformA);
+      (ctx.state.sessionStore.load as any).mockReturnValue(
+        new Map([[
+          'platform-a:shared-thread',
+          persistedState({ threadId: 'shared-thread', platformId: 'platform-a' }),
+        ]]),
+      );
+
+      // Alice is authorized on platform-a; the message arrives on platform-b.
+      await lifecycle.resumePausedSession('shared-thread', 'continue', undefined, ctx, 'alice', 'platform-b');
+
+      // Scoped out: no session resolves for platform-b, so nothing is resumed.
+      // (Without the platformId scope, platform-a's session would be found and
+      // resumed here — acquireClaudeAccount would be called.)
+      expect(ctx.ops.acquireClaudeAccount).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-ups to the **1.31.0** security release. The final focused review of the review-fix delta landed *after* 1.31.0 had already auto-released; this patch addresses its one finding plus two cosmetic nits the owner's merge-review flagged. Nothing here fixes a bug in 1.31.0 — the shipped code is correct — but it adds a missing regression guard and two display fixes.

**This PR bumps the version (`1.31.0 → 1.31.1`), so merging it will trigger `release.yml` → npm publish of 1.31.1.**

## Changes

- **Regression guard for the cross-platform resume scoping** — `resumePausedSession` → `findPersistedByThreadId` is now covered by a red-green test: a message on one platform must not resume a session persisted under another platform whose `threadId` collides. Verified it fails when the `session.platformId === platformId` check is removed (the 1.31.0 fix shipped correct but untested; the review flagged this as the one gap).
- **Sanitize a rejected branch name in the error post** — an invalid `!worktree <name>` containing a backtick/newline is stripped for display so it can't break out of its markdown code span.
- **Non-owner `✅ Invite` downgrade is no longer silent** — when a guest's ✅ is downgraded to a one-shot allow (only the owner may grant standing membership), the bot now says so instead of leaving the reactor to assume the invite worked.

Patch level per semver: fixes + a test, no new feature.

## Testing

- Full unit suite: **3271 pass, 0 fail** (`bun run test`).
- `bun run typecheck`, `bun run lint`, `bun run knip` all clean.
- The new scoping test verified **red** (revert the scope check → fails) and **green** (restored → passes).

## Not in this PR (tracked as follow-ups)

- Active-session `threadId` lookups (`findByThreadId`, the active branch of `isUserAllowedInSession`) remain cross-platform-unscoped — same defense-in-depth class, IDs don't collide today.
- The approval posture isn't shown in `!routines`/`!watches` listings and can't be flipped after creation.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG `[1.31.1]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9MLgT2BbGTdtM6DuMgD9a)_