### PR TITLE
fix: set the session shutdown flag before the first await; resolve chmod via PATH in the test helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -980,15 +980,17 @@ async function startWithoutDaemon() {
     // Guard against multiple shutdown calls (SIGINT + SIGTERM)
     if (isShuttingDown) return;
     isShuttingDown = true;
+    // Set the shutdown flag before ANY await: a service manager that signals
+    // the whole process group (systemd KillMode=control-group) kills the
+    // agent children at the same instant, and their exit events must not be
+    // mistaken for resume failures while we are still yielding to React.
+    session.setShuttingDown();
 
     // Update status bar to show shutdown in progress
     ui.setShuttingDown();
 
     // Give React a moment to render the shutdown state
     await new Promise((resolve) => setTimeout(resolve, 50));
-
-    // Set shutdown flag FIRST to prevent race conditions with exit events
-    session.setShuttingDown();
 
     // Update sticky messages to show shutdown state
     await session.updateAllStickyMessages();

--- a/src/test-utils/chmod-portable.ts
+++ b/src/test-utils/chmod-portable.ts
@@ -41,14 +41,15 @@ export async function setMode(path: string, mode: FileMode): Promise<void> {
   }
 
   // Step 2: shell out as a last resort. Use the absolute octal form so we
-  // don't depend on the symbolic parser of /bin/chmod.
+  // don't depend on the symbolic parser of chmod. Resolve it via PATH:
+  // NixOS has no /bin/chmod (only /run/current-system/sw/bin/chmod).
   const octal = (mode & 0o7777).toString(8).padStart(4, '0');
-  execFileSync('/bin/chmod', [octal, path]);
+  execFileSync('chmod', [octal, path]);
   s = await stat(path);
   if ((s.mode & 0o7777) !== (mode & 0o7777)) {
     throw new Error(
       `setMode(${path}, ${octal}) failed: stat shows ${(s.mode & 0o7777).toString(8)}. ` +
-        `Runtime chmod is broken AND /bin/chmod did not stick — bailing rather than running a useless test.`,
+        `Runtime chmod is broken AND chmod did not stick — bailing rather than running a useless test.`,
     );
   }
 }


### PR DESCRIPTION
Two small, independent fixes; happy to split if you prefer.

## Shutdown ordering

`setShuttingDown()` ran after the 50 ms `await` that lets React paint the shutdown state. A service manager that signals the whole process group (systemd `KillMode=control-group`) delivers SIGTERM to the Claude children at the same instant as to the daemon. Their exit events arrived during that await, the flag was still unset, and lifecycle counted each exit as a resume failure. Three restarts in a row dropped the session (`Exceeded 3 resume failures`).

The flag is now set before the first `await`; everything else in the handler is unchanged.

## Test helper on NixOS

`setMode()` shelled out to `/bin/chmod`, which NixOS does not have (only `/run/current-system/sw/bin/chmod`). It now resolves `chmod` via `PATH`; the three affected unit tests (`setMode` SUID/SGID, `validateOutboundPath`) pass on NixOS again.

## Verification

- Session survived three consecutive `systemctl restart` cycles under `KillMode=control-group` (before: dropped on the third).
- `bun run test` 3425 pass / 0 fail on NixOS, `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnEaPZso3WCMFyQTee9ZsG
