### PR TITLE
Slack: accept posts made through the app's own user token as the person's message

### DIFF
--- a/docs/app-user-posts-spec.md
+++ b/docs/app-user-posts-spec.md
@@ -1,0 +1,74 @@
+# Posts made through the app's own user token are the person's messages
+
+Upstream discussion: anneschuth/claude-threads#TBD.
+
+## What it does
+
+A message posted with `chat.postMessage` and a **user token of this app**
+(`xoxp-…`, obtained when a person authorises the app) shows up in Slack as
+that person, and Slack delivers it with `user` = the person **and**
+`bot_id` + `app_id` of the app. Today the Slack client drops every message
+that carries a `bot_id`, so such a post never reaches Claude, silently.
+
+With this change the client treats a message as bot-authored only when
+
+- its `user` is the bot's own user (the daemon's replies), or
+- it carries a `bot_id` and is **not** from this app with a human `user`.
+
+So a post relayed through this app's own user token is handled exactly like
+the person typing it: same session routing, same allow-list, same everything.
+Other apps' bot posts, classic bot posts without a `user`, and the daemon's
+own replies stay ignored, as before.
+
+The rule is applied in the three places the filter lives: live events,
+missed-message recovery after a reconnect, and thread history with
+`excludeBotMessages`.
+
+## Why
+
+Any integration that speaks *for* a person — a voice front desk, a phone
+bridge, an approval UI — posts on the person's behalf with the app's user
+token, because that is the only way to keep attribution honest and the bot's
+consent gate (channel membership, allow-lists) intact. Slack marks every
+API-posted message with the app's `bot_id`; there is no way to post a
+"pure" human message through the API. Without this exception the daemon
+can never be driven by such an integration.
+
+Origin: the VVS live voice desk (`voice/` on the `local/voice-desk` branch
+of the kaza fork) relayed a spoken question into a task channel as the
+speaker, and the daemon ACKed the event and dropped it at the `bot_id`
+check with no log line. Seen 2026-09-02, message
+`{user: U…, bot_id: B0BUDMNPD26, app_id: A0BSH7L7N9E, bot_profile: {…}}`.
+
+## How
+
+- The client learns its own app id from the Socket Mode `hello`
+  (`connection_info.app_id`) and, belt and braces, from every `events_api`
+  envelope (`payload.api_app_id`). Secondary clients on a shared socket get
+  it handed over with each injected event. No new config, no new API call.
+- One predicate, `isBotAuthored(message)`, replaces the three inline
+  `user === botUserId || bot_id` checks.
+- `app_id` is added to the `SlackEvent` and `SlackMessage` types; it was
+  already on the wire.
+- Until the app id is known (only possible before the first `hello`), the
+  old rule applies: anything with a `bot_id` is ignored. Conservative, and
+  the window is the connection handshake.
+
+Why `app_id` and not `bot_id`: the `bot_id` on a user-token post is a
+per-authorisation bot profile (`B0BUDMNPD26` above), different from the
+bot token's own `bot_id` from `auth.test` (`B0BSH828Z6U`). `app_id` is the
+one stable identity.
+
+## Decisions
+
+| Decision | Why |
+|---|---|
+| No config flag | with `app_id` checked, only this app's own user tokens qualify; nothing to opt out of |
+| Learn the app id from the socket, not config | zero setup; every install already receives it |
+| Old behaviour until the app id is known | never widen the filter on a guess |
+
+## Lessons learned
+
+- A dropped event at the "ignore ourselves" check leaves no trace in the
+  log. Reproducing needed `conversations.history` on the exact `ts` to see
+  the stored message's fields.

--- a/docs/app-user-posts-spec.md
+++ b/docs/app-user-posts-spec.md
@@ -13,12 +13,15 @@ that carries a `bot_id`, so such a post never reaches Claude, silently.
 With this change the client treats a message as bot-authored only when
 
 - its `user` is the bot's own user (the daemon's replies), or
-- it carries a `bot_id` and is **not** from this app with a human `user`.
+- it carries a `bot_id` and is **not** a post from this app, from this
+  workspace, with a `user`.
 
 So a post relayed through this app's own user token is handled exactly like
 the person typing it: same session routing, same allow-list, same everything.
-Other apps' bot posts, classic bot posts without a `user`, and the daemon's
-own replies stay ignored, as before.
+Other apps' bot posts, classic bot posts without a `user`, the daemon's own
+replies, and a bot copy of this same app installed in another workspace that
+shares a Slack Connect channel (same `app_id`, other `team`) stay ignored,
+as before.
 
 The rule is applied in the three places the filter lives: live events,
 missed-message recovery after a reconnect, and thread history with
@@ -42,7 +45,8 @@ check with no log line. Seen 2026-09-02, message
 
 ## How
 
-- The client learns its own app id from the Socket Mode `hello`
+- The client learns its workspace from `auth.test` (`team_id`, already
+  called for the bot user) and its own app id from the Socket Mode `hello`
   (`connection_info.app_id`) and, belt and braces, from every `events_api`
   envelope (`payload.api_app_id`). Secondary clients on a shared socket get
   it handed over with each injected event. No new config, no new API call.
@@ -50,7 +54,7 @@ check with no log line. Seen 2026-09-02, message
   `user === botUserId || bot_id` checks.
 - `app_id` is added to the `SlackEvent` and `SlackMessage` types; it was
   already on the wire.
-- Until the app id is known (only possible before the first `hello`), the
+- Until app and team ids are known (only possible before the first `hello`), the
   old rule applies: anything with a `bot_id` is ignored. Conservative, and
   the window is the connection handshake.
 
@@ -63,7 +67,8 @@ one stable identity.
 
 | Decision | Why |
 |---|---|
-| No config flag | with `app_id` checked, only this app's own user tokens qualify; nothing to opt out of |
+| No config flag | with `app_id` and `team` checked, only this installation's own user tokens qualify; nothing to opt out of |
+| `team` must match too (Codex review) | Slack Connect lets the same app be installed on both sides of a shared channel; the other copy's bot shares our `app_id` but not our `team`, and two daemons answering each other is the one loop this must never open |
 | Learn the app id from the socket, not config | zero setup; every install already receives it |
 | Old behaviour until the app id is known | never widen the filter on a guess |
 

--- a/docs/app-user-posts-spec.md
+++ b/docs/app-user-posts-spec.md
@@ -1,6 +1,6 @@
 # Posts made through the app's own user token are the person's messages
 
-Upstream discussion: anneschuth/claude-threads#TBD.
+Upstream discussion: anneschuth/claude-threads#526.
 
 ## What it does
 

--- a/src/platform/slack/client.test.ts
+++ b/src/platform/slack/client.test.ts
@@ -116,7 +116,7 @@ function makeClient(overrides: Partial<SlackPlatformConfig> = {}): SlackClient {
 
 async function primeBotUser(client: SlackClient, userId = 'U-BOT') {
   fetchResponder = (url) => {
-    if (url.endsWith('auth.test')) return ok({ user_id: userId, url: 'https://team.slack.com/' });
+    if (url.endsWith('auth.test')) return ok({ user_id: userId, team_id: 'T-OURS', url: 'https://team.slack.com/' });
     if (url.includes('users.info')) {
       return ok({ user: { id: userId, name: 'claude', real_name: 'Claude', profile: {} } });
     }
@@ -461,6 +461,7 @@ describe('SlackClient bot-authored filter', () => {
   // when it is posted with a person's user token. Only the person's own
   // messages and posts made through this app's user token should reach Claude.
   const OUR_APP = 'A-OURS';
+  const OUR_TEAM = 'T-OURS';
 
   function hello(client: SlackClient, appId = OUR_APP) {
     (client as any).handleSocketModeEvent({ type: 'hello', connection_info: { app_id: appId } });
@@ -473,7 +474,7 @@ describe('SlackClient bot-authored filter', () => {
   }
 
   async function inject(client: SlackClient, event: Record<string, unknown>) {
-    client._injectSlackEvent({ type: 'message', channel: 'C123', ts: '1.1', text: 'hi', ...event } as any);
+    client._injectSlackEvent({ type: 'message', channel: 'C123', ts: '1.1', text: 'hi', team: OUR_TEAM, ...event } as any);
     await new Promise((r) => setTimeout(r, 0));
   }
 
@@ -496,7 +497,7 @@ describe('SlackClient bot-authored filter', () => {
     (client as any).handleSocketModeEvent({
       type: 'events_api',
       envelope_id: 'e1',
-      payload: { api_app_id: OUR_APP, event: { type: 'message', channel: 'C123', ts: '1.2', text: 'hi', user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP } },
+      payload: { api_app_id: OUR_APP, event: { type: 'message', channel: 'C123', ts: '1.2', text: 'hi', user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP, team: OUR_TEAM } },
     });
     await new Promise((r) => setTimeout(r, 0));
 
@@ -525,6 +526,17 @@ describe('SlackClient bot-authored filter', () => {
     expect(seen).toEqual([]);
   });
 
+  it('a bot copy of this same app in another workspace (Slack Connect) stays ignored', async () => {
+    const client = makeClient();
+    await primeBotUser(client);
+    hello(client);
+    const seen = collectMessages(client);
+
+    await inject(client, { user: 'U-BOT-REMOTE', bot_id: 'B-REMOTE', app_id: OUR_APP, team: 'T-REMOTE' });
+
+    expect(seen).toEqual([]);
+  });
+
   it('a bot post without a user stays ignored, and so does everything with a bot_id before the app id is known', async () => {
     const client = makeClient();
     await primeBotUser(client);
@@ -546,9 +558,10 @@ describe('SlackClient bot-authored filter', () => {
       if (url.includes('conversations.history')) {
         return ok({
           messages: [
-            { type: 'message', ts: '1.1', text: 'relayed', user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP },
-            { type: 'message', ts: '1.2', text: 'reply', user: 'U-BOT', bot_id: 'B-OURS', app_id: OUR_APP },
-            { type: 'message', ts: '1.3', text: 'ci', user: 'U-GITHUB-BOT', bot_id: 'B-GITHUB', app_id: 'A-GITHUB' },
+            { type: 'message', ts: '1.1', text: 'relayed', user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP, team: OUR_TEAM },
+            { type: 'message', ts: '1.2', text: 'reply', user: 'U-BOT', bot_id: 'B-OURS', app_id: OUR_APP, team: OUR_TEAM },
+            { type: 'message', ts: '1.3', text: 'ci', user: 'U-GITHUB-BOT', bot_id: 'B-GITHUB', app_id: 'A-GITHUB', team: OUR_TEAM },
+            { type: 'message', ts: '1.4', text: 'remote copy', user: 'U-BOT-REMOTE', bot_id: 'B-REMOTE', app_id: OUR_APP, team: 'T-REMOTE' },
           ],
         });
       }

--- a/src/platform/slack/client.test.ts
+++ b/src/platform/slack/client.test.ts
@@ -455,3 +455,108 @@ describe('SlackClient API methods', () => {
     await expect(makeClient().downloadFile('F1')).rejects.toThrow(/No download URL/);
   });
 });
+
+describe('SlackClient bot-authored filter', () => {
+  // Slack stamps every API-posted message with the app's bot_id/app_id, even
+  // when it is posted with a person's user token. Only the person's own
+  // messages and posts made through this app's user token should reach Claude.
+  const OUR_APP = 'A-OURS';
+
+  function hello(client: SlackClient, appId = OUR_APP) {
+    (client as any).handleSocketModeEvent({ type: 'hello', connection_info: { app_id: appId } });
+  }
+
+  function collectMessages(client: SlackClient): Array<{ userId: string }> {
+    const seen: Array<{ userId: string }> = [];
+    client.on('message', (post) => seen.push({ userId: post.userId }));
+    return seen;
+  }
+
+  async function inject(client: SlackClient, event: Record<string, unknown>) {
+    client._injectSlackEvent({ type: 'message', channel: 'C123', ts: '1.1', text: 'hi', ...event } as any);
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  it('a post made through this app\'s own user token is the person\'s message', async () => {
+    const client = makeClient();
+    await primeBotUser(client);
+    hello(client);
+    const seen = collectMessages(client);
+
+    await inject(client, { user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP });
+
+    expect(seen).toEqual([{ userId: 'U-ALMIR' }]);
+  });
+
+  it('the app id is also learned from an events_api envelope, for a socket that missed hello', async () => {
+    const client = makeClient();
+    await primeBotUser(client);
+    const seen = collectMessages(client);
+
+    (client as any).handleSocketModeEvent({
+      type: 'events_api',
+      envelope_id: 'e1',
+      payload: { api_app_id: OUR_APP, event: { type: 'message', channel: 'C123', ts: '1.2', text: 'hi', user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP } },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(seen).toEqual([{ userId: 'U-ALMIR' }]);
+  });
+
+  it('the bot\'s own replies stay ignored', async () => {
+    const client = makeClient();
+    await primeBotUser(client, 'U-BOT');
+    hello(client);
+    const seen = collectMessages(client);
+
+    await inject(client, { user: 'U-BOT', bot_id: 'B-OURS', app_id: OUR_APP });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('another app\'s bot posts stay ignored', async () => {
+    const client = makeClient();
+    await primeBotUser(client);
+    hello(client);
+    const seen = collectMessages(client);
+
+    await inject(client, { user: 'U-GITHUB-BOT', bot_id: 'B-GITHUB', app_id: 'A-GITHUB' });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('a bot post without a user stays ignored, and so does everything with a bot_id before the app id is known', async () => {
+    const client = makeClient();
+    await primeBotUser(client);
+    const seen = collectMessages(client);
+
+    await inject(client, { bot_id: 'B-CLASSIC', app_id: OUR_APP });
+    await inject(client, { user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP, ts: '1.3' });
+
+    expect(seen).toEqual([]);
+  });
+
+  it('missed-message recovery applies the same rule', async () => {
+    const client = makeClient();
+    await primeBotUser(client);
+    hello(client);
+    const seen = collectMessages(client);
+    (client as any).lastProcessedTs = '1.0';
+    fetchResponder = (url) => {
+      if (url.includes('conversations.history')) {
+        return ok({
+          messages: [
+            { type: 'message', ts: '1.1', text: 'relayed', user: 'U-ALMIR', bot_id: 'B-PER-AUTH', app_id: OUR_APP },
+            { type: 'message', ts: '1.2', text: 'reply', user: 'U-BOT', bot_id: 'B-OURS', app_id: OUR_APP },
+            { type: 'message', ts: '1.3', text: 'ci', user: 'U-GITHUB-BOT', bot_id: 'B-GITHUB', app_id: 'A-GITHUB' },
+          ],
+        });
+      }
+      return ok({ user: { id: 'U-ALMIR', name: 'almir', real_name: 'Almir', profile: {} } });
+    };
+
+    await (client as any).recoverMissedMessages();
+
+    expect(seen).toEqual([{ userId: 'U-ALMIR' }]);
+  });
+});

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -580,7 +580,8 @@ export class SlackClient extends BasePlatformClient {
   private isBotAuthored(message: { user?: string; bot_id?: string; app_id?: string }): boolean {
     if (message.user === this.botUserId) return true;
     if (!message.bot_id) return false;
-    return !(this.appId && message.app_id === this.appId && message.user);
+    const isOurUserTokenPost = Boolean(this.appId && message.app_id === this.appId && message.user);
+    return !isOurUserTokenPost;
   }
 
   /**

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -65,6 +65,8 @@ export class SlackClient extends BasePlatformClient {
   private botUserId: string | null = null;
   /** This app's id, learned from the socket (`hello`, then every events_api envelope). */
   private appId: string | null = null;
+  /** This installation's workspace, from auth.test. */
+  private teamId: string | null = null;
   private botUser: SlackUser | null = null;
   private teamUrl: string | null = null;
 
@@ -573,14 +575,21 @@ export class SlackClient extends BasePlatformClient {
    * Slack stamps every API-posted message with the posting app's `bot_id` and
    * `app_id`, including one posted with a *person's* user token of this app
    * (an integration relaying what the person said). That message is the
-   * person's: `user` is a human, `app_id` is ours. Everything else with a
-   * `bot_id` — our own replies, other apps, classic bots without a user — is
-   * bot-authored and ignored. Until the app id is known, the old rule holds.
+   * person's: `user` is set, `app_id` is ours, `team` is ours. Everything
+   * else with a `bot_id` — our own replies, other apps, classic bots without
+   * a user, and a bot copy of this same app in another workspace sharing a
+   * Slack Connect channel — is bot-authored and ignored. Until app and team
+   * ids are known, the old rule holds.
    */
-  private isBotAuthored(message: { user?: string; bot_id?: string; app_id?: string }): boolean {
+  private isBotAuthored(message: { user?: string; bot_id?: string; app_id?: string; team?: string }): boolean {
     if (message.user === this.botUserId) return true;
     if (!message.bot_id) return false;
-    const isOurUserTokenPost = Boolean(this.appId && message.app_id === this.appId && message.user);
+    const isOurUserTokenPost = Boolean(
+      this.appId && message.app_id === this.appId && this.teamId && message.team === this.teamId && message.user
+    );
+    if (isOurUserTokenPost) {
+      wsLogger.debug(`Accepting post by ${message.user} made through this app's user token`);
+    }
     return !isOurUserTokenPost;
   }
 
@@ -600,6 +609,7 @@ export class SlackClient extends BasePlatformClient {
     item_user?: string;
     bot_id?: string;
     app_id?: string;
+    team?: string;
     files?: SlackFile[];
   }): void {
     // Shared event source: this socket may carry events for channels owned by
@@ -813,6 +823,7 @@ export class SlackClient extends BasePlatformClient {
   private async fetchBotUser(): Promise<void> {
     const response = await this.api<AuthTestResponse>('POST', 'auth.test');
     this.botUserId = response.user_id;
+    this.teamId = response.team_id ?? null;
     this.teamUrl = response.url.replace(/\/$/, ''); // Remove trailing slash
 
     // Also fetch full user info

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -63,6 +63,8 @@ export class SlackClient extends BasePlatformClient {
   private userCache: Map<string, SlackUser> = new Map();
   private usernameToIdCache: Map<string, string> = new Map();
   private botUserId: string | null = null;
+  /** This app's id, learned from the socket (`hello`, then every events_api envelope). */
+  private appId: string | null = null;
   private botUser: SlackUser | null = null;
   private teamUrl: string | null = null;
 
@@ -186,7 +188,8 @@ export class SlackClient extends BasePlatformClient {
   }
 
   /** Secondary-side: receive an event injected by the parent's socket. */
-  _injectSlackEvent(event: Parameters<SlackClient['handleSlackEvent']>[0]): void {
+  _injectSlackEvent(event: Parameters<SlackClient['handleSlackEvent']>[0], appId?: string | null): void {
+    if (appId) this.appId = appId;
     this.handleSlackEvent(event);
   }
 
@@ -555,10 +558,29 @@ export class SlackClient extends BasePlatformClient {
       return;
     }
 
+    if (envelope.type === 'hello' && envelope.connection_info?.app_id) {
+      this.appId = envelope.connection_info.app_id;
+    }
+
     // Handle events_api envelopes
     if (envelope.type === 'events_api' && envelope.payload?.event) {
+      if (envelope.payload.api_app_id) this.appId = envelope.payload.api_app_id;
       this.handleSlackEvent(envelope.payload.event);
     }
+  }
+
+  /**
+   * Slack stamps every API-posted message with the posting app's `bot_id` and
+   * `app_id`, including one posted with a *person's* user token of this app
+   * (an integration relaying what the person said). That message is the
+   * person's: `user` is a human, `app_id` is ours. Everything else with a
+   * `bot_id` — our own replies, other apps, classic bots without a user — is
+   * bot-authored and ignored. Until the app id is known, the old rule holds.
+   */
+  private isBotAuthored(message: { user?: string; bot_id?: string; app_id?: string }): boolean {
+    if (message.user === this.botUserId) return true;
+    if (!message.bot_id) return false;
+    return !(this.appId && message.app_id === this.appId && message.user);
   }
 
   /**
@@ -576,6 +598,7 @@ export class SlackClient extends BasePlatformClient {
     item?: { type: string; channel: string; ts: string };
     item_user?: string;
     bot_id?: string;
+    app_id?: string;
     files?: SlackFile[];
   }): void {
     // Shared event source: this socket may carry events for channels owned by
@@ -586,7 +609,7 @@ export class SlackClient extends BasePlatformClient {
     if (eventChannel && eventChannel !== this.channelId) {
       const secondary = this.channelClients.get(eventChannel);
       if (secondary) {
-        secondary._injectSlackEvent(event);
+        secondary._injectSlackEvent(event, this.appId);
         return;
       }
     }
@@ -594,8 +617,8 @@ export class SlackClient extends BasePlatformClient {
     // Handle message events
     // Note: file_share subtype is used when a user uploads a file with a message
     if (event.type === 'message' && (!event.subtype || event.subtype === 'file_share')) {
-      // Ignore messages from ourselves
-      if (event.user === this.botUserId || event.bot_id) {
+      // Ignore messages from ourselves and other bots
+      if (this.isBotAuthored(event)) {
         return;
       }
 
@@ -758,7 +781,7 @@ export class SlackClient extends BasePlatformClient {
 
       for (const message of sortedMessages) {
         // Skip bot messages
-        if (message.user === this.botUserId || message.bot_id) {
+        if (this.isBotAuthored(message)) {
           continue;
         }
 
@@ -1159,7 +1182,7 @@ export class SlackClient extends BasePlatformClient {
           `conversations.replies?channel=${this.channelId}&ts=${threadId}&limit=1000${cursorParam}`
         );
         for (const msg of response.messages || []) {
-          if (options?.excludeBotMessages && (msg.user === this.botUserId || msg.bot_id)) continue;
+          if (options?.excludeBotMessages && this.isBotAuthored(msg)) continue;
           filtered.push(msg);
         }
         // Sliding window: each page arrives oldest-first, so after sorting,

--- a/src/platform/slack/types.ts
+++ b/src/platform/slack/types.ts
@@ -6,6 +6,8 @@ export interface SlackSocketModeEvent {
   retry_attempt?: number;
   retry_reason?: string;
   payload?: SlackEventPayload;
+  /** Present on `hello`. */
+  connection_info?: { app_id?: string };
 }
 
 export interface SlackEventPayload {
@@ -33,6 +35,7 @@ export interface SlackEvent {
   event_ts?: string;
   channel_type?: string;
   bot_id?: string;
+  app_id?: string;
   files?: SlackFile[];
 }
 
@@ -70,6 +73,7 @@ export interface SlackMessage {
   ts: string;
   user?: string;
   bot_id?: string;
+  app_id?: string;
   text: string;
   thread_ts?: string;
   reply_count?: number;

--- a/src/platform/slack/types.ts
+++ b/src/platform/slack/types.ts
@@ -36,6 +36,8 @@ export interface SlackEvent {
   channel_type?: string;
   bot_id?: string;
   app_id?: string;
+  /** Workspace the poster belongs to; differs from ours in Slack Connect channels. */
+  team?: string;
   files?: SlackFile[];
 }
 
@@ -74,6 +76,7 @@ export interface SlackMessage {
   user?: string;
   bot_id?: string;
   app_id?: string;
+  team?: string;
   text: string;
   thread_ts?: string;
   reply_count?: number;


### PR DESCRIPTION
Closes #526.

Slack stamps every API-posted message with the posting app's `bot_id` and `app_id`, including one posted with a **person's user token of this app** (an integration relaying what the person said, e.g. a voice front desk). The client dropped all of them at `if (event.user === this.botUserId || event.bot_id) return;`, silently.

**Change:** a message is bot-authored when its `user` is the bot itself, **or** it carries a `bot_id` and is not this app's with a human `user`. One predicate, `isBotAuthored()`, at the three places the check lived: live events, missed-message recovery, thread history with `excludeBotMessages`.

- The client learns its own `app_id` from the socket (`hello` → `connection_info.app_id`, and every `events_api` envelope → `api_app_id`); secondary clients on a shared socket get it with each injected event. No config, no extra API call. Until it's known, the old rule applies.
- `app_id` added to `SlackEvent` / `SlackMessage` types (it was already on the wire).
- Why `app_id` and not `bot_id`: the `bot_id` on a user-token post is a per-authorisation bot profile, different from the bot token's own `bot_id` from `auth.test`.

**Still ignored, with tests:** the bot's own replies, other apps' bots, classic bot posts without a `user`, and anything with a `bot_id` before the app id is known.

Spec: `docs/app-user-posts-spec.md`. 6 new unit tests in `client.test.ts`; full suite green (3301).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fPD7RcCw2vVv6MmrxTfJH
