### PR TITLE
Release 1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.0] - 2026-09-01
+
+### Added
+- **Slack: shared event source — one Socket Mode connection per app** (#502, thanks @kaza). Slack round-robins Socket Mode envelopes across all of an app's open connections, so a second `SlackClient` on the same app token silently steals events from the first. Now exactly one client (the parent) owns the socket; other clients register as secondaries and receive their channels' events injected by the parent — Web API calls stay independent per instance. The parent mirrors connection state onto secondaries (idempotently re-armed across disconnects), and on reconnect, missed-message recovery runs for the parent and every registered secondary. Zero behavior change for existing single-channel configs; this is the mechanism that unblocks DM auto-discovery on Slack and other multi-channel consumers.
+
 ## [1.31.2] - 2026-08-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.31.2",
+  "version": "1.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.31.2",
+      "version": "1.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.31.2",
+  "version": "1.32.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.32.0**. On merge, `release.yml` verifies the tree, tags, creates the GitHub release, and publishes to npm.

Minor because it ships a new capability: the Slack shared event source (#502).

## Changes

- `package.json` / `package-lock.json`: 1.31.2 → 1.32.0 (`npm version minor`; `bun install` after — no lockfile changes, as expected)
- `CHANGELOG.md`: adds the `[1.32.0]` entry for #502 (the PR itself shipped mechanism + tests only, so the changelog entry is written here)

**What ships in 1.32.0**:
- **Slack: shared event source — one Socket Mode connection per app** (#502, thanks @kaza): parent client owns the only socket and injects registered channels' events into secondary clients, closing the Slack envelope round-robin problem. Includes reconnect recovery for secondaries and idempotent state mirroring across disconnects. Zero behavior change for existing configs; unblocks DM auto-discovery on Slack and other multi-channel consumers.

## Testing

Full CI green on #502's final head (unit, lint, typecheck, security, integration both platforms, build, node-smoke). Independent verification in a scratch worktree: 3169/3169 unit tests, red-check on the reconnect-recovery fix genuinely fails with the fix reverted. The release workflow re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_