### PR TITLE
fix(mattermost): probe quiet sockets with ping before declaring them dead

### DIFF
--- a/src/platform/base-client.ts
+++ b/src/platform/base-client.ts
@@ -369,6 +369,13 @@ export abstract class BasePlatformClient extends EventEmitter implements Platfor
   }
 
   /**
+   * Send a request the server answers immediately (platform-specific). The
+   * reply must flow through the normal message path so it updates
+   * lastMessageAt. Default: no probe (heartbeat relies on organic traffic).
+   */
+  protected sendHeartbeatProbe(): void {}
+
+  /**
    * Start heartbeat monitoring to detect dead connections.
    * If no activity is detected for HEARTBEAT_TIMEOUT_MS, forces a reconnect.
    */
@@ -389,6 +396,16 @@ export abstract class BasePlatformClient extends EventEmitter implements Platfor
         return;
       }
 
+      // A quiet channel produces no traffic at all, which is indistinguishable
+      // from a dead socket. Ask the server for something cheap; its reply
+      // counts as activity, so only a socket that really stopped answering
+      // trips the timeout above.
+      // Half the interval, not the full one: the first tick lands a few ms
+      // short of INTERVAL and would skip the probe, and the next tick then
+      // trips TIMEOUT (= 2 × INTERVAL) by the same few ms.
+      if (silentFor >= this.HEARTBEAT_INTERVAL_MS / 2) {
+        this.sendHeartbeatProbe();
+      }
       wsLogger.debug(`Heartbeat check (last activity ${Math.round(silentFor / 1000)}s ago)`);
     }, this.HEARTBEAT_INTERVAL_MS);
   }

--- a/src/platform/mattermost/client.test.ts
+++ b/src/platform/mattermost/client.test.ts
@@ -363,13 +363,17 @@ describe('heartbeat probe', () => {
       ws: unknown; HEARTBEAT_INTERVAL_MS: number; HEARTBEAT_TIMEOUT_MS: number;
       startHeartbeat(): void; stopHeartbeat(): void; scheduleReconnect(): void; updateLastMessageTime(): void;
     };
-    Object.defineProperty(c, 'HEARTBEAT_INTERVAL_MS', { value: 15 });
-    Object.defineProperty(c, 'HEARTBEAT_TIMEOUT_MS', { value: 60 });
+    // Real timers: the timeout check runs before the probe, so an event-loop
+    // stall longer than TIMEOUT between two ticks would reconnect and fail
+    // the test. 25/250/500 keeps ten times the slack of a loaded CI runner
+    // while the timeout can still trip inside the wait.
+    Object.defineProperty(c, 'HEARTBEAT_INTERVAL_MS', { value: 25 });
+    Object.defineProperty(c, 'HEARTBEAT_TIMEOUT_MS', { value: 250 });
     let reconnects = 0;
     c.scheduleReconnect = () => { reconnects++; };
     c.ws = { readyState: 1, send: (data: string) => { sent.push(data); c.updateLastMessageTime(); } };
     c.startHeartbeat();
-    await new Promise((r) => setTimeout(r, 120));
+    await new Promise((r) => setTimeout(r, 500));
     c.stopHeartbeat();
     expect(sent.length).toBeGreaterThan(0);
     expect(JSON.parse(sent[0])).toMatchObject({ action: 'ping' });

--- a/src/platform/mattermost/client.test.ts
+++ b/src/platform/mattermost/client.test.ts
@@ -354,3 +354,25 @@ describe('MattermostClient HTTP methods', () => {
     expect(attempts).toBe(3);
   }, 10_000);
 });
+
+describe('heartbeat probe', () => {
+  it('probes a quiet socket with ping instead of declaring it dead', async () => {
+    const client = makeClient();
+    const sent: string[] = [];
+    const c = client as unknown as {
+      ws: unknown; HEARTBEAT_INTERVAL_MS: number; HEARTBEAT_TIMEOUT_MS: number;
+      startHeartbeat(): void; stopHeartbeat(): void; scheduleReconnect(): void; updateLastMessageTime(): void;
+    };
+    Object.defineProperty(c, 'HEARTBEAT_INTERVAL_MS', { value: 15 });
+    Object.defineProperty(c, 'HEARTBEAT_TIMEOUT_MS', { value: 60 });
+    let reconnects = 0;
+    c.scheduleReconnect = () => { reconnects++; };
+    c.ws = { readyState: 1, send: (data: string) => { sent.push(data); c.updateLastMessageTime(); } };
+    c.startHeartbeat();
+    await new Promise((r) => setTimeout(r, 120));
+    c.stopHeartbeat();
+    expect(sent.length).toBeGreaterThan(0);
+    expect(JSON.parse(sent[0])).toMatchObject({ action: 'ping' });
+    expect(reconnects).toBe(0);
+  });
+});

--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -775,6 +775,12 @@ export class MattermostClient extends BasePlatformClient {
     return `${this.url}/_redirect/pl/${targetId}`;
   }
 
+  /** Heartbeat probe: Mattermost answers the `ping` action with a `pong` status reply. */
+  protected override sendHeartbeatProbe(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ action: 'ping', seq: Date.now() }));
+  }
+
   // Send typing indicator via WebSocket
   sendTyping(parentId?: string): void {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {

--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -38,7 +38,9 @@ export { WS as WebSocket };
  *
  * undici's WHATWG WebSocket auto-pongs internally and exposes no frame-level
  * ping visibility at all, so that runtime stays uncovered at this layer;
- * client-initiated pings from the heartbeat are the eventual answer there.
+ * there the heartbeat's own probe (`BasePlatformClient.sendHeartbeatProbe`,
+ * a client-initiated `ping` whose reply counts as activity) keeps a quiet
+ * socket alive.
  * Both attachments are optional-chained, so a runtime lacking either is a
  * silent no-op rather than a throw.
  */


### PR DESCRIPTION
## Problem

A channel with no traffic produces no WebSocket frames, which the heartbeat could not tell apart from a dead socket: after `HEARTBEAT_TIMEOUT_MS` of silence it forced a reconnect — every 90–150 s in a quiet channel, logged as `Connection dead (no activity for 90s)`. Any bot sitting in a low-traffic Mattermost channel reconnects in a loop all day.

## Fix

`BasePlatformClient` gains `sendHeartbeatProbe()`, called by the heartbeat tick once the socket has been silent for **half** the interval. The Mattermost client sends the `ping` action; the server's `pong` reply flows through `onmessage` and counts as activity, so only a socket that really stopped answering trips the timeout.

Half the interval, not the full one: the first tick lands a few ms short of `INTERVAL` and would skip the probe, and the next tick would then trip `TIMEOUT` (= 2 × `INTERVAL`) by the same few ms.

Slack is covered by #532 (protocol pings counted as activity); this is the Mattermost counterpart. Refs #498.

## Verification

- Production bot in a quiet private channel: 220 s without a reconnect (before: a reconnect every 90–150 s).
- New test in `src/platform/mattermost/client.test.ts`: a quiet socket is probed with `ping` and not declared dead.
- `tsc --noEmit`, eslint, platform suites clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnEaPZso3WCMFyQTee9ZsG
