### PR TITLE
Show and flip routine/watch approval posture after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The approval posture of a routine or watch is now visible and changeable after creation.** `!routines` / `!watches` listings show each item's posture inline (👍 approvals · ✅ autonomous), and a new owner-gated `!routines approval <n> on|off` / `!watches approval <n> on|off` flips it — `off` makes an item run autonomously, `on` restores per-action approval. Turning a watch autonomous is the same sensitive choice the creation card gates behind the owner and an explicit ✅, so the flip command is owner-gated too; the safe approvals-required posture stays the default for older data.
+
 ### Security
 - **Active-session thread-id lookups are now scoped by `platformId`**, completing the cross-platform privacy boundary that 1.31.0/1.31.1 established for the persisted store. `SessionRegistry.findByThreadId` takes an optional `platformId` and resolves O(1) against the composite key when given; the message router (`handleMessage`) and the in-session authorization check (`isUserAllowedInSession`) now pass it, so a thread id that collides across platforms can no longer resolve to — or authorize a user against — another platform's *active* session, and the router and auth check always agree on which session a message belongs to. Defense-in-depth: real Mattermost (26-char) and Slack (dotted-ts) ids don't collide today.
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Type `!help` in any session thread:
 | `!remember <text>`                          | Save a note to the channel's shared memory                                               |
 | `!memory`                                   | Show channel memory (`forget <n\|text>` removes entries)                                 |
 | `!routine <schedule, task>`                 | Schedule a recurring routine in natural language (confirmed with 👍)                     |
-| `!routines`                                 | List routines (`pause\|resume\|delete\|run <n>` to manage)                               |
+| `!routines`                                 | List routines (`pause\|resume\|delete\|run <n>`, `approval <n> on\|off` to manage)       |
 | `!watch <when ..., task>`                   | Create an event trigger in natural language (confirmed with 👍)                          |
-| `!watches`                                  | List event triggers (`pause\|resume\|delete <n>` to manage)                             |
+| `!watches`                                  | List event triggers (`pause\|resume\|delete <n>`, `approval <n> on\|off` to manage)      |
 | `!update`                                   | Show auto-update status (`!update now` / `!update defer`)                                |
 | `!bug <desc>`                               | Report a bug with context (creates a GitHub issue)                                       |
 | `!approve`                                  | Approve pending plan (alternative to 👍; also `!yes`)                                    |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -382,8 +382,12 @@ confirmation says so.
 
 **Managing:**
 
-- `!routines` — numbered list with schedule, creator, and last-run status
+- `!routines` — numbered list with schedule, creator, last-run status, and
+  the approval posture (👍 approvals · ✅ autonomous)
 - `!routines pause|resume|delete <n>` — owner-gated
+- `!routines approval <n> on|off` — owner-gated; flip the approval posture
+  after creation. `on` restores per-action approval, `off` makes each run
+  autonomous (no approval prompts, even on a `skipPermissions` platform)
 - `!routines run <n>` — fire now, outside the schedule (platform-allowed
   users only — not temporarily `!invite`d guests; does not consume the
   period's scheduled fire)
@@ -452,8 +456,12 @@ all three, and **nothing is saved until someone reacts 👍**.
 
 **Managing:**
 
-- `!watches` — numbered list with condition, creator, and last-fire status
+- `!watches` — numbered list with condition, creator, last-fire status, and
+  the approval posture (👍 approvals · ✅ autonomous)
 - `!watches pause|resume|delete <n>` — owner-gated
+- `!watches approval <n> on|off` — owner-gated; flip the approval posture
+  after creation. `off` makes each fire autonomous — reserve it for triggers
+  you fully trust, since a watch fires on channel content anyone can post
 - (No manual `run` — watches are event-driven; use `!routines run` for
   on-demand work.)
 

--- a/src/operations/commands/automation.ts
+++ b/src/operations/commands/automation.ts
@@ -138,13 +138,24 @@ export async function postRoutineConfirmation(
 }
 
 /**
+ * One-glance approval-posture marker for a list row. Autonomous items run
+ * tool actions with no human in the loop (on attacker-influenceable channel
+ * content, for watches), so make that posture the one that stands out.
+ * Undefined posture (older data that never passed `applyItemDefaults`) reads
+ * as the safe approval-required default — matching how the fire path treats it.
+ */
+function postureMarker(item: { requireApproval?: boolean }): string {
+  return item.requireApproval === false ? ' · ✅ autonomous' : ' · 👍 approvals';
+}
+
+/**
  * Shared implementation of the `!routines` / `!watches` management commands:
  * numbered list, pause/resume/delete (owner-gated), plus flavor-specific
  * extra actions (routines' `run`, which is platform-allowlist-gated
  * instead). One policy for parsing, index lookup, gating, logging and audit;
  * the flavors carry only wording and store wiring.
  */
-async function manageListItems<T extends { id: string; name: string; createdBy: string; enabled: boolean }>(
+async function manageListItems<T extends { id: string; name: string; createdBy: string; enabled: boolean; requireApproval?: boolean }>(
   session: Session,
   args: string | undefined,
   username: string,
@@ -163,7 +174,7 @@ async function manageListItems<T extends { id: string; name: string; createdBy: 
     /** Per-item line body after the "N. " numbering. */
     describe(item: T, formatter: ReturnType<Session['platform']['getFormatter']>): string;
     list(): T[];
-    update(id: string, patch: { enabled?: boolean; consecutiveFailures?: number }): Promise<unknown>;
+    update(id: string, patch: { enabled?: boolean; requireApproval?: boolean; consecutiveFailures?: number }): Promise<unknown>;
     remove(id: string): Promise<unknown>;
     /**
      * Actions exempt from the owner gate but requiring the platform
@@ -197,9 +208,40 @@ async function manageListItems<T extends { id: string; name: string; createdBy: 
       'info',
       `${flavor.emoji} ${formatter.formatBold(`${plural} (${items.length})`)} — ${flavor.headlineSuffix}\n\n` +
       `${lines.join('\n')}\n\n` +
-      `${formatter.formatItalic(`Manage with ${'`' + cmd + ' ' + flavor.actions + ' <n>`'}.`)}`,
+      `${formatter.formatItalic(`Manage with ${'`' + cmd + ' ' + flavor.actions + ' <n>`'}; set approval posture with ${'`' + cmd + ' approval <n> on|off`'}.`)}`,
     );
     session.threadLogger?.logCommand(flavor.command, 'list', username);
+    return;
+  }
+
+  // `approval <n> on|off` — flip the per-item approval posture. Kept out of
+  // the uniform `<action> <n>` alternation because it carries a third token.
+  // Owner-gated like pause/resume/delete: turning approval OFF makes an item
+  // run autonomously, the same sensitive choice the creation card gates
+  // behind the owner + an explicit ✅.
+  const approvalMatch = trimmed.match(/^approval\s+(\d+)\s+(on|off)$/i);
+  if (approvalMatch) {
+    const [, indexArg, mode] = approvalMatch;
+    const item = flavor.list()[parseInt(indexArg, 10) - 1];
+    if (!item) {
+      await post(session, 'warning', `${flavor.emoji} No ${flavor.noun.toLowerCase()} ${indexArg}. See ${formatter.formatCode(cmd)}.`);
+      return;
+    }
+    if (!await requireSessionOwner(session, username, `manage ${flavor.command}`)) {
+      return;
+    }
+    const requireApproval = mode.toLowerCase() === 'on';
+    await flavor.update(item.id, { requireApproval });
+    await post(
+      session,
+      'success',
+      requireApproval
+        ? `👍 ${flavor.noun} ${formatter.formatBold(item.name)} will ask for approval before each action.`
+        : `✅ ${flavor.noun} ${formatter.formatBold(item.name)} will run autonomously — no approval prompts. Only leave this on for triggers you fully trust.`,
+    );
+    sessionLog(session).info(`${flavor.emoji} @${username}: ${cmd} approval ${indexArg} ${mode.toLowerCase()} ("${item.name}")`);
+    auditCommand(session, flavor.command, `approval ${indexArg} ${mode.toLowerCase()}`, username);
+    session.threadLogger?.logCommand(flavor.command, `approval ${indexArg} ${mode.toLowerCase()}`, username);
     return;
   }
 
@@ -208,7 +250,7 @@ async function manageListItems<T extends { id: string; name: string; createdBy: 
     await post(
       session,
       'warning',
-      `${flavor.emoji} Usage: ${formatter.formatCode(cmd)} or ${formatter.formatCode(`${cmd} ${flavor.actions} <n>`)}`,
+      `${flavor.emoji} Usage: ${formatter.formatCode(cmd)}, ${formatter.formatCode(`${cmd} ${flavor.actions} <n>`)} or ${formatter.formatCode(`${cmd} approval <n> on|off`)}`,
     );
     return;
   }
@@ -277,7 +319,7 @@ export async function manageRoutines(
     describe: (r, formatter) => {
       const status = r.enabled ? '' : ' — ⏸️ paused';
       const last = r.lastRunAt ? ` · last run ${formatIsoMinute(r.lastRunAt)} (${r.lastRunStatus})` : '';
-      return `${formatter.formatBold(r.name)} — ${describeSchedule(r.schedule)} · by ${formatter.formatCode('@' + r.createdBy)}${status}${last}`;
+      return `${formatter.formatBold(r.name)} — ${describeSchedule(r.schedule)} · by ${formatter.formatCode('@' + r.createdBy)}${postureMarker(r)}${status}${last}`;
     },
     list: () => ctx.state.routinesStore.list(platformId),
     update: (id, patch) => ctx.state.routinesStore.update(platformId, id, patch),
@@ -435,7 +477,7 @@ export async function manageWatches(
     describe: (w, formatter) => {
       const status = w.enabled ? '' : ' — ⏸️ paused';
       const last = w.lastFiredAt ? ` · last fired ${formatIsoMinute(w.lastFiredAt)} (${w.lastFireStatus})` : '';
-      return `${formatter.formatBold(w.name)} — fires when ${w.condition} · by ${formatter.formatCode('@' + w.createdBy)}${status}${last}`;
+      return `${formatter.formatBold(w.name)} — fires when ${w.condition} · by ${formatter.formatCode('@' + w.createdBy)}${postureMarker(w)}${status}${last}`;
     },
     list: () => ctx.state.watchesStore.list(platformId),
     update: (id, patch) => ctx.state.watchesStore.update(platformId, id, patch),

--- a/src/operations/commands/handler.test.ts
+++ b/src/operations/commands/handler.test.ts
@@ -1332,15 +1332,57 @@ describe('routine commands', () => {
     expect(ctx.state.routinesStore.list('test-platform')).toHaveLength(0);
   });
 
+  it('shows the approval posture per row, and it tracks the stored value', async () => {
+    const session = createMockSession();
+    const ctx = createRoutinesCtx(new Map([[session.sessionId, session]]));
+    const routine = await seedRoutine(ctx); // default posture: approval-required
+
+    await commands.manageRoutines(session, undefined, 'testuser', ctx);
+    let listing = (session.platform.createPost as any).mock.calls
+      .map((c: any[]) => c[0]).find((m: string) => m.includes('Routines (1)'));
+    expect(listing).toContain('👍 approvals');
+    expect(listing).not.toContain('✅ autonomous');
+
+    // Flip to autonomous in the store → the marker follows.
+    await ctx.state.routinesStore.update('test-platform', routine.id, { requireApproval: false });
+    (session.platform.createPost as any).mockClear();
+    await commands.manageRoutines(session, undefined, 'testuser', ctx);
+    listing = (session.platform.createPost as any).mock.calls
+      .map((c: any[]) => c[0]).find((m: string) => m.includes('Routines (1)'));
+    expect(listing).toContain('✅ autonomous');
+  });
+
+  it('!routines approval <n> on|off flips the posture and is owner-gated', async () => {
+    const session = createMockSession();
+    const ctx = createRoutinesCtx(new Map([[session.sessionId, session]]));
+    const routine = await seedRoutine(ctx);
+    expect(ctx.state.routinesStore.get('test-platform', routine.id)?.requireApproval).toBe(true);
+
+    // A non-owner cannot make a routine autonomous.
+    await commands.manageRoutines(session, 'approval 1 off', 'stranger', ctx);
+    expect(ctx.state.routinesStore.get('test-platform', routine.id)?.requireApproval).toBe(true);
+
+    // The owner can flip it off (autonomous) and back on.
+    await commands.manageRoutines(session, 'approval 1 off', 'testuser', ctx);
+    expect(ctx.state.routinesStore.get('test-platform', routine.id)?.requireApproval).toBe(false);
+    await commands.manageRoutines(session, 'approval 1 on', 'testuser', ctx);
+    expect(ctx.state.routinesStore.get('test-platform', routine.id)?.requireApproval).toBe(true);
+
+    const calls = (session.platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
+    expect(calls.some((m: string) => m.includes('run autonomously'))).toBe(true);
+  });
+
   it('reports unknown indices and bad subcommands', async () => {
     const session = createMockSession();
     const ctx = createRoutinesCtx(new Map([[session.sessionId, session]]));
 
     await commands.manageRoutines(session, 'pause 7', 'testuser', ctx);
     await commands.manageRoutines(session, 'frobnicate 1', 'testuser', ctx);
+    await commands.manageRoutines(session, 'approval 9 off', 'testuser', ctx); // unknown index on the approval path
 
     const calls = (session.platform.createPost as any).mock.calls.map((c: any[]) => c[0]);
     expect(calls.some((m: string) => m.includes('No routine 7'))).toBe(true);
+    expect(calls.some((m: string) => m.includes('No routine 9'))).toBe(true);
     expect(calls.some((m: string) => m.includes('Usage'))).toBe(true);
   });
 });
@@ -1561,6 +1603,42 @@ describe('watch commands', () => {
 
     await commands.manageWatches(session, 'delete 1', 'testuser', ctx);
     expect(ctx.state.watchesStore.list('test-platform')).toHaveLength(0);
+  });
+
+  it('shows the approval posture per row, and it tracks the stored value', async () => {
+    const session = createMockSession();
+    const ctx = createWatchesCtx(new Map([[session.sessionId, session]]));
+    const watch = await seedWatch(ctx); // default posture: approval-required
+
+    await commands.manageWatches(session, undefined, 'testuser', ctx);
+    let listing = (session.platform.createPost as any).mock.calls
+      .map((c: any[]) => c[0]).find((m: string) => m.includes('Watches (1)'));
+    expect(listing).toContain('👍 approvals');
+    expect(listing).not.toContain('✅ autonomous');
+
+    await ctx.state.watchesStore.update('test-platform', watch.id, { requireApproval: false });
+    (session.platform.createPost as any).mockClear();
+    await commands.manageWatches(session, undefined, 'testuser', ctx);
+    listing = (session.platform.createPost as any).mock.calls
+      .map((c: any[]) => c[0]).find((m: string) => m.includes('Watches (1)'));
+    expect(listing).toContain('✅ autonomous');
+  });
+
+  it('!watches approval <n> on|off flips the posture and is owner-gated', async () => {
+    const session = createMockSession();
+    const ctx = createWatchesCtx(new Map([[session.sessionId, session]]));
+    const watch = await seedWatch(ctx);
+    expect(ctx.state.watchesStore.get('test-platform', watch.id)?.requireApproval).toBe(true);
+
+    // A watch fires on attacker-influenceable content, so a guest must not be
+    // able to strip its approval requirement.
+    await commands.manageWatches(session, 'approval 1 off', 'stranger', ctx);
+    expect(ctx.state.watchesStore.get('test-platform', watch.id)?.requireApproval).toBe(true);
+
+    await commands.manageWatches(session, 'approval 1 off', 'testuser', ctx);
+    expect(ctx.state.watchesStore.get('test-platform', watch.id)?.requireApproval).toBe(false);
+    await commands.manageWatches(session, 'approval 1 on', 'testuser', ctx);
+    expect(ctx.state.watchesStore.get('test-platform', watch.id)?.requireApproval).toBe(true);
   });
 
   it('reports unknown indices and bad subcommands', async () => {

--- a/src/persistence/routines-store.ts
+++ b/src/persistence/routines-store.ts
@@ -186,7 +186,7 @@ export class RoutinesStore extends PlatformListStore<Routine> {
   }
 
   /** Merge a partial update into one routine. Returns the updated routine or undefined. */
-  override update(platformId: string, id: string, patch: Partial<Pick<Routine, 'enabled' | 'lastRunAt' | 'lastRunStatus' | 'consecutiveFailures'>>): Promise<Routine | undefined> {
+  override update(platformId: string, id: string, patch: Partial<Pick<Routine, 'enabled' | 'requireApproval' | 'lastRunAt' | 'lastRunStatus' | 'consecutiveFailures'>>): Promise<Routine | undefined> {
     return super.update(platformId, id, patch);
   }
 }

--- a/src/persistence/watches-store.ts
+++ b/src/persistence/watches-store.ts
@@ -162,7 +162,7 @@ export class WatchesStore extends PlatformListStore<Watch> {
   }
 
   /** Merge a partial update into one watch. Returns the updated watch or undefined. */
-  override update(platformId: string, id: string, patch: Partial<Pick<Watch, 'enabled' | 'lastFiredAt' | 'lastFireStatus' | 'firesToday' | 'consecutiveFailures'>>): Promise<Watch | undefined> {
+  override update(platformId: string, id: string, patch: Partial<Pick<Watch, 'enabled' | 'requireApproval' | 'lastFiredAt' | 'lastFireStatus' | 'firesToday' | 'consecutiveFailures'>>): Promise<Watch | undefined> {
     return super.update(platformId, id, patch);
   }
 }


### PR DESCRIPTION
## Summary

Follow-up #2 from the security review. The approval posture that 1.31.0 added to routines/watches (👍 approvals-required vs ✅ autonomous) was chosen once on the creation card and then **invisible and immutable** — you couldn't tell which of your routines runs autonomously, nor change your mind without deleting and recreating. This surfaces the posture and lets the owner flip it.

**No version bump** — lands under `## [Unreleased]`, rides the next release.

## Changes

- **Visible per row.** `!routines` / `!watches` listings now show each item's posture inline: `👍 approvals` or `✅ autonomous`.
- **Flippable, owner-gated.** New `!routines approval <n> on|off` / `!watches approval <n> on|off`:
  - `on` → restore per-action approval (safe).
  - `off` → run autonomously (no approval prompts, even on a `skipPermissions` platform).
  - Turning a watch autonomous is the same sensitive choice the creation card gates behind the owner + an explicit ✅ (a watch fires on channel content anyone can post), so the flip command is owner-gated too.
- Undefined posture (data persisted before 1.31.0) reads as the safe approvals-required default, matching how the fire path treats it.
- Both stores' `update()` now accept `requireApproval`; the shared `manageListItems` handles the extra `on|off` token, kept out of the uniform `<action> <n>` alternation because it carries a third token.

## Testing

- Red-green tests for **both** flavors (verified **red** without the fix):
  - the posture marker in the listing tracks the stored value (default `👍 approvals`; flips to `✅ autonomous` after a store update);
  - `approval <n> on|off` is owner-gated (a non-owner/guest cannot strip a watch's approval requirement) and persists the flip;
  - unknown-index handling on the new path.
- Full suite: **3278 pass, 0 fail**; `tsc` / `eslint` / `knip` clean.

## Docs

- `docs/CONFIGURATION.md` (routines + watches "Managing" lists), `README.md` command table, CHANGELOG `[Unreleased]`.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9MLgT2BbGTdtM6DuMgD9a)_