### PR TITLE
Scope active-session threadId lookups by platformId (defense-in-depth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- **Active-session thread-id lookups are now scoped by `platformId`**, completing the cross-platform privacy boundary that 1.31.0/1.31.1 established for the persisted store. `SessionRegistry.findByThreadId` takes an optional `platformId` and resolves O(1) against the composite key when given; the message router (`handleMessage`) and the in-session authorization check (`isUserAllowedInSession`) now pass it, so a thread id that collides across platforms can no longer resolve to — or authorize a user against — another platform's *active* session, and the router and auth check always agree on which session a message belongs to. Defense-in-depth: real Mattermost (26-char) and Slack (dotted-ts) ids don't collide today.
+
 ## [1.31.1] - 2026-08-29
 
 ### Security

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -211,7 +211,7 @@ export async function handleMessage(
 
     // Follow-up in active thread
     // Use registry to check for active session directly
-    const activeSession = session.registry.findByThreadId(threadRoot);
+    const activeSession = session.registry.findByThreadId(threadRoot, platformId);
     if (activeSession) {
       // A message opening by addressing someone else is a side conversation:
       // track it (if from an approved user) and don't interrupt Claude.

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -528,11 +528,12 @@ describe('SessionManager', () => {
     mgr: SessionManager,
     platform: PlatformClient,
     threadId: string,
-    overrides: Record<string, unknown> = {}
+    overrides: Record<string, unknown> = {},
+    platformId = 'test-platform'
   ) {
-    const sessionId = `test-platform:${threadId}`;
+    const sessionId = `${platformId}:${threadId}`;
     const session: any = {
-      platformId: 'test-platform',
+      platformId,
       threadId,
       sessionId,
       claudeSessionId: `claude-${threadId}`,
@@ -612,6 +613,28 @@ describe('SessionManager', () => {
         sessionAllowedUsers: new Set(['alice']),
       });
       expect(manager.isUserAllowedInSession('thread-X', 'mallory', 'test-platform')).toBe(false);
+    });
+
+    test('scopes the active-session check to the platform (cross-platform thread-id collision)', () => {
+      // SECURITY: two platforms host an active session on the same thread id,
+      // each with its own allowlist. The active-session authorization must be
+      // scoped to the message's platform — a user allowed on platform A's
+      // session must NOT be authorized when the query is scoped to platform B.
+      injectSession(manager, platform as unknown as PlatformClient, 'shared', {
+        sessionAllowedUsers: new Set(['alice']),
+      }); // default platformId 'test-platform'
+      injectSession(manager, platform as unknown as PlatformClient, 'shared', {
+        sessionAllowedUsers: new Set(['bob']),
+      }, 'other-platform');
+
+      // Each user is authorized only on their own platform's session.
+      expect(manager.isUserAllowedInSession('shared', 'alice', 'test-platform')).toBe(true);
+      expect(manager.isUserAllowedInSession('shared', 'bob', 'other-platform')).toBe(true);
+      // The boundary: alice (allowed on test-platform) is NOT authorized when
+      // the query is scoped to other-platform. Without the scoping, the unscoped
+      // first-match lookup would wrongly authorize her here.
+      expect(manager.isUserAllowedInSession('shared', 'alice', 'other-platform')).toBe(false);
+      expect(manager.isUserAllowedInSession('shared', 'bob', 'test-platform')).toBe(false);
     });
   });
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1234,8 +1234,9 @@ export class SessionManager extends EventEmitter {
    * Delegates to registry.getPersistedByThreadId() internally.
    */
   hasPausedSession(threadId: string, platformId?: string): boolean {
-    // If there's an active session, it's not paused
-    if (this.registry.findByThreadId(threadId)) return false;
+    // If there's an active session, it's not paused (scoped to platform when
+    // known, consistent with the persisted lookup below).
+    if (this.registry.findByThreadId(threadId, platformId)) return false;
     // Check for persisted session
     return this.registry.getPersistedByThreadId(threadId, platformId) !== undefined;
   }
@@ -1748,7 +1749,12 @@ export class SessionManager extends EventEmitter {
   }
 
   isUserAllowedInSession(threadId: string, username: string, platformId: string): boolean {
-    const session = this.findSessionByThreadId(threadId);
+    // Scope the active-session lookup to the message's platform too (not just
+    // the persisted branch below): a thread id colliding across platforms must
+    // not authorize a user against another platform's active session, and this
+    // must resolve the SAME session the message router did (message-handler
+    // also scopes its findByThreadId by platformId).
+    const session = this.registry.find(platformId, threadId);
     if (!session) {
       // Check persisted session, scoped to the message's platform so a
       // cross-platform thread-id collision cannot authorize a user against

--- a/src/session/registry.test.ts
+++ b/src/session/registry.test.ts
@@ -226,7 +226,7 @@ describe('SessionRegistry', () => {
       expect(found).toBeUndefined();
     });
 
-    it('searches across multiple platforms', () => {
+    it('searches across multiple platforms when no platformId is given', () => {
       const session1 = createMockSession({ platformId: 'p1', threadId: 't1' });
       const session2 = createMockSession({ platformId: 'p2', threadId: 't2' });
 
@@ -235,6 +235,26 @@ describe('SessionRegistry', () => {
 
       expect(registry.findByThreadId('t1')).toBe(session1);
       expect(registry.findByThreadId('t2')).toBe(session2);
+    });
+
+    it('scopes to the given platformId (does not cross the platform boundary)', () => {
+      // SECURITY: two platforms with a colliding thread id. A lookup that knows
+      // the message's platform must resolve only that platform's active session,
+      // never the other's (platformId is the store's privacy boundary).
+      const onP1 = createMockSession({ platformId: 'p1', threadId: 'shared' });
+      const onP2 = createMockSession({ platformId: 'p2', threadId: 'shared' });
+      registry.register(onP1);
+      registry.register(onP2);
+
+      expect(registry.findByThreadId('shared', 'p1')).toBe(onP1);
+      expect(registry.findByThreadId('shared', 'p2')).toBe(onP2);
+    });
+
+    it('returns undefined when the thread is active only on a different platform', () => {
+      const onP1 = createMockSession({ platformId: 'p1', threadId: 'shared' });
+      registry.register(onP1);
+
+      expect(registry.findByThreadId('shared', 'p2')).toBeUndefined();
     });
   });
 

--- a/src/session/registry.ts
+++ b/src/session/registry.ts
@@ -75,10 +75,21 @@ export class SessionRegistry {
   }
 
   /**
-   * Find active session by thread ID alone (searches all platforms).
-   * Use when platformId is not readily available.
+   * Find an active session by thread ID.
+   *
+   * When the caller knows the platform, pass `platformId`: the lookup then
+   * resolves O(1) against the composite key and is scoped to that platform.
+   * platformId is the session store's privacy boundary, so a thread id that
+   * collides across platforms must not resolve to another platform's active
+   * session — security-relevant callers (the message router, the in-session
+   * authorization check) always pass it. Without a `platformId` this falls
+   * back to an unscoped scan across all platforms, kept for the callers that
+   * genuinely don't have one to hand.
    */
-  findByThreadId(threadId: string): Session | undefined {
+  findByThreadId(threadId: string, platformId?: string): Session | undefined {
+    if (platformId !== undefined) {
+      return this.find(platformId, threadId);
+    }
     for (const session of this.sessions.values()) {
       if (session.threadId === threadId) {
         return session;


### PR DESCRIPTION
## Summary

Follow-up #1 from the security review. Completes the cross-platform privacy boundary that 1.31.0/1.31.1 established for the **persisted** session store — now for the **in-memory active-session** lookups. Defense-in-depth, not a live bug: real Mattermost (26-char) and Slack (dotted-ts) thread ids don't collide today.

**No version bump** — this lands under `## [Unreleased]` and can ride the next release; merging it does not auto-publish.

## The gap

Sessions are keyed `platformId:threadId`. The review scoped the persisted lookups, but the active-session ones still matched on thread id alone:
- `SessionRegistry.findByThreadId(threadId)` scanned all platforms and returned the first thread-id match.
- The active-session branch of `isUserAllowedInSession` used that unscoped lookup even though it now receives `platformId`.

So a thread id colliding across two platforms could, in principle, resolve to — or authorize a user against — the *other* platform's active session, and the message router and the auth check could disagree on which session a message belongs to.

## Changes

- `SessionRegistry.findByThreadId(threadId, platformId?)` — when `platformId` is given, resolves **O(1)** against the composite key, scoped to that platform; unscoped scan kept as the fallback for callers that don't have one.
- `handleMessage` (the message router) passes `platformId` → a message resolves only to its own platform's active session.
- `isUserAllowedInSession`'s active branch uses `registry.find(platformId, threadId)` → authorizes against the same session the router resolved.
- `hasPausedSession`'s active check is scoped too, for consistency.

Non-boundary per-command lookups (`findSessionByThreadId`'s other callers) keep the unscoped fallback: they run only *after* the platform-scoped router/auth have admitted the message, and ids don't collide today. Scoping them would be a wide, low-value refactor.

## Testing

- Red-green tests (both verified **red** without the fix):
  - registry: a colliding thread id on two platforms resolves only the correct platform's session (and returns `undefined` for a platform with no such session);
  - `isUserAllowedInSession`: a user allowed on platform A's active session is **not** authorized when the query is scoped to platform B.
- Full suite: **3274 pass, 0 fail**; `tsc` / `eslint` / `knip` clean.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated — CHANGELOG `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9MLgT2BbGTdtM6DuMgD9a)_