### PR TITLE
Fix flaky integration test: 'should ignore side conversations'

### DIFF
--- a/tests/integration/suites/session-lifecycle.test.ts
+++ b/tests/integration/suites/session-lifecycle.test.ts
@@ -328,25 +328,39 @@ describe.skipIf(SKIP)('Session Lifecycle', () => {
         // Wait for session to end (result event processed)
         await waitForSessionEnded(bot.sessionManager, rootPost.id, { timeout: 5000 });
 
-        // Wait for bot post count to stabilize (ensures all buffered content is flushed)
-        const initialBotPostCount = await waitForStableBotPostCount(ctx, rootPost.id, {
+        // Let the ended session's output settle in the read API before acting.
+        await waitForStableBotPostCount(ctx, rootPost.id, {
           timeout: 5000,
           stableFor: 500,
         });
 
-        // Send a message to someone else in the thread (not @mentioning the bot)
-        // Using a message that clearly does NOT mention the bot
-        await sendFollowUp(ctx, rootPost.id, 'Hey team, what do you think about this?');
+        // Send a message to someone else in the thread (not @mentioning the bot).
+        // Keep the created post so we can compare against its creation time.
+        const sideConvo = await sendFollowUp(ctx, rootPost.id, 'Hey team, what do you think about this?');
 
-        // Wait for bot post count to stabilize again (check for unwanted responses)
-        const afterBotPostCount = await waitForStableBotPostCount(ctx, rootPost.id, {
+        // Give the bot a window to (wrongly) respond, if it were going to.
+        await waitForStableBotPostCount(ctx, rootPost.id, {
           timeout: 2000,
           stableFor: 500,
         });
 
-        // Bot should not have started a new session or responded to non-mention
+        // Bot should not have started a new session or responded to the non-mention.
         expect(bot.sessionManager.isInSessionThread(rootPost.id)).toBe(false);
-        expect(afterBotPostCount).toBe(initialBotPostCount);
+
+        // Correct-by-construction check, immune to Mattermost's read-visibility lag:
+        // a genuine bot *response* to the side conversation would be created AFTER
+        // it, whereas any post from the just-ended session was created BEFORE it.
+        // So assert no bot post exists that was created after the side-conversation
+        // message. (The previous `afterCount === initialCount` assertion flaked when
+        // a post from the ended session became readable via the API just after the
+        // baseline window closed — a test read-timing race, not a resume bug: the
+        // ended session is soft-deleted and `resumePausedSession` reads `load()`,
+        // which excludes soft-deleted sessions, so the reply is a genuine no-op.)
+        const postsAfter = await getThreadPosts(ctx, rootPost.id);
+        const botRepliesAfterSideConvo = postsAfter.filter(
+          (p) => ctx.botUserIds.includes(p.userId) && p.createAt > sideConvo.createAt,
+        );
+        expect(botRepliesAfterSideConvo).toEqual([]);
       });
     });
 


### PR DESCRIPTION
## Summary

De-flakes the `Session Lifecycle > … > should ignore side conversations (@other_user)` integration test, which intermittently fails on the **mattermost** matrix (it flaked on #514's CI). **Test-only change — no product code touched.**

## Root cause (a test read-timing race, not a product bug)

The test ends a session, sends a plain non-mention follow-up, then asserted the bot's post count was unchanged (`afterCount === initialCount`).

- On normal exit, `handleExit` awaits the final flush, then synchronously removes the session from the registry and soft-deletes it. A non-mention follow-up afterward hits the paused-session path, but `resumePausedSession` reads `load()`, which **excludes soft-deleted sessions** → the reply is a genuine **no-op, no post**. The non-racy assertion in the same test (`isInSessionThread === false`) confirms correct behavior and never flaked.
- The flake is purely in the count assertion: on Mattermost (eventually-consistent post reads — unlike the deterministic Slack mock, where it never flakes) a post from the **just-ended** session can become readable via the API *just after* the baseline stability window closed, inflating the after-count.

## Fix (correct-by-construction, immune to read-visibility lag)

Instead of comparing counts, assert that **no bot post exists that was created after the side-conversation message**. A genuine response would be created *after* the trigger; any ended-session post was created *before* it — so a late-visible old post can no longer masquerade as a new reply. This removes the timing dependency entirely rather than tuning a settle window.

## Testing

- Verified on the **Slack** integration path: 16/16 green across single-test and full-suite loops (`test:integration:slack`), so no regression there.
- The **Mattermost** path can't be exercised locally in this environment (no Docker daemon), so this PR's own `integration (mattermost)` CI run is the real-environment check. The change is designed to be correct by construction (timestamp comparison), not a timing tweak.
- `tsc` / `eslint` clean.

## Context

This unblocks the 1.31.1 release PR (#514), which was red purely on this flake. Once this merges, #514 picks up the de-flaked test.

## Checklist

- [x] Tests pass (Slack integration + unit gate; Mattermost via this PR's CI)
- [x] Linting passes
- [ ] Documentation updated — n/a (test-infra only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9MLgT2BbGTdtM6DuMgD9a)_