### PR TITLE
1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-09-05
+
+### Added
+- **Slack sessions show a working status instead of nothing** (#525, thanks @kaza). `sendTyping()` was a no-op on Slack, so a Slack session showed no sign of life between the ack reaction and the first output while Mattermost had a typing indicator all along. `assistant.threads.setStatus` fills it in, needs no new scope and no manifest change, and is torn down when the turn ends — a status persists until something replaces it, unlike a self-expiring websocket frame, so `clearTyping()` joins the platform contract. Slack documents the method as AI-assistant-threads-only; it works in ordinary channels, and the degradation path is silent if that ever changes.
+
 ### Fixed
+- **Idle Slack connections are no longer killed once a minute** (#532, thanks @kaza). The 60-second heartbeat counted only text frames, and an idle Socket Mode connection carries nothing but protocol-level pings — so the heartbeat concluded every healthy idle connection was dead, tore it down and reconnected, forever. Each teardown is a window in which a message can be missed. Fixed on Bun and Node 20; Node 22+/undici exposes no frame-level ping visibility at all and remains open in #498.
 - **A session that stalls mid-turn is no longer reported as idle** (#548, found by @kaza while reviewing #533). The idle reaper decides from `lastActivityAt` alone, with no check on whether a turn is open. That clock is fed by every Claude event, so a streaming turn keeps it warm — but a turn that goes silent (a wedged CLI, a dropped API connection, one long-running tool call) was reaped with *"Session timed out after N minutes of inactivity"*, which is false and sends the user looking in the wrong place. The timeout and pre-timeout warning now distinguish three cases: a turn blocked on a plan approval or question says the bot is waiting on *you*, a turn that went silent reports lost output, and a genuinely idle session reads exactly as before. All variants are registered with the #491 bot-to-bot loop guard, so one bot's status post still can never read as a request to another.
 
 ## [1.33.1] - 2026-09-05

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.33.1",
+      "version": "1.34.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.33.1",
+  "version": "1.34.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump and CHANGELOG promotion for 1.34.0. Merging this triggers `release.yml`, which tags, releases and publishes.

Minor rather than patch: #525 adds a user-visible capability on Slack.

**Added**
- Slack sessions show a working status instead of nothing (#525, @kaza)

**Fixed**
- Idle Slack connections are no longer killed once a minute (#532, @kaza)
- A session that stalls mid-turn is no longer reported as idle (#549, from @kaza's analysis in #533)

Three of the four PRs in this release came from @kaza, who also found the reaper bug while arguing about a feature that does not exist yet.

Note that #498 stays open despite #532 closing it on merge: Node 22+/undici exposes no frame-level ping visibility, so that runtime is still affected. Reopened with the remaining work described.

`bun test src/` 3395 pass / 0 fail on the merge base, tsc and eslint clean. `bun.lock` is unchanged because it does not record the root version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USdFSTsyxgBgwvyp1UU491
