### PR TITLE
Count Slack protocol pings as socket activity (fixes #498)

### DIFF
--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -1,4 +1,4 @@
-import { WebSocket } from '../../utils/websocket.js';
+import { WebSocket, countPingsAsActivity } from '../../utils/websocket.js';
 import type { SlackPlatformConfig } from '../../config/index.js';
 import { wsLogger, createLogger } from '../../utils/logger.js';
 import { truncateMessageSafely, escapeRegExp, getEmojiName, formatWebSocketError, resolvePostThreadId, isDcmThreadId, normalizeAckReaction, resolveDirectChannelMode, type ResolvedDirectChannelMode, type ApprovalsMode } from '../utils.js';
@@ -460,12 +460,11 @@ export class SlackClient extends BasePlatformClient {
       };
 
       // Slack keeps idle Socket Mode connections alive with protocol-level ping
-      // frames (~10s cadence) — they never reach onmessage. Bun's WebSocket
-      // surfaces them as 'ping' events; count them as activity, or the 60s
-      // heartbeat executes every healthy idle connection (observed 2026-08-25).
-      (this.ws as unknown as EventTarget).addEventListener?.('ping', () => {
-        this.updateLastMessageTime();
-      });
+      // frames (~10s cadence) — they never reach onmessage. Without counting
+      // them the 60s heartbeat executes every healthy idle connection
+      // (observed 2026-08-25). Covers Bun and Node 20; see the helper for why
+      // Node 22+/undici cannot be covered here (#498).
+      countPingsAsActivity(this.ws, () => this.updateLastMessageTime());
 
       this.ws.onmessage = (event) => {
         this.updateLastMessageTime();

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -459,6 +459,14 @@ export class SlackClient extends BasePlatformClient {
         wsLogger.info('Socket Mode: WebSocket connected, waiting for hello...');
       };
 
+      // Slack keeps idle Socket Mode connections alive with protocol-level ping
+      // frames (~10s cadence) — they never reach onmessage. Bun's WebSocket
+      // surfaces them as 'ping' events; count them as activity, or the 60s
+      // heartbeat executes every healthy idle connection (observed 2026-08-25).
+      (this.ws as unknown as EventTarget).addEventListener?.('ping', () => {
+        this.updateLastMessageTime();
+      });
+
       this.ws.onmessage = (event) => {
         this.updateLastMessageTime();
 

--- a/src/utils/websocket.test.ts
+++ b/src/utils/websocket.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for the ping-as-activity attachment (#498).
+ *
+ * An idle Socket Mode connection carries only protocol-level ping frames, so
+ * a heartbeat fed from `onmessage` alone concludes every healthy idle
+ * connection is dead and kills it once a minute, forever. These pin both the
+ * fake-object contract and the real behavior against a live `ws` server.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { WebSocketServer } from 'ws';
+import type { AddressInfo } from 'node:net';
+import { countPingsAsActivity } from './websocket.js';
+
+describe('countPingsAsActivity', () => {
+  it('feeds the clock through an EventTarget-style ping (Bun native)', () => {
+    let pings = 0;
+    const listeners: Record<string, () => void> = {};
+    const fake = {
+      addEventListener: (event: string, fn: () => void) => {
+        listeners[event] = fn;
+      },
+    };
+
+    countPingsAsActivity(fake, () => pings++);
+    listeners.ping?.();
+
+    expect(pings).toBe(1);
+  });
+
+  it('feeds the clock through an EventEmitter-style ping (Node 20 ws)', () => {
+    let pings = 0;
+    const listeners: Record<string, () => void> = {};
+    const fake = {
+      on: (event: string, fn: () => void) => {
+        listeners[event] = fn;
+      },
+    };
+
+    countPingsAsActivity(fake, () => pings++);
+    listeners.ping?.();
+
+    expect(pings).toBe(1);
+  });
+
+  it('is a silent no-op on a socket exposing neither (Node 22+ undici)', () => {
+    expect(() => countPingsAsActivity({}, () => {})).not.toThrow();
+  });
+
+  it('attaches both mechanisms without double-counting a single frame', () => {
+    // A runtime offering both would otherwise count one frame twice. Each
+    // mechanism fires only for its own dispatch, so one frame is one call.
+    let pings = 0;
+    const et: Record<string, () => void> = {};
+    const ee: Record<string, () => void> = {};
+    const fake = {
+      addEventListener: (e: string, fn: () => void) => { et[e] = fn; },
+      on: (e: string, fn: () => void) => { ee[e] = fn; },
+    };
+
+    countPingsAsActivity(fake, () => pings++);
+    et.ping?.();
+
+    expect(pings).toBe(1);
+  });
+
+  // End-to-end coverage rather than a discriminator: Bun's `ws` client
+  // satisfies both attachment styles, so this stays green if either half is
+  // removed. The two fake-object tests above are what pin each mechanism.
+  it('counts a real protocol ping from a live ws server', async () => {
+    const server = new WebSocketServer({ port: 0 });
+    try {
+      const port = (server.address() as AddressInfo).port;
+      server.on('connection', (socket) => socket.ping());
+
+      const { WebSocket: WsClient } = await import('ws');
+      const client = new WsClient(`ws://127.0.0.1:${port}`);
+
+      const sawPing = await new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(false), 3000);
+        countPingsAsActivity(client, () => {
+          clearTimeout(timer);
+          resolve(true);
+        });
+        client.on('error', () => {
+          clearTimeout(timer);
+          resolve(false);
+        });
+      });
+
+      client.close();
+      expect(sawPing).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -18,3 +18,31 @@ if (typeof globalThis.WebSocket !== 'undefined') {
 }
 
 export { WS as WebSocket };
+
+/**
+ * Count protocol-level ping frames as socket activity.
+ *
+ * An idle Socket Mode connection carries no text frames — its keepalive is
+ * entirely ping/pong at the protocol level, which `onmessage` never sees. A
+ * heartbeat fed only by `onmessage` therefore executes every healthy idle
+ * connection on schedule (#498).
+ *
+ * Ping visibility differs per runtime, so both mechanisms are attached and
+ * whichever exists wins:
+ *
+ * | Runtime          | Mechanism                    |
+ * |------------------|------------------------------|
+ * | Bun (native)     | `addEventListener('ping')`   |
+ * | Node 20 (`ws`)   | `.on('ping')` (EventEmitter) |
+ * | Node 22+ (undici)| none — see below             |
+ *
+ * undici's WHATWG WebSocket auto-pongs internally and exposes no frame-level
+ * ping visibility at all, so that runtime stays uncovered at this layer;
+ * client-initiated pings from the heartbeat are the eventual answer there.
+ * Both attachments are optional-chained, so a runtime lacking either is a
+ * silent no-op rather than a throw.
+ */
+export function countPingsAsActivity(ws: unknown, onPing: () => void): void {
+  (ws as EventTarget).addEventListener?.('ping', onPing);
+  (ws as { on?: (event: string, listener: () => void) => void }).on?.('ping', onPing);
+}


### PR DESCRIPTION
## Summary

Fixes #498. Eight lines, one file.

The 60-second heartbeat only counted text frames as activity. An idle Slack Socket Mode connection sends only protocol pings (~10s cadence), which the handler never saw — so the heartbeat concluded every healthy idle connection was dead and killed it, once a minute, forever.

## Changes

- Count Slack protocol pings as socket activity.

## Testing

Verified against live Slack: 5+ idle minutes with zero false deaths, where before the connection was torn down every 60 seconds. Running on our deployment since 2026-08-25. Suite green on current `main`.

## Note

The reconnects were mostly invisible because they succeeded — the cost was a permanent churn of teardowns and reconnects on every idle channel, and each one is a window in which a message can be missed.
