### PR TITLE
Release 1.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.32.1] - 2026-09-02
+
+### Changed
+- **Dependency updates.** Production: hono 4.13.5, zod 4.5.4, js-yaml 4.3.2, express-rate-limit 8.7.0 (#522); dev-dependency group refreshed (#521). Validated with the full unit and Slack integration suites.
+
 ## [1.32.0] - 2026-09-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.32.0",
+      "version": "1.32.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump to **1.32.1**. On merge, `release.yml` verifies the tree, tags, creates the GitHub release, and publishes to npm.

## Changes

- `package.json` / `package-lock.json`: 1.32.0 → 1.32.1 (`npm version patch` + `bun install`)
- `CHANGELOG.md`: adds the `[1.32.1]` entry (Dependabot PRs carry none)

**What ships in 1.32.1**:
- **Dependency updates** — production: hono 4.13.5, zod 4.5.4, js-yaml 4.3.2, express-rate-limit 8.7.0 (#522); dev-dependency group refreshed (#521).

## Testing

The lockfile-sync workflow's bot-pushed heads get no CI runs, so both PRs were validated locally on their exact heads before merging: tsc, eslint (+knip for #521), **3295/3295 unit tests each**, **136/136 Slack integration tests** for the production bumps, and the combined main+#521 merge tree re-validated (tsc + full unit suite). The release workflow re-runs the full battery before tagging and publishing.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [x] Documentation updated (if needed) — CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_