### PR TITLE
1.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.34.1] - 2026-09-06
+
 ### Fixed
 - **A long message no longer stalls message handling** (#551). The bot-to-bot status-post guard runs on every inbound message, on the event loop, before routing — and its authorization-refusal pattern used a greedy `\S+`, so any message that was *not* a refusal made the engine retry the split at every position before failing. Measured quadratic: ~150 ms at Mattermost's 16k post limit, 3.7 s at 80k, triggerable by any channel member with one long token. The quantifier is now lazy, which matches exactly the same strings (the addressee is a single whitespace-free token) in well under a millisecond. Measured under JSC, the engine Bun uses; V8 optimizes the greedy form away, so the fault is invisible when re-measured under Node.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.34.0",
+      "version": "1.34.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Version bump and CHANGELOG promotion for 1.34.1. Merging this triggers `release.yml`, which tags, releases and publishes.

Patch: one fix, no new surface.

**Fixed**
- A long message no longer stalls message handling (#553, fixes #551)

The status-post guard runs on every inbound message on the event loop, and a greedy `\S+` made non-matching messages quadratic in their length — ~150 ms at Mattermost's 16k post limit, 3.7 s at 80k, triggerable by any channel member with one long token. One character.

Reviewed independently: 200,000 fuzz cases with zero behavioral divergence between the greedy and lazy forms, the single-token addressee premise checked against all three emission sites, and every other pattern in the list re-stressed at 200k characters. The review also established that the fault only appears under JSC — V8 optimizes the greedy form away — which is now recorded in the code and the CHANGELOG so nobody re-measures under Node and concludes it was imaginary.

`bun test src/` 3396 pass / 0 fail, tsc and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USdFSTsyxgBgwvyp1UU491
