### PR TITLE
1.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.31.2] - 2026-08-30
+
 ### Added
 - **The approval posture of a routine or watch is now visible and changeable after creation.** `!routines` / `!watches` listings show each item's posture inline (👍 approvals · ✅ autonomous), and a new owner-gated `!routines approval <n> on|off` / `!watches approval <n> on|off` flips it — `off` makes an item run autonomously, `on` restores per-action approval. Turning a watch autonomous is the same sensitive choice the creation card gates behind the owner and an explicit ✅, so the flip command is owner-gated too; the safe approvals-required posture stays the default for older data.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.31.1",
+      "version": "1.31.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.31.1",
+  "version": "1.31.2",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Release **1.31.2** — ships the two security-review follow-ups already merged to `main` under `[Unreleased]`. Merging this triggers `release.yml` → tag, GitHub release, and npm publish.

## What ships

- **Routine/watch approval posture is now visible and changeable after creation** (#517) — `!routines` / `!watches` listings show each item's posture inline (👍 approvals · ✅ autonomous); new owner-gated `!routines approval <n> on|off` / `!watches approval <n> on|off` flips it.
- **Active-session thread-id lookups scoped by `platformId`** (#516) — completes the cross-platform privacy boundary 1.31.0/1.31.1 established for the persisted store, now for in-memory active sessions. Defense-in-depth.

## Why patch, not minor

The approval posture itself shipped in 1.31.0; this only **exposes and toggles an existing `requireApproval` field** (layered onto an existing feature) plus an internal defense-in-depth scoping fix — a refinement of 1.31.0 rather than net-new capability.

## Changes

- `package.json` 1.31.1 → 1.31.2 (`package-lock.json` in lockstep; `bun.lock` unchanged — it doesn't record the root version).
- CHANGELOG: promoted `[Unreleased]` → `[1.31.2] - 2026-08-30`.

No source changes — everything shipping here already landed and went green on `main` via #516 and #517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9MLgT2BbGTdtM6DuMgD9a)_