### PR TITLE
cleanStale: never tombstone DCM sessions (fixes #499)

### DIFF
--- a/src/persistence/session-store.test.ts
+++ b/src/persistence/session-store.test.ts
@@ -299,6 +299,42 @@ describe('SessionStore', () => {
       expect(history[0].threadId).toBe('old-thread');
     });
 
+    it('never tombstones a DCM session, however idle (fixes #499)', () => {
+      // A thread session and a channel session, both well past the age limit.
+      // The thread one is aged out as always; the DCM one must survive.
+      //
+      // The asymmetry is the point. A tombstoned thread session costs nothing
+      // — the next message opens a new thread and starts fresh. A DCM session
+      // IS its channel, so tombstoning it leaves nowhere else to go: every
+      // later message dies in `resumePausedSession` on "No persisted session
+      // found" (a DEBUG line, no reply), and the channel is unusable until
+      // someone edits sessions.json on the host. Idle age is the wrong owner
+      // for that lifecycle; the channel's own archive/teardown is the right
+      // one.
+      const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+      const threadSession = createTestSession({
+        threadId: 'idle-thread',
+        lastActivityAt: twoHoursAgo,
+      });
+      const channelSession = createTestSession({
+        threadId: 'dcm:slack-vvs--ch-C0BV9SBB6R2',
+        lastActivityAt: twoHoursAgo,
+      });
+
+      store.save('test-platform:idle-thread', threadSession);
+      store.save('test-platform:dcm:slack-vvs--ch-C0BV9SBB6R2', channelSession);
+
+      const staleIds = store.cleanStale(60 * 60 * 1000); // 1 hour
+
+      expect(staleIds).toEqual(['test-platform:idle-thread']);
+
+      // The channel session is still live, not merely still on disk: `load()`
+      // is what the resume path reads, and it is the lookup the bug hid it from.
+      const live = store.load();
+      expect(live.has('test-platform:dcm:slack-vvs--ch-C0BV9SBB6R2')).toBe(true);
+      expect(live.has('test-platform:idle-thread')).toBe(false);
+    });
+
     it('skips already soft-deleted sessions', () => {
       const session = createTestSession({
         threadId: 'old-thread',

--- a/src/persistence/session-store.ts
+++ b/src/persistence/session-store.ts
@@ -287,6 +287,12 @@ export class SessionStore {
       // Skip already soft-deleted sessions
       if (session.cleanedAt) continue;
 
+      // DCM sessions are channel-scoped tasks: the channel's archive/teardown
+      // owns their lifecycle, not idle age. Tombstoning one after a quiet hour
+      // makes the whole channel permanently unresponsive (every message dies
+      // on "No persisted session found").
+      if (session.threadId.startsWith('dcm:')) continue;
+
       const lastActivity = new Date(session.lastActivityAt).getTime();
       if (now - lastActivity > maxAgeMs) {
         staleIds.push(sessionId);


### PR DESCRIPTION
## Summary

Fixes #499. Six lines, one file.

`cleanStale` tombstones sessions that have gone quiet. A DCM session's lifecycle belongs to its channel, not to the stale sweeper, so tombstoning one makes the channel **permanently and silently deaf**: no error, no restart, no log entry a user would see. The bot simply stops answering in that channel and nothing indicates why.

## Changes

- `cleanStale` skips DCM sessions. The channel owns their lifecycle — archive/unarchive is the intended path, and the sweeper has no business ending one.

## Testing

Running on our deployment since 2026-08-25. Before the fix, a channel left alone for an hour was reliably dead on return; after it, our channels stay live across multi-hour gaps and daemon restarts. Suite green on current `main`.

## Why it matters more than its size suggests

This is the failure mode that costs the most: an agent given overnight work, and by morning the channel has been deaf for hours with no way to tell. Nothing surfaces it — you find out by discovering nothing happened.
