### PR TITLE
1.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.33.1] - 2026-09-05
+
+### Fixed
+- **A `!stop` in a direct-channel-mode channel no longer makes it permanently deaf** (#538, thanks @kaza). The paused-session gate and the resume sink disagreed about soft-deleted sessions, so a tombstoned record claimed every message and dropped it. Tombstones now carry an end reason: a user-stopped session stays ended (the next message starts a fresh session), while a stale-swept one is revived — honoring the "send a new message to continue" promise — with the tombstone cleared only after the resume authorization gate. Also closes the reaction-resume door on stopped sessions, and `!help` now answers in a paused thread instead of vanishing. Fixes #537.
+- **Direct-channel-mode sessions are no longer tombstoned by the boot-time stale sweep** (#530, thanks @kaza). One quiet hour used to brick the channel silently. Fixes #499.
+- **Pooled accounts selected by `home` now clear inherited `CLAUDE_CONFIG_DIR`** (#540, thanks @kaza), which outranks the `HOME` override — a daemon started under its own profile silently billed every pooled session to its own seat and probed its own quota per pool entry. Also clears `CLAUDE_SECURESTORAGE_CONFIG_DIR` and inherited bearer credentials; API-key and single-account modes unaffected. Fixes both session spawning and the usage probe. Fixes #539.
+
 ## [1.33.0] - 2026-09-02
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release **1.33.1**: three production bug fixes from @kaza, all independently verified and merged this morning.

- **#538** — `!stop` no longer bricks a direct-channel-mode channel (tombstone `EndReason` split: stopped stays ended, stale revives; authorization-gated write-back; reaction door closed; `!help` answers in paused threads). Fixes #537.
- **#530** — the boot-time stale sweep no longer tombstones DCM sessions. Fixes #499.
- **#540** — pooled `home` accounts clear inherited `CLAUDE_CONFIG_DIR` (and `CLAUDE_SECURESTORAGE_CONFIG_DIR` + bearer credentials), fixing silent single-seat billing and self-probing pools. Fixes #539.

CHANGELOG entries written here (crediting @kaza) because the fix PRs carried none; version bumped `1.33.0` → `1.33.1`.

## Testing

- `bunx tsc --noEmit` clean
- `bun run lint` clean
- `bun test src/` — 3325 pass / 0 fail

On merge, `release.yml` tags `v1.33.1`, creates the GitHub release, and publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kd8WgZi9NHB8zWH2VkuyeN)_