### PR TITLE
Stop a long message from stalling message handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **A long message no longer stalls message handling** (#551). The bot-to-bot status-post guard runs on every inbound message, on the event loop, before routing — and its authorization-refusal pattern used a greedy `\S+`, so any message that was *not* a refusal made the engine retry the split at every position before failing. Measured quadratic: ~150 ms at Mattermost's 16k post limit, 3.7 s at 80k, triggerable by any channel member with one long token. The quantifier is now lazy, which matches exactly the same strings (the addressee is a single whitespace-free token) in well under a millisecond.
+- **A long message no longer stalls message handling** (#551). The bot-to-bot status-post guard runs on every inbound message, on the event loop, before routing — and its authorization-refusal pattern used a greedy `\S+`, so any message that was *not* a refusal made the engine retry the split at every position before failing. Measured quadratic: ~150 ms at Mattermost's 16k post limit, 3.7 s at 80k, triggerable by any channel member with one long token. The quantifier is now lazy, which matches exactly the same strings (the addressee is a single whitespace-free token) in well under a millisecond. Measured under JSC, the engine Bun uses; V8 optimizes the greedy form away, so the fault is invisible when re-measured under Node.
 
 ## [1.34.0] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A long message no longer stalls message handling** (#551). The bot-to-bot status-post guard runs on every inbound message, on the event loop, before routing — and its authorization-refusal pattern used a greedy `\S+`, so any message that was *not* a refusal made the engine retry the split at every position before failing. Measured quadratic: ~150 ms at Mattermost's 16k post limit, 3.7 s at 80k, triggerable by any channel member with one long token. The quantifier is now lazy, which matches exactly the same strings (the addressee is a single whitespace-free token) in well under a millisecond.
+
 ## [1.34.0] - 2026-09-05
 
 ### Added

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -2890,4 +2890,28 @@ describe('isClaudeThreadsStatusPost (#491)', () => {
   ])('lets ordinary messages through: %s', (message) => {
     expect(isClaudeThreadsStatusPost(message)).toBe(false);
   });
+
+  /**
+   * #551: the guard runs on every inbound message, on the event loop, before
+   * routing. A greedy `\S+` in the refusal pattern made a non-matching message
+   * quadratic in its length — ~150 ms at Mattermost's 16k post limit, 3.7 s at
+   * 80k — which any channel member could trigger with one long token.
+   *
+   * The bound is deliberately loose (the fixed form runs in well under a
+   * millisecond, the regression took seconds) so this fails on real
+   * backtracking rather than on a slow CI runner.
+   */
+  test('stays linear on a long non-matching message', () => {
+    const cases = [
+      `⚠️ ${'a'.repeat(80_000)}`,
+      `⚠️ ${'*'.repeat(80_000)}`,
+      `⏱️ ${'a'.repeat(80_000)}`,
+    ];
+
+    const started = performance.now();
+    for (const message of cases) {
+      expect(isClaudeThreadsStatusPost(message)).toBe(false);
+    }
+    expect(performance.now() - started).toBeLessThan(250);
+  });
 });

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -2901,6 +2901,10 @@ describe('isClaudeThreadsStatusPost (#491)', () => {
    * millisecond, the regression took seconds) so this fails on real
    * backtracking rather than on a slow CI runner.
    */
+  // Explicit timeout: in the broken state the greedy form takes ~7.4 s, which
+  // would also blow bun's 5 s default and report as a runner timeout on top of
+  // the assertion. A generous per-test bound keeps a future regression legible
+  // as the assertion failure it is.
   test('stays linear on a long non-matching message', () => {
     const cases = [
       `⚠️ ${'a'.repeat(80_000)}`,
@@ -2913,5 +2917,5 @@ describe('isClaudeThreadsStatusPost (#491)', () => {
       expect(isClaudeThreadsStatusPost(message)).toBe(false);
     }
     expect(performance.now() - started).toBeLessThan(250);
-  });
+  }, 30_000);
 });

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -53,7 +53,14 @@ const BOLD = String.raw`(?:\*{1,2}|_{1,2})?`;
 const STATUS_POST_PATTERNS: RegExp[] = [
   // Authorization refusals — the addressee may render as @name, `name`, or a
   // raw <@U…> token depending on platform and version.
-  /^⚠️\s+\S+ is not authorized\b/u,
+  //
+  // `\S+?` is lazy deliberately (#551): greedy `\S+` made this quadratic,
+  // because every message that is NOT a refusal forces the engine to retry the
+  // `\s+`/`\S+` split at every position before failing. This runs on every
+  // inbound message on the event loop, so a single long token cost ~150 ms at
+  // Mattermost's 16k post limit and 3.7 s at 80k. Lazy matches exactly the
+  // same strings — the addressee is one whitespace-free token — in ~0 ms.
+  /^⚠️\s+\S+? is not authorized\b/u,
   new RegExp(`^⚠️\\s+${BOLD}Too busy${BOLD} -`, 'u'),
   // Keep in sync with cleanupIdleSessions in src/session/lifecycle.ts: a
   // stalled or decision-blocked turn reports differently from a genuinely

--- a/src/message-handler.ts
+++ b/src/message-handler.ts
@@ -60,6 +60,10 @@ const STATUS_POST_PATTERNS: RegExp[] = [
   // inbound message on the event loop, so a single long token cost ~150 ms at
   // Mattermost's 16k post limit and 3.7 s at 80k. Lazy matches exactly the
   // same strings — the addressee is one whitespace-free token — in ~0 ms.
+  //
+  // Measured under JSC (Bun), which is what we ship on. V8 optimizes the
+  // greedy form away, so re-measuring this under Node shows nothing — that is
+  // the engine hiding it, not the problem being absent.
   /^⚠️\s+\S+? is not authorized\b/u,
   new RegExp(`^⚠️\\s+${BOLD}Too busy${BOLD} -`, 'u'),
   // Keep in sync with cleanupIdleSessions in src/session/lifecycle.ts: a


### PR DESCRIPTION
Fixes #551, found during the security pass on #549 and filed separately because it predates that PR.

## The problem

`isClaudeThreadsStatusPost` runs on **every inbound message**, on the event loop, before the ack receipt and before any routing. Its first pattern was:

```js
/^⚠️\s+\S+ is not authorized\b/u
```

For a message that is *not* a refusal, ` is not authorized` never matches, so the engine retries the `\s+`/`\S+` split at every position before giving up. Measured on `'⚠️ ' + 'a'.repeat(n)`:

| n | greedy | lazy |
|---|---|---|
| 20,000 | 235 ms | 0.1 ms |
| 40,000 | 926 ms | 0.1 ms |
| 80,000 | 3,708 ms | 0.2 ms |

Clean quadratic. Mattermost's default post limit is 16k, so ~150 ms of fully blocked event loop per message — and it needs no privileges, just one long token from any channel member.

## The change

One character: `\S+` → `\S+?`.

The addressee is always a single whitespace-free token (`formatCode(username)`, an `@name`, or a raw `<@U…>`), so lazy matches exactly the same set. I verified that directly rather than assuming: **zero divergences** between the two forms across the matching cases (all three addressee shapes, extra whitespace) and the non-matching ones (the existing `lets ordinary messages through` table plus `⚠️ is not authorized` with no addressee).

I also stress-tested **every other pattern** in the list at 200k characters of `a`, `*`, `_`, and mixed filler against each of the five emoji prefixes. All stay under 3 ms. This was the only affected one.

## Testing

One regression test asserting the guard stays linear on long non-matching input. The bound is deliberately loose (250 ms for three 80k-char messages, against ~0 ms fixed and seconds broken) so it fails on real backtracking rather than on a slow CI runner.

Red-green verified: restoring the greedy quantifier fails it at **7,395 ms**, while every existing matching test stays green — so the fix changes performance, not behavior.

`bun test src/` 3396 pass / 0 fail, `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USdFSTsyxgBgwvyp1UU491
