### PR TITLE
feat: agent backend abstraction and OpenAI Codex as a second backend

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -52,6 +52,17 @@ platforms:
 | `threadLogs` | Thread logging (see below) | enabled |
 | `stickyMessage` | Sticky message text customization (see below) | none |
 | `claudeAccounts` | Multi-account pool (see below) | single-account mode |
+| `agentBackend` | Agent that runs new sessions: `claude` (Claude Code CLI) or `codex` (OpenAI Codex via `codex app-server`, see below). Existing sessions keep the backend they were started with. | `claude` |
+
+### Agent Backend (`agentBackend`)
+
+`agentBackend: codex` runs every new session on OpenAI Codex instead of the Claude Code CLI. The bot talks to `codex app-server` over stdio (JSON-RPC, one process per session), tested against Codex 0.153.4; startup checks that `codex` is installed and logged in (`codex login`) and warns on a version drift.
+
+What carries over unchanged: approvals via reactions (including "approve for the rest of this session"), questions from the agent (`item/tool/requestUserInput` is rendered like `AskUserQuestion`), `!stop`, `!cd`, `!permissions`, worktrees, file and image attachments (sent as `localImage` input), file uploads and agent actions through the bot's MCP server (Codex loads it as `claude-threads-mcp`), thread logs, audit log, memory, session resume across bot restarts (`thread/resume`). Backend-specific commands: `!compact` (`thread/compact/start`), `!model <name>`, `!effort <level>`, `!context` / `!cost` (token usage). Codex-side usage limits are reported in the thread with the reset time.
+
+Not supported with `codex`: `claudeAccounts` (Claude-only; startup refuses the combination), Claude slash-command passthrough, Claude plugins. Title and branch suggestions use `codex exec --ephemeral`. Codex additionally loads the MCP servers from its own `~/.codex/config.toml`; keep `allowedUsers` in mind when those servers reach personal data.
+
+Permission mapping: `default` → Codex `approvalPolicy: untrusted`, `sandbox: workspace-write`; `auto` → `on-request`; `bypass` → `never`, `danger-full-access`.
 
 ### Resource Limits (`limits`)
 

--- a/src/agents/codex/app-server.test.ts
+++ b/src/agents/codex/app-server.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { CodexAppServer } from './app-server.js';
+import { createLogger } from '../../utils/logger.js';
+
+describe('CodexAppServer', () => {
+  test('a spawn failure reports the error and releases the running state', async () => {
+    const rpc = new CodexAppServer(createLogger('test'), '/nonexistent/codex-binary');
+    const errors: Error[] = [];
+    const exits: Array<number | null> = [];
+    rpc.onError = (e) => errors.push(e);
+    rpc.onExit = (c) => exits.push(c);
+    rpc.spawn('/tmp');
+    const rejected = expect(rpc.request('initialize', {})).rejects.toThrow(/failed to start/);
+    await Bun.sleep(30);
+    expect(errors).toHaveLength(1);
+    expect(rpc.isRunning()).toBe(false);
+    expect(exits).toHaveLength(1);
+    await rejected;
+  });
+});

--- a/src/agents/codex/app-server.ts
+++ b/src/agents/codex/app-server.ts
@@ -6,7 +6,8 @@
  * responses `id`+`result|error`, notifications `method` only, and server→client
  * requests (approvals) carry `id`+`method` and expect a response with that id.
  */
-import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import { crossSpawn } from '../../utils/spawn.js';
 import { createInterface } from 'readline';
 import type { Logger } from '../../utils/logger.js';
 
@@ -31,8 +32,12 @@ export class CodexAppServer {
 
   spawn(cwd: string, env: NodeJS.ProcessEnv = process.env): void {
     if (this.proc) throw new Error('Already running');
-    const proc = spawn(this.bin, ['app-server', '--listen', 'stdio://'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] });
+    const proc = crossSpawn(this.bin, ['app-server', '--listen', 'stdio://'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] });
     this.proc = proc;
+    // A write into a stdin the server already closed raises EPIPE as a
+    // stream 'error'; without a listener that is an uncaught exception that
+    // takes the whole bot down. The pending request fails via exit/timeout.
+    proc.stdin.on('error', (err) => this.log.debug(`stdin: ${(err as NodeJS.ErrnoException).code ?? err.message}`));
     createInterface({ input: proc.stdout }).on('line', (line) => this.handle(line));
     proc.stderr.on('data', (chunk: Buffer) => {
       const text = chunk.toString();

--- a/src/agents/codex/app-server.ts
+++ b/src/agents/codex/app-server.ts
@@ -1,0 +1,125 @@
+/**
+ * Minimal JSON-RPC client for `codex app-server` over stdio.
+ *
+ * Wire format (verified against codex-cli 0.153.4, see prototypes/codex-app-server.ts):
+ * newline-delimited JSON, no `jsonrpc` field. Requests carry `id`+`method`,
+ * responses `id`+`result|error`, notifications `method` only, and server→client
+ * requests (approvals) carry `id`+`method` and expect a response with that id.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
+import { createInterface } from 'readline';
+import type { Logger } from '../../utils/logger.js';
+
+export type Json = Record<string, unknown>;
+type Pending = { resolve: (v: unknown) => void; reject: (e: Error) => void };
+
+/** Pinned protocol version: types were generated from this CLI version. */
+export const CODEX_PROTOCOL_VERSION = '0.153.4';
+
+export class CodexAppServer {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private nextId = 1;
+  private pending = new Map<number, Pending>();
+  private stderrBuffer = '';
+
+  onNotification: (method: string, params: Json) => void = () => {};
+  onServerRequest: (method: string, params: Json) => Promise<unknown> = async () => ({});
+  onExit: (code: number | null) => void = () => {};
+  onError: (err: Error) => void = () => {};
+
+  constructor(private readonly log: Logger, private readonly bin = process.env.CODEX_BIN ?? 'codex') {}
+
+  spawn(cwd: string, env: NodeJS.ProcessEnv = process.env): void {
+    if (this.proc) throw new Error('Already running');
+    const proc = spawn(this.bin, ['app-server', '--listen', 'stdio://'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] });
+    this.proc = proc;
+    createInterface({ input: proc.stdout }).on('line', (line) => this.handle(line));
+    proc.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      this.stderrBuffer = (this.stderrBuffer + text).slice(-8192);
+      this.log.debug(`stderr: ${text.trim()}`);
+    });
+    let finished = false;
+    const finish = (code: number | null, reason: string) => {
+      if (finished) return;
+      finished = true;
+      this.proc = null;
+      for (const p of this.pending.values()) p.reject(new Error(`codex app-server ${reason}`));
+      this.pending.clear();
+      this.onExit(code);
+    };
+    proc.on('error', (err) => {
+      this.onError(err);
+      // A spawn failure (ENOENT …) may never emit 'exit': release the running
+      // state here so the session is not left looking alive.
+      if (proc.exitCode === null && !proc.pid) finish(null, `failed to start: ${err.message}`);
+    });
+    proc.on('exit', (code) => finish(code, `exited (${code})`));
+  }
+
+  isRunning(): boolean { return this.proc !== null; }
+  get pid(): number | undefined { return this.proc?.pid; }
+  getLastStderr(): string { return this.stderrBuffer; }
+
+  /** SIGTERM, escalating to SIGKILL when the process ignores it. */
+  kill(graceMs = 5000): void {
+    const proc = this.proc;
+    if (!proc) return;
+    proc.kill('SIGTERM');
+    setTimeout(() => {
+      if (this.proc === proc) {
+        this.log.warn(`codex app-server ignored SIGTERM for ${graceMs}ms → SIGKILL`);
+        proc.kill('SIGKILL');
+      }
+    }, graceMs).unref();
+  }
+
+  /**
+   * Send a request. Every response is expected promptly — even turn/start
+   * only acknowledges the turn — so a missing reply means a wedged server.
+   */
+  request<T = unknown>(method: string, params?: unknown, timeoutMs = 60000): Promise<T> {
+    const id = this.nextId++;
+    return new Promise<T>((resolve, reject) => {
+      if (!this.proc) return reject(new Error('codex app-server not running'));
+      const timer = setTimeout(() => {
+        if (!this.pending.delete(id)) return;
+        reject(new Error(`codex ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      timer.unref();
+      this.pending.set(id, {
+        resolve: (v) => { clearTimeout(timer); (resolve as (v: unknown) => void)(v); },
+        reject: (e) => { clearTimeout(timer); reject(e); },
+      });
+      this.write({ id, method, params });
+    });
+  }
+
+  notify(method: string, params?: unknown): void { this.write({ method, params }); }
+
+  private write(msg: Json): void {
+    this.proc?.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  private handle(line: string): void {
+    if (!line.trim()) return;
+    let msg: Json;
+    try { msg = JSON.parse(line) as Json; } catch { this.log.debug(`non-JSON line: ${line.slice(0, 200)}`); return; }
+    const { id, method, params, result, error } = msg as {
+      id?: number; method?: string; params?: Json; result?: unknown; error?: { message?: string };
+    };
+    if (method && id !== undefined) {
+      this.onServerRequest(method, params ?? {})
+        .then((r) => this.write({ id, result: r }))
+        .catch((e) => this.write({ id, error: { code: -32000, message: String(e) } }));
+    } else if (method) {
+      this.onNotification(method, params ?? {});
+    } else if (id !== undefined) {
+      const p = this.pending.get(id);
+      if (!p) return;
+      this.pending.delete(id);
+      if (error) p.reject(new Error(error.message ?? JSON.stringify(error)));
+      else p.resolve(result);
+    }
+  }
+}

--- a/src/agents/codex/session.test.ts
+++ b/src/agents/codex/session.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, test } from 'bun:test';
+import { parseCodexResetAt } from './session.js';
+
+describe('parseCodexResetAt', () => {
+  test('parses the codex usage-limit phrase incl. ordinal suffix', () => {
+    const msg = "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Sep 6th, 2026 12:28 AM.";
+    expect(parseCodexResetAt(msg)).toBe(Date.parse('Sep 6, 2026 12:28 AM'));
+  });
+  test('returns undefined without a reset phrase', () => {
+    expect(parseCodexResetAt('You have hit your usage limit.')).toBeUndefined();
+  });
+});
+
+import { CodexSession, extractImagePaths } from './session.js';
+import type { ClaudeEvent } from '../../claude/cli.js';
+
+// Drives the private server-request path without spawning codex.
+function harness(permissionTimeoutMs?: number) {
+  const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null, permissionTimeoutMs });
+  const events: ClaudeEvent[] = [];
+  agent.on('event', (e: ClaudeEvent) => events.push(e));
+  const ask = (command: string) =>
+    (agent as unknown as { handleServerRequest(m: string, p: Record<string, unknown>): Promise<{ decision: string }> })
+      .handleServerRequest('item/commandExecution/requestApproval', { command });
+  return { agent, events, ask };
+}
+
+describe('CodexSession approvals', () => {
+  test('serializes prompts: second approval_request only after the first is decided', async () => {
+    const { agent, events, ask } = harness();
+    const first = ask('ls');
+    const second = ask('pwd');
+    await Bun.sleep(0);
+    const requests = () => events.filter((e) => e.type === 'approval_request');
+    expect(requests()).toHaveLength(1);
+    agent.respondToApproval(String(requests()[0].request_id), true);
+    expect(await first).toEqual({ decision: 'accept' });
+    await Bun.sleep(0);
+    expect(requests()).toHaveLength(2);
+    agent.respondToApproval(String(requests()[1].request_id), false);
+    expect(await second).toEqual({ decision: 'decline' });
+  });
+
+  test('times out into decline + approval_timeout; a late answer is a no-op', async () => {
+    const { agent, events, ask } = harness(20);
+    const pending = ask('rm -rf /');
+    expect(await pending).toEqual({ decision: 'decline' });
+    const timeout = events.find((e) => e.type === 'approval_timeout');
+    const request = events.find((e) => e.type === 'approval_request');
+    expect(timeout?.request_id).toBe(request?.request_id);
+    agent.respondToApproval(String(request?.request_id), true); // must not throw or re-resolve
+  });
+
+  test('allow-all answers acceptForSession and silences later prompts', async () => {
+    const { agent, events, ask } = harness();
+    const first = ask('ls');
+    await Bun.sleep(0);
+    agent.respondToApproval(String(events[0].request_id), true, true);
+    expect(await first).toEqual({ decision: 'acceptForSession' });
+    expect(await ask('pwd')).toEqual({ decision: 'accept' });
+    expect(events.filter((e) => e.type === 'approval_request')).toHaveLength(1);
+  });
+
+  test('interrupt declines open prompts and closes their posts', async () => {
+    const { agent, events, ask } = harness();
+    (agent as unknown as { activeTurn: unknown }).activeTurn = { threadId: 't', turnId: 'u' };
+    const pending = ask('sleep 60');
+    await Bun.sleep(0);
+    expect(agent.interrupt()).toBe(true);
+    expect(await pending).toEqual({ decision: 'decline' });
+    const request = events.find((e) => e.type === 'approval_request');
+    expect(events.find((e) => e.type === 'approval_timeout')?.request_id).toBe(request?.request_id);
+  });
+
+  test('bypass mode auto-accepts without prompting', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null, permissionMode: 'bypass' });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const r = await (agent as unknown as { handleServerRequest(m: string, p: Record<string, unknown>): Promise<unknown> })
+      .handleServerRequest('item/commandExecution/requestApproval', { command: 'ls' });
+    expect(r).toEqual({ decision: 'accept' });
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('extractImagePaths', () => {
+  test('picks image paths out of the attachment header block only', () => {
+    const content = [
+      '[Attached files from chat — saved to disk, use Read or move/copy as needed:]',
+      '- /tmp/up/a.png (image/png, 12 KB)',
+      '- /tmp/up/notes.pdf (application/pdf, 1 MB)',
+      '- /tmp/up/b.jpg (image/jpeg, 3 KB)',
+      '',
+      'Look at this: - /not/a/file.png (image/png, 1 KB)',
+    ].join('\n');
+    expect(extractImagePaths(content)).toEqual(['/tmp/up/a.png', '/tmp/up/b.jpg']);
+  });
+  test('returns nothing for plain text', () => {
+    expect(extractImagePaths('hello')).toEqual([]);
+  });
+});
+
+describe('CodexSession questions and permissions', () => {
+  const call = (agent: CodexSession, method: string, params: Record<string, unknown>) =>
+    (agent as unknown as { handleServerRequest(m: string, p: Record<string, unknown>): Promise<unknown> }).handleServerRequest(method, params);
+
+  test('requestUserInput renders AskUserQuestion and maps answers header → id', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const pending = call(agent, 'item/tool/requestUserInput', {
+      questions: [
+        { id: 'q1', header: 'Branch', question: 'Which branch?', isOther: false, isSecret: false, options: [{ label: 'main', description: '' }, { label: 'dev', description: '' }] },
+        { id: 'q2', header: 'Confirm', question: 'Go ahead?', isOther: false, isSecret: false, options: null },
+      ],
+      isBlocking: true, autoResolutionMs: null,
+    });
+    await Bun.sleep(0);
+    const toolUse = (events[0].message as { content: Array<{ name: string; input: { questions: Array<{ header: string; options: unknown[] }> } }> }).content[0];
+    expect(toolUse.name).toBe('AskUserQuestion');
+    expect(toolUse.input.questions.map((q) => q.header)).toEqual(['Branch', 'Confirm']);
+    expect(toolUse.input.questions[1].options).toHaveLength(1); // fallback option for option-less questions
+    agent.respondToQuestion([{ header: 'Branch', answer: 'dev' }, { header: 'Confirm', answer: 'OK' }]);
+    expect(await pending).toEqual({ answers: { q1: { answers: ['dev'] }, q2: { answers: ['OK'] } } });
+  });
+
+  test('permissions approval grants the requested profile for the turn, or nothing on decline', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const perms = { network: { allowAll: true }, fileSystem: null };
+    const p1 = call(agent, 'item/permissions/requestApproval', { permissions: perms, reason: 'curl' });
+    await Bun.sleep(0);
+    agent.respondToApproval(String(events[0].request_id), true);
+    expect(await p1).toEqual({ permissions: perms, scope: 'turn' });
+    const p2 = call(agent, 'item/permissions/requestApproval', { permissions: perms });
+    await Bun.sleep(0);
+    agent.respondToApproval(String(events[1].request_id), false);
+    expect(await p2).toEqual({ permissions: {}, scope: 'turn' });
+  });
+});
+
+describe('CodexSession item translation', () => {
+  const drive = () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const n = (agent as unknown as { handleNotification(m: string, p: Record<string, unknown>): void });
+    return { events, notify: (m: string, p: Record<string, unknown>) => n.handleNotification(m, p) };
+  };
+  const blocks = (e: ClaudeEvent) => (e.message as { content: Array<Record<string, unknown>> }).content;
+
+  test('commandExecution → Bash tool_use + tool_result with exit-code error flag', () => {
+    const { events, notify } = drive();
+    notify('item/started', { item: { type: 'commandExecution', id: 'c1', command: 'ls', status: 'inProgress' } });
+    notify('item/completed', { item: { type: 'commandExecution', id: 'c1', command: 'ls', status: 'completed', aggregatedOutput: 'a\nb', exitCode: 2 } });
+    expect(events[0].type).toBe('assistant');
+    expect(blocks(events[0])[0]).toMatchObject({ type: 'tool_use', id: 'c1', name: 'Bash', input: { command: 'ls' } });
+    expect(events[1].type).toBe('user');
+    expect(blocks(events[1])[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'c1', content: 'a\nb', is_error: true });
+  });
+
+  test('declined command → error tool_result, no crash on missing output', () => {
+    const { events, notify } = drive();
+    notify('item/completed', { item: { type: 'commandExecution', id: 'c2', command: 'rm', status: 'declined', aggregatedOutput: null, exitCode: null } });
+    expect(blocks(events[0])[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'c2', is_error: true });
+  });
+
+  test('fileChange → one Edit per path, mcpToolCall → mcp__server__tool, reasoning → thinking', () => {
+    const { events, notify } = drive();
+    notify('item/started', { item: { type: 'fileChange', id: 'f1', status: 'inProgress', changes: [{ path: '/x/a.ts', kind: 'update', diff: '+1' }, { path: '/x/b.ts', kind: 'add', diff: '+2' }] } });
+    notify('item/completed', { item: { type: 'fileChange', id: 'f1', status: 'completed', changes: [{ path: '/x/a.ts', kind: 'update', diff: '+1' }, { path: '/x/b.ts', kind: 'add', diff: '+2' }] } });
+    notify('item/started', { item: { type: 'mcpToolCall', id: 'm1', server: 'claude-threads-mcp', tool: 'send_file', status: 'inProgress', arguments: { path: '/x/a.png' } } });
+    notify('item/completed', { item: { type: 'mcpToolCall', id: 'm1', server: 'claude-threads-mcp', tool: 'send_file', status: 'completed', arguments: {}, result: { ok: true }, error: null } });
+    notify('item/completed', { item: { type: 'reasoning', id: 'r1', summary: ['thinking hard'], content: [] } });
+    const names = events.flatMap((e) => blocks(e).map((b) => `${b.type}:${b.name ?? b.tool_use_id ?? ''}`));
+    expect(names).toEqual([
+      'tool_use:Edit', 'tool_use:Edit', 'tool_result:f1:/x/a.ts', 'tool_result:f1:/x/b.ts',
+      'tool_use:mcp__claude-threads-mcp__send_file', 'tool_result:m1', 'thinking:',
+    ]);
+  });
+
+  test('turn lifecycle → result carries the accumulated text and the interrupted status', () => {
+    const { events, notify } = drive();
+    notify('turn/started', { threadId: 't', turn: { id: 'u1' } });
+    notify('item/completed', { item: { type: 'agentMessage', id: 'a1', text: 'Hallo' } });
+    notify('turn/completed', { threadId: 't', turn: { id: 'u1', status: 'interrupted', error: null } });
+    const result = events.find((e) => e.type === 'result');
+    expect(result).toMatchObject({ subtype: 'error_interrupted', is_error: false, result: 'Hallo' });
+  });
+});
+
+describe('CodexSession MCP elicitations', () => {
+  const call = (agent: CodexSession, params: Record<string, unknown>) =>
+    (agent as unknown as { handleServerRequest(m: string, p: Record<string, unknown>): Promise<unknown> })
+      .handleServerRequest('mcpServer/elicitation/request', params);
+  const approval = (serverName: string, tool: string) => ({
+    serverName, mode: 'form', message: `Allow the ${serverName} MCP server to run tool "${tool}"?`,
+    _meta: { codex_approval_kind: 'mcp_tool_call', persist: ['session', 'always'], tool_params_display: [{ name: 'path', display_name: 'path', value: '/x' }] },
+    requestedSchema: { type: 'object', properties: {} },
+  });
+
+  test("the bot's own MCP tools are accepted without a prompt", async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    expect(await call(agent, approval('claude-threads-mcp', 'send_file'))).toEqual({ action: 'accept', content: {}, _meta: null });
+    expect(events).toHaveLength(0);
+  });
+
+  test('foreign MCP tools prompt; decline maps to action decline', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const pending = call(agent, approval('mail', 'send_email'));
+    await Bun.sleep(0);
+    expect(events[0]).toMatchObject({ type: 'approval_request', tool_name: 'MCP mail/send_email', content: 'path: /x' });
+    agent.respondToApproval(String(events[0].request_id), false);
+    expect(await pending).toEqual({ action: 'decline', content: null, _meta: null });
+  });
+
+  test('real elicitation forms are declined', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    expect(await call(agent, { serverName: 'x', mode: 'url', message: 'login', url: 'https://x', elicitationId: '1', _meta: null }))
+      .toEqual({ action: 'decline', content: null, _meta: null });
+  });
+});
+
+describe('imageGeneration items', () => {
+  test('completed image → tool_result + agent_file with the saved path', () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const n = agent as unknown as { handleNotification(m: string, p: Record<string, unknown>): void };
+    n.handleNotification('item/started', { item: { type: 'imageGeneration', id: 'i1', status: 'inProgress', revisedPrompt: 'a viking', result: '', failure: null } });
+    n.handleNotification('item/completed', { item: { type: 'imageGeneration', id: 'i1', status: 'completed', revisedPrompt: 'a viking', result: '', failure: null, savedPath: '/home/x/.codex/generated_images/t/i1.png' } });
+    expect(events.map((e) => e.type)).toEqual(['assistant', 'user', 'agent_file']);
+    expect(events[2]).toMatchObject({ path: '/home/x/.codex/generated_images/t/i1.png' });
+    expect(events[2].caption).toBeUndefined();
+  });
+  test('failed image → error tool_result, no upload', () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    (agent as unknown as { handleNotification(m: string, p: Record<string, unknown>): void })
+      .handleNotification('item/completed', { item: { type: 'imageGeneration', id: 'i2', status: 'failed', revisedPrompt: null, result: '', failure: { message: 'blocked' } } });
+    expect(events.map((e) => e.type)).toEqual(['user']);
+  });
+});
+
+describe('CodexSession exit codes', () => {
+  test('a requested kill reports exit 0; an unexpected death keeps its code', async () => {
+    const mk = () => {
+      const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+      const codes: unknown[] = [];
+      agent.on('exit', (c: unknown) => codes.push(c));
+      const rpc = (agent as unknown as { rpc: { onExit: (c: number | null) => void; isRunning: () => boolean; kill: () => void } }).rpc;
+      return { agent, codes, rpc };
+    };
+    const a = mk();
+    a.rpc.isRunning = () => true;
+    a.rpc.kill = () => a.rpc.onExit(null);
+    await a.agent.kill();
+    expect(a.codes).toEqual([0]);
+    const b = mk();
+    b.rpc.onExit(null);
+    expect(b.codes).toEqual([null]);
+  });
+});
+
+describe('review regressions', () => {
+  const srv = (agent: CodexSession) => agent as unknown as {
+    handleServerRequest(m: string, p: Record<string, unknown>): Promise<unknown>;
+    activeTurn: unknown; ready: Promise<void> | null; threadId: string | null;
+    rpc: { request: (m: string, p?: unknown) => Promise<unknown> };
+  };
+
+  test('interrupt declines queued approvals unseen, not only the visible one', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const a = srv(agent);
+    a.activeTurn = { threadId: 't', turnId: 'u' };
+    a.rpc.request = async () => ({});
+    const first = a.handleServerRequest('item/commandExecution/requestApproval', { command: 'first' });
+    const second = a.handleServerRequest('item/commandExecution/requestApproval', { command: 'second' });
+    await Bun.sleep(0);
+    agent.interrupt();
+    expect(await Promise.all([first, second])).toEqual([{ decision: 'decline' }, { decision: 'decline' }]);
+    expect(events.filter((e) => e.type === 'approval_request')).toHaveLength(1);
+  });
+
+  test('a rejected turn/start emits a terminal error result', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const a = srv(agent);
+    a.ready = Promise.resolve();
+    a.threadId = 't';
+    a.rpc.request = async () => { throw new Error('invalid turn parameters'); };
+    agent.sendMessage('hello');
+    await Bun.sleep(0);
+    expect(events.find((e) => e.type === 'result')).toMatchObject({ is_error: true, result: 'invalid turn parameters' });
+  });
+
+  test('answers carry the question-set id; a foreign id is ignored, a timeout announces itself', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null, permissionTimeoutMs: 30 });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const a = srv(agent);
+    const q = (id: string, timeout: number | null) => a.handleServerRequest('item/tool/requestUserInput', {
+      questions: [{ id, header: 'Confirm', question: id, isOther: false, isSecret: false, options: [{ label: 'yes', description: '' }] }],
+      isBlocking: true, autoResolutionMs: timeout,
+    });
+    const first = q('old', 20);
+    await Bun.sleep(0);
+    const oldSetId = String((events[0].message as { content: Array<{ id: string }> }).content[0].id);
+    expect(await first).toEqual({ answers: {} });
+    expect(events.find((e) => e.type === 'question_timeout')?.request_id).toBe(oldSetId);
+    const second = q('new', null);
+    await Bun.sleep(0);
+    agent.respondToQuestion([{ header: 'Confirm', answer: 'yes' }], oldSetId); // stale id → ignored
+    const newSetId = String((events.at(-1)!.message as { content: Array<{ id: string }> }).content[0].id);
+    agent.respondToQuestion([{ header: 'Confirm', answer: 'yes' }], newSetId);
+    expect(await second).toEqual({ answers: { new: { answers: ['yes'] } } });
+  });
+
+  test('image paths with spaces are extracted', () => {
+    expect(extractImagePaths('[Attached files from chat — saved to disk, use Read or move/copy as needed:]\n- /tmp/up/Screenshot 2026-09-06 (1).png (image/png, 12 KB)\n\nhi'))
+      .toEqual(['/tmp/up/Screenshot 2026-09-06 (1).png']);
+  });
+});

--- a/src/agents/codex/session.test.ts
+++ b/src/agents/codex/session.test.ts
@@ -369,7 +369,43 @@ describe('review regressions', () => {
     const result = events.find((e) => e.type === 'result') as ClaudeEvent & { usage: Record<string, number>; modelUsage: Record<string, Record<string, number>> };
     expect(result.usage).toEqual({ input_tokens: 100, output_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 300 });
     expect(result.modelUsage.codex).toMatchObject({ inputTokens: 400, cacheReadInputTokens: 600, cacheCreationInputTokens: 0, outputTokens: 300, contextWindow: 200000 });
+    expect(agent.getStatusData()?.total_input_tokens).toBe(400); // current context = last input incl. cache, for the status-line consumer
     for (const v of Object.values(result.usage)) expect(Number.isNaN(v)).toBe(false);
+  });
+
+  test('interrupt before the thread is open drops the queued first message', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const a = srv(agent);
+    let open!: () => void;
+    a.ready = new Promise<void>((r) => { open = r; });
+    a.threadId = 't';
+    const calls: string[] = [];
+    a.rpc.request = async (m) => { calls.push(m); return {}; };
+    agent.sendMessage('hello');
+    expect(agent.interrupt()).toBe(true); // something was queued
+    open();
+    await Bun.sleep(0); await Bun.sleep(0);
+    expect(calls).toEqual([]);
+    agent.sendMessage('after'); // later messages are unaffected
+    await Bun.sleep(0); await Bun.sleep(0);
+    expect(calls).toEqual(['turn/start']);
+  });
+
+  test('interrupt while turn/start awaits its ack interrupts that turn once the id arrives', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const a = srv(agent);
+    a.ready = Promise.resolve();
+    a.threadId = 't';
+    const calls: Array<[string, unknown]> = [];
+    let ack!: (v: unknown) => void;
+    a.rpc.request = (m, p) => { calls.push([m, p]); return m === 'turn/start' ? new Promise((r) => { ack = r; }) : Promise.resolve({}); };
+    agent.sendMessage('go');
+    await Bun.sleep(0); await Bun.sleep(0);
+    expect(agent.interrupt()).toBe(true);
+    ack({ turn: { id: 'turn-7' } });
+    await Bun.sleep(0); await Bun.sleep(0);
+    expect(calls.map((c) => c[0])).toEqual(['turn/start', 'turn/interrupt']);
+    expect(calls[1][1]).toMatchObject({ turnId: 'turn-7' });
   });
 
   test('a steer that loses the race against turn end falls back to a new turn', async () => {

--- a/src/agents/codex/session.test.ts
+++ b/src/agents/codex/session.test.ts
@@ -381,11 +381,14 @@ describe('review regressions', () => {
     a.threadId = 't';
     const calls: string[] = [];
     a.rpc.request = async (m) => { calls.push(m); return {}; };
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
     agent.sendMessage('hello');
     expect(agent.interrupt()).toBe(true); // something was queued
     open();
     await Bun.sleep(0); await Bun.sleep(0);
     expect(calls).toEqual([]);
+    expect(events.find((e) => e.type === 'result')).toMatchObject({ subtype: 'error_interrupted' }); // ends the chat's processing state
     agent.sendMessage('after'); // later messages are unaffected
     await Bun.sleep(0); await Bun.sleep(0);
     expect(calls).toEqual(['turn/start']);

--- a/src/agents/codex/session.test.ts
+++ b/src/agents/codex/session.test.ts
@@ -325,6 +325,62 @@ describe('review regressions', () => {
     expect(await second).toEqual({ answers: { new: { answers: ['yes'] } } });
   });
 
+  test('a message during a running turn steers it; after the turn it starts a new one', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const a = srv(agent);
+    a.ready = Promise.resolve();
+    a.threadId = 't';
+    const calls: Array<[string, unknown]> = [];
+    a.rpc.request = async (m, p) => { calls.push([m, p]); return {}; };
+    a.activeTurn = { threadId: 't', turnId: 'turn-1' };
+    agent.sendMessage('also check the tests');
+    await Bun.sleep(0);
+    expect(calls).toEqual([['turn/steer', { threadId: 't', input: [{ type: 'text', text: 'also check the tests', text_elements: [] }], expectedTurnId: 'turn-1' }]]);
+    a.activeTurn = null;
+    agent.sendMessage('next');
+    await Bun.sleep(0);
+    expect(calls[1][0]).toBe('turn/start');
+  });
+
+  test('a steer that loses the race against turn end falls back to a new turn', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const a = srv(agent);
+    a.ready = Promise.resolve();
+    a.threadId = 't';
+    const calls: string[] = [];
+    a.rpc.request = async (m) => {
+      calls.push(m);
+      if (m === 'turn/steer') { a.activeTurn = null; throw new Error('no active turn'); }
+      return {};
+    };
+    a.activeTurn = { threadId: 't', turnId: 'turn-1' };
+    agent.sendMessage('hi');
+    await Bun.sleep(0);
+    expect(calls).toEqual(['turn/steer', 'turn/start']);
+  });
+
+  test('a replaced question set leaves approvals of the same turn open', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const a = srv(agent);
+    a.activeTurn = { threadId: 't', turnId: 'u' };
+    const approval = a.handleServerRequest('item/commandExecution/requestApproval', { command: 'ls' });
+    const q = (id: string) => a.handleServerRequest('item/tool/requestUserInput', {
+      questions: [{ id, header: 'H', question: id, isOther: false, isSecret: false, options: [{ label: 'y', description: '' }] }],
+      isBlocking: true, autoResolutionMs: null,
+    });
+    const first = q('one');
+    await Bun.sleep(0);
+    void q('two');
+    expect(await first).toEqual({ answers: {} }); // superseded
+    await Bun.sleep(0);
+    const request = events.find((e) => e.type === 'approval_request');
+    expect(events.find((e) => e.type === 'approval_timeout')).toBeUndefined(); // approval still open
+    agent.respondToApproval(String(request?.request_id), true);
+    expect(await approval).toEqual({ decision: 'accept' });
+  });
+
   test('image paths with spaces are extracted', () => {
     expect(extractImagePaths('[Attached files from chat — saved to disk, use Read or move/copy as needed:]\n- /tmp/up/Screenshot 2026-09-06 (1).png (image/png, 12 KB)\n\nhi'))
       .toEqual(['/tmp/up/Screenshot 2026-09-06 (1).png']);

--- a/src/agents/codex/session.test.ts
+++ b/src/agents/codex/session.test.ts
@@ -342,6 +342,36 @@ describe('review regressions', () => {
     expect(calls[1][0]).toBe('turn/start');
   });
 
+  test('two messages before turn/started: one turn/start, the second steers the acknowledged turn', async () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const a = srv(agent);
+    a.ready = Promise.resolve();
+    a.threadId = 't';
+    const calls: string[] = [];
+    a.rpc.request = async (m) => { calls.push(m); return m === 'turn/start' ? { turn: { id: 'turn-9' } } : {}; };
+    agent.sendMessage('one');
+    agent.sendMessage('two');
+    await Bun.sleep(0); await Bun.sleep(0); await Bun.sleep(0);
+    expect(calls).toEqual(['turn/start', 'turn/steer']);
+  });
+
+  test('token usage: cached tokens are split out of input, missing counters become 0, no NaN', () => {
+    const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
+    const events: ClaudeEvent[] = [];
+    agent.on('event', (e: ClaudeEvent) => events.push(e));
+    const a = agent as unknown as { handleNotification(m: string, p: Record<string, unknown>): void };
+    a.handleNotification('thread/tokenUsage/updated', { tokenUsage: {
+      total: { totalTokens: 1300, inputTokens: 1000, cachedInputTokens: 600, outputTokens: 300, reasoningOutputTokens: 0 },
+      last: { totalTokens: 500, inputTokens: 400, cachedInputTokens: 300, outputTokens: 100, reasoningOutputTokens: 0 },
+      modelContextWindow: 200000,
+    } });
+    a.handleNotification('turn/completed', { turn: { id: 'u', status: 'completed', error: null } });
+    const result = events.find((e) => e.type === 'result') as ClaudeEvent & { usage: Record<string, number>; modelUsage: Record<string, Record<string, number>> };
+    expect(result.usage).toEqual({ input_tokens: 100, output_tokens: 100, cache_creation_input_tokens: 0, cache_read_input_tokens: 300 });
+    expect(result.modelUsage.codex).toMatchObject({ inputTokens: 400, cacheReadInputTokens: 600, cacheCreationInputTokens: 0, outputTokens: 300, contextWindow: 200000 });
+    for (const v of Object.values(result.usage)) expect(Number.isNaN(v)).toBe(false);
+  });
+
   test('a steer that loses the race against turn end falls back to a new turn', async () => {
     const agent = new CodexSession({ workingDir: '/tmp', memory: null, agentFeatures: null });
     const a = srv(agent);

--- a/src/agents/codex/session.ts
+++ b/src/agents/codex/session.ts
@@ -147,6 +147,9 @@ export class CodexSession extends EventEmitter implements AgentSession {
       this.rpc.kill();
       throw err;
     });
+    // Nobody may ever await `ready` (resume that fails before the first user
+    // message): keep the rejection for sendMessage(), but not unhandled.
+    this.ready.catch(() => {});
   }
 
   sendMessage(content: string): void {
@@ -167,6 +170,7 @@ export class CodexSession extends EventEmitter implements AgentSession {
       // rejected turn/start must close that state like a failed turn.
       this.log.error(`turn/start failed: ${err}`);
       const message = err instanceof Error ? err.message : String(err);
+      this.assistant({ type: 'text', text: `❌ Codex did not start the turn: ${message}` });
       this.emitEvent({ type: 'system', subtype: 'error', error: message });
       this.emitEvent({ type: 'result', subtype: 'error_turn_start', is_error: true, result: message, duration_ms: 0, num_turns: 0, session_id: this.threadId });
     });
@@ -318,6 +322,22 @@ export class CodexSession extends EventEmitter implements AgentSession {
           duration_ms: Date.now() - this.turnStartedAt,
           num_turns: 1,
           session_id: this.threadId,
+          // Same shape the Claude CLI puts on its result: this is what fills
+          // the session header (model, context %). Codex reports no cost.
+          ...(this.status ? {
+            total_cost_usd: 0,
+            usage: this.status.current_usage,
+            modelUsage: {
+              [this.model]: {
+                inputTokens: this.status.total_input_tokens,
+                outputTokens: this.status.total_output_tokens,
+                cacheReadInputTokens: this.status.current_usage?.cache_read_input_tokens ?? 0,
+                cacheCreationInputTokens: this.status.current_usage?.cache_creation_input_tokens ?? 0,
+                contextWindow: this.status.context_window_size,
+                costUSD: 0,
+              },
+            },
+          } : {}),
         });
         return;
       }
@@ -495,12 +515,12 @@ export class CodexSession extends EventEmitter implements AgentSession {
   }
 
   private askUser(toolName: string, content: string): Promise<ApprovalDecision> {
-    if (this.sessionApproved || (this.options.permissionMode ?? 'default') === 'bypass') {
-      return Promise.resolve('accept');
-    }
     const epoch = this.turnEpoch;
     const run = () => new Promise<ApprovalDecision>((resolve) => {
       if (epoch !== this.turnEpoch) { resolve('decline'); return; } // turn was interrupted meanwhile
+      // Checked here, not before queueing: a ✅ on the prompt ahead of us in
+      // the queue covers this request too.
+      if (this.sessionApproved || (this.options.permissionMode ?? 'default') === 'bypass') { resolve('accept'); return; }
       const requestId = randomUUID();
       const timeoutMs = this.options.permissionTimeoutMs ?? 120000;
       const timer = setTimeout(() => {

--- a/src/agents/codex/session.ts
+++ b/src/agents/codex/session.ts
@@ -166,7 +166,13 @@ export class CodexSession extends EventEmitter implements AgentSession {
     this.queuedSends++;
     this.sendChain = this.sendChain.then(() => ready).then(async () => {
       if (!this.threadId) return;
-      if (epoch !== this.sendEpoch) { this.log.debug('queued message dropped: interrupted before dispatch'); return; }
+      if (epoch !== this.sendEpoch) {
+        // The chat has been "processing" since the user posted; a message
+        // that never becomes a turn must still end that state.
+        this.log.debug('queued message dropped: interrupted before dispatch');
+        this.emitEvent({ type: 'result', subtype: 'error_interrupted', is_error: false, result: '', duration_ms: 0, num_turns: 0, session_id: this.threadId });
+        return;
+      }
       const input = [
         { type: 'text', text: content, text_elements: [] },
         ...extractImagePaths(content).map((path) => ({ type: 'localImage', path })),

--- a/src/agents/codex/session.ts
+++ b/src/agents/codex/session.ts
@@ -1,0 +1,604 @@
+/**
+ * Codex backend: drives one `codex app-server` process per bot session and
+ * translates its notifications into Claude stream-json shaped events so the
+ * existing transformer / events handler render them unchanged.
+ *
+ * Emitted event shapes (subset of what ClaudeCli produces):
+ *   system/init            {type:'system', subtype:'init', model, session_id}
+ *   assistant text         {type:'assistant', message:{content:[{type:'text'}]}}
+ *   assistant tool_use     {type:'assistant', message:{content:[{type:'tool_use', id, name, input}]}}
+ *   user tool_result       {type:'user', message:{content:[{type:'tool_result', tool_use_id, content, is_error}]}}
+ *   result                 {type:'result', subtype:'success'|'error', is_error, session_id, ...}
+ *   approval_request       {type:'approval_request', request_id, tool_name, content}  (Codex-only)
+ *   system/error           {type:'system', subtype:'error', error}
+ *
+ * ponytail: one process per session, no reconnect; account pool (HOME override)
+ * ignored — Codex uses ~/.codex of the bot user. Add when a second Codex login
+ * is needed.
+ */
+import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
+import {
+  buildMcpServerDefinition, resolveMcpServerPath, MCP_SERVER_NAME,
+  type ClaudeCliOptions, type ClaudeEvent, type StatusLineData,
+} from '../../claude/cli.js';
+import type { AgentSession } from '../types.js';
+import { createLogger } from '../../utils/logger.js';
+import { CodexAppServer, type Json } from './app-server.js';
+
+type ApprovalDecision = 'accept' | 'acceptForSession' | 'decline';
+
+interface ActiveTurn { threadId: string; turnId: string }
+
+/** Backend-specific guidance appended to the bot's system prompt. */
+const CODEX_DEVELOPER_NOTES = [
+  'Images you generate are posted into the chat automatically as soon as they are saved.',
+  'Do not copy generated images anywhere and do not call send_file for them; just describe the result briefly.',
+].join(' ');
+
+const POLICY: Record<string, { approvalPolicy: string; sandbox: string }> = {
+  default: { approvalPolicy: 'untrusted', sandbox: 'workspace-write' },
+  auto: { approvalPolicy: 'on-request', sandbox: 'workspace-write' },
+  bypass: { approvalPolicy: 'never', sandbox: 'danger-full-access' },
+};
+
+/**
+ * "… try again at Sep 6th, 2026 12:28 AM." → epoch ms (local time), or
+ * undefined when the phrase is absent or unparsable. Ordinal suffixes break
+ * Date.parse, so they are stripped first.
+ */
+export function parseCodexResetAt(message: string): number | undefined {
+  const when = /try again at ([^.]+)\./i.exec(message)?.[1];
+  if (!when) return undefined;
+  const ts = Date.parse(when.replace(/(\d+)(st|nd|rd|th)/, '$1'));
+  return Number.isFinite(ts) ? ts : undefined;
+}
+
+/**
+ * Image attachments arrive in the prompt as the streaming handler's file
+ * list ("- /abs/path (image/png, 12 KB)"). Codex can take them natively as
+ * `localImage` inputs, so pull those paths out; the text keeps the list so
+ * non-image files stay discoverable by path.
+ */
+export function extractImagePaths(content: string): string[] {
+  if (!content.startsWith('[Attached files from chat')) return [];
+  const paths: string[] = [];
+  for (const line of content.split('\n')) {
+    if (line === '') break; // end of the file list block
+    const m = /^- (\/.+) \(image\/[^,)]+, /.exec(line);
+    if (m) paths.push(m[1]);
+  }
+  return paths;
+}
+
+/** MCP results are a content envelope; show the text blocks, not the JSON wrapper. */
+function mcpResultText(result: unknown): string {
+  const content = (result as { content?: Array<{ type?: string; text?: string }> } | null)?.content;
+  if (Array.isArray(content)) {
+    const text = content.filter((c) => c.type === 'text' && typeof c.text === 'string').map((c) => c.text).join('\n');
+    if (text) return text;
+  }
+  return result === undefined || result === null ? '' : JSON.stringify(result);
+}
+
+export class CodexSession extends EventEmitter implements AgentSession {
+  readonly backend = 'codex' as const;
+  private readonly log;
+  private readonly rpc: CodexAppServer;
+  private threadId: string | null = null;
+  private model = 'codex';
+  private ready: Promise<void> | null = null;
+  private activeTurn: ActiveTurn | null = null;
+  private turnText = '';
+  private turnStartedAt = 0;
+  private status: StatusLineData | null = null;
+  private permanentFailure: string | null = null;
+  private pendingApprovals = new Map<string, (d: ApprovalDecision) => void>();
+  // ponytail: one approval prompt at a time — the approval executor holds a
+  // single pendingApproval slot. Parallel tool calls queue here; widen the
+  // executor before removing this.
+  private approvalQueue: Promise<unknown> = Promise.resolve();
+  private pendingQuestion: {
+    id: string;
+    questions: Array<{ id: string; header: string }>;
+    resolve: (answers: Record<string, { answers: string[] }>) => void;
+  } | null = null;
+  private effort: string | null = null;
+  /** Set by an allow-all (✅) decision: no more prompts this session. */
+  private sessionApproved = false;
+  private killRequested = false;
+  /** Bumped on interrupt / turn end: prompts queued for an older epoch resolve as declined unseen. */
+  private turnEpoch = 0;
+
+  constructor(private readonly options: ClaudeCliOptions) {
+    super();
+    this.log = options.logSessionId
+      ? createLogger('codex').forSession(options.logSessionId)
+      : createLogger('codex');
+    this.rpc = new CodexAppServer(this.log);
+    this.rpc.onNotification = (m, p) => this.handleNotification(m, p);
+    this.rpc.onServerRequest = (m, p) => this.handleServerRequest(m, p);
+    this.rpc.onExit = (code) => {
+      this.activeTurn = null;
+      this.closeOpenPrompts('process exit');
+      // A kill we asked for is a clean exit. Claude exits 0 on SIGINT; the
+      // app-server dies by SIGTERM (code null), and lifecycle counts every
+      // non-zero exit of a resumed session as a resume failure — three bot
+      // restarts would silently drop the session.
+      this.emit('exit', this.killRequested ? 0 : code);
+    };
+    this.rpc.onError = (err) => {
+      this.log.error(`codex error: ${err}`);
+      this.emit('error', err);
+    };
+  }
+
+  // ---- AgentSession -------------------------------------------------------
+
+  start(): void {
+    this.rpc.spawn(this.options.workingDir);
+    this.log.debug(`codex app-server spawned: pid=${this.rpc.pid}`);
+    this.ready = this.openThread().catch((err) => {
+      // A failed thread/start or thread/resume is fatal for this process:
+      // surface it like a CLI that exited non-zero so lifecycle's resume
+      // accounting (resumeFailCount) keeps working.
+      this.log.error(`codex thread open failed: ${err}`);
+      this.emitEvent({ type: 'system', subtype: 'error', error: String(err) });
+      this.rpc.kill();
+      throw err;
+    });
+  }
+
+  sendMessage(content: string): void {
+    if (!this.ready) throw new Error('Not started');
+    void this.ready.then(async () => {
+      if (!this.threadId) return;
+      await this.rpc.request('turn/start', {
+        threadId: this.threadId,
+        input: [
+          { type: 'text', text: content, text_elements: [] },
+          ...extractImagePaths(content).map((path) => ({ type: 'localImage', path })),
+        ],
+        model: this.model,
+        effort: this.effort,
+      });
+    }).catch((err) => {
+      // The chat is in "processing" from the moment the user posted; a
+      // rejected turn/start must close that state like a failed turn.
+      this.log.error(`turn/start failed: ${err}`);
+      const message = err instanceof Error ? err.message : String(err);
+      this.emitEvent({ type: 'system', subtype: 'error', error: message });
+      this.emitEvent({ type: 'result', subtype: 'error_turn_start', is_error: true, result: message, duration_ms: 0, num_turns: 0, session_id: this.threadId });
+    });
+  }
+
+  interrupt(): boolean {
+    const turn = this.activeTurn;
+    if (!turn) return false;
+    // Nothing waits for a decision on an aborted turn: close open prompts now
+    // (their posts resolve as denied via approval_timeout) instead of after
+    // the permission timeout.
+    this.closeOpenPrompts('interrupt');
+    void this.rpc.request('turn/interrupt', turn).catch((err) => this.log.debug(`turn/interrupt failed: ${err}`));
+    return true;
+  }
+
+  async kill(): Promise<void> {
+    if (!this.rpc.isRunning()) return;
+    this.killRequested = true;
+    await new Promise<void>((resolve) => {
+      const prev = this.rpc.onExit;
+      this.rpc.onExit = (code) => { prev(code); resolve(); };
+      this.rpc.kill();
+      setTimeout(resolve, 5000).unref();
+    });
+  }
+
+  isRunning(): boolean { return this.rpc.isRunning(); }
+  isPermanentFailure(): boolean { return this.permanentFailure !== null; }
+  getPermanentFailureReason(): string | null { return this.permanentFailure; }
+  getStatusData(): StatusLineData | null { return this.status; }
+  getLastStderr(): string { return this.rpc.getLastStderr(); }
+
+  /** Feed the user's decision for an `approval_request` event back to Codex. */
+  respondToApproval(requestId: string, approved: boolean, allowAll = false): void {
+    const resolve = this.pendingApprovals.get(requestId);
+    if (!resolve) return;
+    this.pendingApprovals.delete(requestId);
+    if (approved && allowAll) this.sessionApproved = true;
+    resolve(!approved ? 'decline' : allowAll ? 'acceptForSession' : 'accept');
+  }
+
+  /** Feed the user's answers (keyed by question header) back to Codex. */
+  respondToQuestion(answers: Array<{ header: string; answer: string }>, toolUseId?: string): void {
+    const pending = this.pendingQuestion;
+    if (!pending) return;
+    if (toolUseId && toolUseId !== pending.id) {
+      this.log.debug(`ignoring answers for ${toolUseId}: pending question set is ${pending.id}`);
+      return;
+    }
+    this.pendingQuestion = null;
+    const byId: Record<string, { answers: string[] }> = {};
+    for (const a of answers) {
+      const q = pending.questions.find((x) => x.header === a.header);
+      if (q) byId[q.id] = { answers: [a.answer] };
+    }
+    pending.resolve(byId);
+  }
+
+  // ---- Codex → Claude-shaped events ---------------------------------------
+
+  private async openThread(): Promise<void> {
+    await this.rpc.request('initialize', {
+      clientInfo: { name: 'claude-threads', title: 'claude-threads', version: '0' },
+      capabilities: null,
+    }, 30000);
+    this.rpc.notify('initialized');
+
+    const mode = this.options.permissionMode ?? 'default';
+    const common = {
+      cwd: this.options.workingDir,
+      ...POLICY[mode],
+      developerInstructions: [this.options.appendSystemPrompt, CODEX_DEVELOPER_NOTES].filter(Boolean).join('\n\n'),
+      config: this.threadConfig(),
+    };
+    const resume = this.options.resume && this.options.sessionId;
+    const r = resume
+      ? await this.rpc.request<{ thread: Json; model: string }>('thread/resume', {
+          threadId: this.options.sessionId, ...common, excludeTurns: true,
+        }, 30000)
+      : await this.rpc.request<{ thread: Json; model: string }>('thread/start', common, 30000);
+    this.threadId = String(r.thread.id);
+    this.model = r.model;
+    this.log.info(`codex thread ${resume ? 'resumed' : 'started'}: ${this.threadId} (${this.model})`);
+    this.emitEvent({ type: 'system', subtype: 'init', model: this.model, session_id: this.threadId, slash_commands: [] });
+  }
+
+  /**
+   * Per-thread config overrides. The bot's own MCP server rides along so
+   * Codex gets send_file / read_post / react_to_post / agent actions — the
+   * same tools Claude has. Its permission_prompt tool stays unused: Codex
+   * approvals are server requests handled in-process (see askUser).
+   */
+  private threadConfig(): Record<string, unknown> | null {
+    const o = this.options;
+    if (!o.platformConfig) return null;
+    const def = buildMcpServerDefinition({
+      mcpServerPath: resolveMcpServerPath(),
+      platformConfig: o.platformConfig,
+      threadId: o.threadId,
+      permissionTimeoutMs: o.permissionTimeoutMs ?? 120000,
+      debug: Boolean(process.env.DEBUG),
+      workingDir: o.workingDir,
+      uploadDir: o.uploadDir,
+      outboundFiles: o.outboundFiles,
+      sessionOwnerUsername: o.sessionOwnerUsername,
+      decisionBridgePath: o.decisionBridgePath,
+      agentFeatures: o.agentFeatures,
+    });
+    return { mcp_servers: { [MCP_SERVER_NAME]: def } };
+  }
+
+  private emitEvent(event: ClaudeEvent): void { this.emit('event', event); }
+
+  private assistant(block: Json): void {
+    this.emitEvent({ type: 'assistant', session_id: this.threadId, message: { role: 'assistant', content: [block] } });
+  }
+
+  private toolResult(toolUseId: string, content: string, isError: boolean): void {
+    this.emitEvent({
+      type: 'user', session_id: this.threadId,
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content, is_error: isError }] },
+    });
+  }
+
+  private handleNotification(method: string, p: Json): void {
+    switch (method) {
+      case 'turn/started': {
+        const turn = p.turn as Json;
+        this.activeTurn = { threadId: String(p.threadId), turnId: String(turn.id) };
+        this.turnText = '';
+        this.turnStartedAt = Date.now();
+        return;
+      }
+      case 'item/started':
+        return this.handleItem(p.item as Json, false);
+      case 'item/completed':
+        return this.handleItem(p.item as Json, true);
+      case 'turn/completed': {
+        const turn = p.turn as Json;
+        const error = turn.error as { message?: string } | null;
+        this.activeTurn = null;
+        this.closeOpenPrompts('turn completed');
+        this.emitEvent({
+          type: 'result',
+          subtype: turn.status === 'completed' ? 'success' : `error_${turn.status}`,
+          is_error: turn.status === 'failed',
+          result: error?.message ?? this.turnText,
+          duration_ms: Date.now() - this.turnStartedAt,
+          num_turns: 1,
+          session_id: this.threadId,
+        });
+        return;
+      }
+      case 'thread/tokenUsage/updated': {
+        const usage = p.tokenUsage as { total: Json; last: Json; modelContextWindow: number | null };
+        const total = usage.total as Record<string, number>;
+        const last = usage.last as Record<string, number>;
+        this.status = {
+          context_window_size: usage.modelContextWindow ?? 0,
+          total_input_tokens: total.inputTokens,
+          total_output_tokens: total.outputTokens,
+          current_usage: {
+            input_tokens: last.inputTokens,
+            output_tokens: last.outputTokens,
+            cache_creation_input_tokens: last.cacheWriteInputTokens,
+            cache_read_input_tokens: last.cachedInputTokens,
+          },
+          model: { id: this.model, display_name: this.model },
+          cost: null,
+          timestamp: Date.now(),
+        };
+        this.emit('status', this.status);
+        return;
+      }
+      case 'error': {
+        const err = p.error as { message?: string; codexErrorInfo?: unknown } | undefined;
+        const message = err?.message ?? 'unknown codex error';
+        const info = typeof err?.codexErrorInfo === 'string' ? err.codexErrorInfo : JSON.stringify(err?.codexErrorInfo ?? null);
+        this.log.error(`codex error (willRetry=${String(p.willRetry)}, ${info}): ${message}`);
+        // Auth problems need a human (`codex login`): flag them permanent so
+        // lifecycle stops retrying resumes, and say so in the chat.
+        if (/unauthori|log ?in|sign in|refresh token|access token|auth/i.test(message)) this.permanentFailure = message;
+        if (!p.willRetry) {
+          // A failed turn otherwise ends silently in the chat (result events
+          // carry no visible text): surface the reason as agent text.
+          this.assistant({ type: 'text', text: `❌ Codex: ${message}` });
+        }
+        // "You've hit your usage limit ... try again at Sep 6th, 2026 12:28 AM."
+        // (codex 0.153.4, ChatGPT plan). Same cooldown path as Claude's detector.
+        if (err?.codexErrorInfo === 'usageLimitExceeded' || /usage limit/i.test(message)) {
+          const resetAt = parseCodexResetAt(message);
+          this.emit('rate-limit', { detected: true, matched: message, ...(resetAt ? { resetAtEpochMs: resetAt } : {}) });
+        }
+        if (!p.willRetry) this.emitEvent({ type: 'system', subtype: 'error', error: message });
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private handleItem(item: Json, completed: boolean): void {
+    const id = String(item.id);
+    switch (item.type) {
+      case 'agentMessage':
+        // Claude emits whole messages, not deltas — mirror that on completion.
+        if (completed && typeof item.text === 'string' && item.text) {
+          this.turnText += item.text;
+          this.assistant({ type: 'text', text: item.text });
+        }
+        return;
+      case 'reasoning':
+        if (completed) {
+          const summary = (item.summary as string[] | undefined)?.join('\n');
+          if (summary) this.assistant({ type: 'thinking', thinking: summary });
+        }
+        return;
+      case 'commandExecution':
+        if (!completed) {
+          this.assistant({ type: 'tool_use', id, name: 'Bash', input: { command: item.command, description: undefined } });
+        } else if (item.status !== 'declined') {
+          this.toolResult(id, String(item.aggregatedOutput ?? ''), item.exitCode !== 0 && item.exitCode !== null);
+        } else {
+          this.toolResult(id, 'Command declined by user', true);
+        }
+        return;
+      case 'fileChange': {
+        const changes = (item.changes as Array<{ path: string; kind: unknown; diff: string }>) ?? [];
+        if (!completed) {
+          for (const c of changes) {
+            this.assistant({ type: 'tool_use', id: `${id}:${c.path}`, name: 'Edit', input: { file_path: c.path, old_string: '', new_string: c.diff } });
+          }
+        } else {
+          for (const c of changes) this.toolResult(`${id}:${c.path}`, String(item.status), item.status === 'failed' || item.status === 'declined');
+        }
+        return;
+      }
+      case 'mcpToolCall':
+        if (!completed) {
+          this.assistant({ type: 'tool_use', id, name: `mcp__${item.server}__${item.tool}`, input: item.arguments ?? {} });
+        } else {
+          const err = item.error as { message?: string } | null;
+          this.toolResult(id, err?.message ?? mcpResultText(item.result), Boolean(err));
+        }
+        return;
+      case 'webSearch':
+        if (!completed) this.assistant({ type: 'server_tool_use', id, name: 'web_search', input: { query: item.query } });
+        return;
+      case 'imageGeneration': {
+        // Codex saves generated images under $CODEX_HOME/generated_images.
+        // Surface the call like a tool and hand the file to the bot for
+        // upload (events handler: 'agent_file') — no send_file round trip.
+        if (!completed) {
+          this.assistant({ type: 'tool_use', id, name: 'ImageGeneration', input: { prompt: item.revisedPrompt ?? '' } });
+          return;
+        }
+        const failure = item.failure as { message?: string } | null;
+        const savedPath = typeof item.savedPath === 'string' ? item.savedPath : null;
+        this.toolResult(id, failure?.message ?? (savedPath ? `saved ${savedPath}` : String(item.status)), Boolean(failure));
+        if (savedPath && !failure) {
+          this.emitEvent({ type: 'agent_file', path: savedPath, session_id: this.threadId });
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  // ---- Approvals (server → client requests) -------------------------------
+
+  private async handleServerRequest(method: string, p: Json): Promise<unknown> {
+    switch (method) {
+      case 'item/commandExecution/requestApproval': {
+        const decision = await this.askUser('Bash', `\`${String(p.command ?? '')}\`` + (p.reason ? `\n${String(p.reason)}` : ''));
+        return { decision };
+      }
+      case 'item/fileChange/requestApproval': {
+        const decision = await this.askUser('Edit', `File changes${p.reason ? `: ${String(p.reason)}` : ''}${p.grantRoot ? ` under ${String(p.grantRoot)}` : ''}`);
+        return { decision };
+      }
+      case 'item/permissions/requestApproval': {
+        const perms = p.permissions as { network?: unknown; fileSystem?: unknown } | undefined;
+        const wants = [perms?.network && 'network access', perms?.fileSystem && 'extra file-system access'].filter(Boolean).join(', ');
+        const decision = await this.askUser('Permissions', `${wants || 'additional permissions'}${p.reason ? `: ${String(p.reason)}` : ''}`);
+        return decision === 'decline'
+          ? { permissions: {}, scope: 'turn' }
+          : { permissions: perms ?? {}, scope: decision === 'acceptForSession' ? 'session' : 'turn' };
+      }
+      case 'item/tool/requestUserInput':
+        return this.askQuestions(p);
+      case 'mcpServer/elicitation/request':
+        return this.handleElicitation(p);
+      default:
+        this.log.warn(`unhandled codex server request ${method} → decline`);
+        return { decision: 'decline' };
+    }
+  }
+
+  /**
+   * Codex asks for MCP tool calls via an elicitation form with
+   * `_meta.codex_approval_kind === 'mcp_tool_call'` (verified 0.153.4). The
+   * bot's own MCP server is trusted without a prompt — same as the Claude
+   * path, where our tools bypass permission_prompt (send_dm prompts itself).
+   * Other servers' tools go through the normal approval UI. Real elicitation
+   * forms/URL logins have no chat UI yet → decline.
+   */
+  private async handleElicitation(p: Json): Promise<unknown> {
+    const meta = p._meta as {
+      codex_approval_kind?: string;
+      tool_params_display?: Array<{ display_name: string; value: unknown }>;
+    } | null;
+    if (p.mode !== 'form' || meta?.codex_approval_kind !== 'mcp_tool_call') {
+      this.log.warn(`elicitation (${String(p.mode)}) from ${String(p.serverName)} has no chat UI → decline`);
+      return { action: 'decline', content: null, _meta: null };
+    }
+    const tool = /run tool "([^"]+)"/.exec(String(p.message ?? ''))?.[1] ?? 'tool';
+    let decision: ApprovalDecision = 'accept';
+    if (p.serverName !== MCP_SERVER_NAME) {
+      const params = (meta.tool_params_display ?? []).map((x) => `${x.display_name}: ${String(x.value)}`).join(', ');
+      decision = await this.askUser(`MCP ${String(p.serverName)}/${tool}`, params || String(p.message));
+    }
+    if (decision === 'decline') return { action: 'decline', content: null, _meta: null };
+    return { action: 'accept', content: {}, _meta: decision === 'acceptForSession' ? { persist: 'session' } : null };
+  }
+
+  private askUser(toolName: string, content: string): Promise<ApprovalDecision> {
+    if (this.sessionApproved || (this.options.permissionMode ?? 'default') === 'bypass') {
+      return Promise.resolve('accept');
+    }
+    const epoch = this.turnEpoch;
+    const run = () => new Promise<ApprovalDecision>((resolve) => {
+      if (epoch !== this.turnEpoch) { resolve('decline'); return; } // turn was interrupted meanwhile
+      const requestId = randomUUID();
+      const timeoutMs = this.options.permissionTimeoutMs ?? 120000;
+      const timer = setTimeout(() => {
+        if (!this.pendingApprovals.delete(requestId)) return;
+        this.log.info(`approval ${requestId} timed out after ${timeoutMs}ms → decline`);
+        this.emitEvent({ type: 'approval_timeout', request_id: requestId, session_id: this.threadId });
+        resolve('decline');
+      }, timeoutMs);
+      this.pendingApprovals.set(requestId, (d) => { clearTimeout(timer); resolve(d); });
+      this.emitEvent({ type: 'approval_request', request_id: requestId, tool_name: toolName, content, session_id: this.threadId });
+    });
+    const next = this.approvalQueue.then(run, run);
+    this.approvalQueue = next;
+    return next;
+  }
+
+  // ---- Native !commands ---------------------------------------------------
+
+  async runSlashCommand(command: string, args?: string): Promise<string | null> {
+    switch (command) {
+      case 'compact':
+        if (!this.threadId) return 'Not started yet.';
+        await this.rpc.request('thread/compact/start', { threadId: this.threadId });
+        return 'Compacting conversation context…';
+      case 'model':
+        if (args) { this.model = args; return `Model set to \`${args}\` for the next turns.`; }
+        return `Current model: \`${this.model}\``;
+      case 'effort':
+        if (args) { this.effort = args; return `Reasoning effort set to \`${args}\` for the next turns.`; }
+        return `Current reasoning effort: \`${this.effort ?? 'default'}\``;
+      case 'context':
+      case 'cost': {
+        const s = this.status;
+        if (!s) return 'No usage data yet.';
+        const pct = s.context_window_size ? Math.round(100 * (s.current_usage?.input_tokens ?? 0) / s.context_window_size) : 0;
+        return `Context: ${s.current_usage?.input_tokens ?? 0}/${s.context_window_size} tokens (${pct}%) · total in ${s.total_input_tokens}, out ${s.total_output_tokens} · model ${s.model?.id}`;
+      }
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Codex questions ride the AskUserQuestion UI: a synthetic tool_use renders
+   * the numbered options, lifecycle's 'question:complete' feeds
+   * respondToQuestion. One set at a time (the executor has one slot).
+   */
+  private askQuestions(p: Json): Promise<{ answers: Record<string, { answers: string[] }> }> {
+    const raw = (p.questions as Array<{ id: string; header: string; question: string; options: Array<{ label: string; description: string }> | null }>) ?? [];
+    if (this.pendingQuestion) this.closeOpenPrompts('question replaced');
+    return new Promise((resolve) => {
+      const timeoutMs = (p.autoResolutionMs as number | null) ?? this.options.permissionTimeoutMs ?? 120000;
+      const setId = `q-${randomUUID()}`;
+      const pending = {
+        id: setId,
+        questions: raw.map((q) => ({ id: q.id, header: q.header })),
+        resolve: (answers: Record<string, { answers: string[] }>) => { clearTimeout(timer); resolve({ answers }); },
+      };
+      const timer = setTimeout(() => {
+        if (this.pendingQuestion !== pending) return;
+        this.pendingQuestion = null;
+        this.log.info('question set timed out → empty answers');
+        this.emitEvent({ type: 'question_timeout', request_id: setId, session_id: this.threadId });
+        resolve({ answers: {} });
+      }, timeoutMs);
+      this.pendingQuestion = pending;
+      this.assistant({
+        type: 'tool_use', id: setId, name: 'AskUserQuestion',
+        input: {
+          questions: raw.map((q) => ({
+            header: q.header, question: q.question, multiSelect: false,
+            options: q.options?.length ? q.options : [{ label: 'OK', description: 'Continue' }],
+          })),
+        },
+      });
+    });
+  }
+
+  /**
+   * Single exit for every open prompt (approvals and the question set):
+   * decline / empty-answer them, tell the bot to close their posts, and
+   * invalidate queued prompts of the current turn. Used by interrupt, turn
+   * end, question replacement and process exit alike.
+   */
+  private closeOpenPrompts(reason: string): void {
+    this.turnEpoch++;
+    const open = this.pendingApprovals.size + (this.pendingQuestion ? 1 : 0);
+    for (const [requestId, resolve] of this.pendingApprovals) {
+      this.emitEvent({ type: 'approval_timeout', request_id: requestId, session_id: this.threadId });
+      resolve('decline');
+    }
+    this.pendingApprovals.clear();
+    const question = this.pendingQuestion;
+    if (question) {
+      this.pendingQuestion = null;
+      this.emitEvent({ type: 'question_timeout', request_id: question.id, session_id: this.threadId });
+      question.resolve({});
+    }
+    if (open) this.log.debug(`${open} open prompt(s) closed: ${reason}`);
+  }
+}

--- a/src/agents/codex/session.ts
+++ b/src/agents/codex/session.ts
@@ -92,6 +92,10 @@ export class CodexSession extends EventEmitter implements AgentSession {
   private turnText = '';
   private turnStartedAt = 0;
   private status: StatusLineData | null = null;
+  /** Cumulative counters from thread/tokenUsage/updated, normalised to Claude's split (input excludes cached). */
+  private totals: { input: number; cachedInput: number; cacheWrite: number; output: number } | null = null;
+  /** Sends run one after another: two messages before turn/started must not both issue turn/start. */
+  private sendChain: Promise<void> = Promise.resolve();
   private permanentFailure: string | null = null;
   private pendingApprovals = new Map<string, (d: ApprovalDecision) => void>();
   // ponytail: one approval prompt at a time — the approval executor holds a
@@ -154,7 +158,8 @@ export class CodexSession extends EventEmitter implements AgentSession {
 
   sendMessage(content: string): void {
     if (!this.ready) throw new Error('Not started');
-    void this.ready.then(async () => {
+    const ready = this.ready;
+    this.sendChain = this.sendChain.then(() => ready).then(async () => {
       if (!this.threadId) return;
       const input = [
         { type: 'text', text: content, text_elements: [] },
@@ -174,7 +179,10 @@ export class CodexSession extends EventEmitter implements AgentSession {
           this.log.debug(`turn/steer failed after the turn ended (${err}); starting a new turn`);
         }
       }
-      await this.rpc.request('turn/start', { threadId: this.threadId, input, model: this.model, effort: this.effort });
+      const r = await this.rpc.request<{ turn?: { id?: string } }>('turn/start', { threadId: this.threadId, input, model: this.model, effort: this.effort });
+      // The response acknowledges the turn before turn/started arrives; the
+      // next queued message must already see it as active (→ steer).
+      if (!this.activeTurn && r?.turn?.id) this.activeTurn = { threadId: this.threadId, turnId: String(r.turn.id) };
     }).catch((err) => {
       // The chat is in "processing" from the moment the user posted; a
       // rejected turn/start must close that state like a failed turn.
@@ -334,15 +342,15 @@ export class CodexSession extends EventEmitter implements AgentSession {
           session_id: this.threadId,
           // Same shape the Claude CLI puts on its result: this is what fills
           // the session header (model, context %). Codex reports no cost.
-          ...(this.status ? {
+          ...(this.status && this.totals ? {
             total_cost_usd: 0,
             usage: this.status.current_usage,
             modelUsage: {
               [this.model]: {
-                inputTokens: this.status.total_input_tokens,
-                outputTokens: this.status.total_output_tokens,
-                cacheReadInputTokens: this.status.current_usage?.cache_read_input_tokens ?? 0,
-                cacheCreationInputTokens: this.status.current_usage?.cache_creation_input_tokens ?? 0,
+                inputTokens: this.totals.input,
+                outputTokens: this.totals.output,
+                cacheReadInputTokens: this.totals.cachedInput,
+                cacheCreationInputTokens: this.totals.cacheWrite,
                 contextWindow: this.status.context_window_size,
                 costUSD: 0,
               },
@@ -352,18 +360,26 @@ export class CodexSession extends EventEmitter implements AgentSession {
         return;
       }
       case 'thread/tokenUsage/updated': {
+        // Codex counts cached tokens inside inputTokens; Claude's consumers add
+        // input + cache_read themselves, so split them here. Fields may be
+        // absent on older servers — never let undefined reach the arithmetic.
         const usage = p.tokenUsage as { total: Json; last: Json; modelContextWindow: number | null };
-        const total = usage.total as Record<string, number>;
-        const last = usage.last as Record<string, number>;
+        const norm = (u: Record<string, number | undefined>) => {
+          const cached = u.cachedInputTokens ?? 0;
+          return { input: Math.max(0, (u.inputTokens ?? 0) - cached), cachedInput: cached, cacheWrite: u.cacheWriteInputTokens ?? 0, output: u.outputTokens ?? 0 };
+        };
+        const total = norm(usage.total as Record<string, number | undefined>);
+        const last = norm(usage.last as Record<string, number | undefined>);
+        this.totals = total;
         this.status = {
           context_window_size: usage.modelContextWindow ?? 0,
-          total_input_tokens: total.inputTokens,
-          total_output_tokens: total.outputTokens,
+          total_input_tokens: total.input,
+          total_output_tokens: total.output,
           current_usage: {
-            input_tokens: last.inputTokens,
-            output_tokens: last.outputTokens,
-            cache_creation_input_tokens: last.cacheWriteInputTokens,
-            cache_read_input_tokens: last.cachedInputTokens,
+            input_tokens: last.input,
+            output_tokens: last.output,
+            cache_creation_input_tokens: last.cacheWrite,
+            cache_read_input_tokens: last.cachedInput,
           },
           model: { id: this.model, display_name: this.model },
           cost: null,
@@ -565,8 +581,9 @@ export class CodexSession extends EventEmitter implements AgentSession {
       case 'cost': {
         const s = this.status;
         if (!s) return 'No usage data yet.';
-        const pct = s.context_window_size ? Math.round(100 * (s.current_usage?.input_tokens ?? 0) / s.context_window_size) : 0;
-        return `Context: ${s.current_usage?.input_tokens ?? 0}/${s.context_window_size} tokens (${pct}%) · total in ${s.total_input_tokens}, out ${s.total_output_tokens} · model ${s.model?.id}`;
+        const inContext = (s.current_usage?.input_tokens ?? 0) + (s.current_usage?.cache_read_input_tokens ?? 0);
+        const pct = s.context_window_size ? Math.round(100 * inContext / s.context_window_size) : 0;
+        return `Context: ${inContext}/${s.context_window_size} tokens (${pct}%) · total in ${s.total_input_tokens}, out ${s.total_output_tokens} · model ${s.model?.id}`;
       }
       default:
         return null;

--- a/src/agents/codex/session.ts
+++ b/src/agents/codex/session.ts
@@ -96,6 +96,9 @@ export class CodexSession extends EventEmitter implements AgentSession {
   private totals: { input: number; cachedInput: number; cacheWrite: number; output: number } | null = null;
   /** Sends run one after another: two messages before turn/started must not both issue turn/start. */
   private sendChain: Promise<void> = Promise.resolve();
+  private queuedSends = 0;
+  /** Bumped by interrupt(): sends queued before it are dropped, a turn/start still in flight is interrupted on arrival. */
+  private sendEpoch = 0;
   private permanentFailure: string | null = null;
   private pendingApprovals = new Map<string, (d: ApprovalDecision) => void>();
   // ponytail: one approval prompt at a time — the approval executor holds a
@@ -159,8 +162,11 @@ export class CodexSession extends EventEmitter implements AgentSession {
   sendMessage(content: string): void {
     if (!this.ready) throw new Error('Not started');
     const ready = this.ready;
+    const epoch = this.sendEpoch;
+    this.queuedSends++;
     this.sendChain = this.sendChain.then(() => ready).then(async () => {
       if (!this.threadId) return;
+      if (epoch !== this.sendEpoch) { this.log.debug('queued message dropped: interrupted before dispatch'); return; }
       const input = [
         { type: 'text', text: content, text_elements: [] },
         ...extractImagePaths(content).map((path) => ({ type: 'localImage', path })),
@@ -183,7 +189,10 @@ export class CodexSession extends EventEmitter implements AgentSession {
       // The response acknowledges the turn before turn/started arrives; the
       // next queued message must already see it as active (→ steer).
       if (!this.activeTurn && r?.turn?.id) this.activeTurn = { threadId: this.threadId, turnId: String(r.turn.id) };
-    }).catch((err) => {
+      // An interrupt that arrived while the ack was pending had no turn id to
+      // target; it applies to this turn now that there is one.
+      if (epoch !== this.sendEpoch && this.activeTurn) this.interrupt();
+    }).finally(() => { this.queuedSends--; }).catch((err) => {
       // The chat is in "processing" from the moment the user posted; a
       // rejected turn/start must close that state like a failed turn.
       this.log.error(`turn/start failed: ${err}`);
@@ -196,7 +205,14 @@ export class CodexSession extends EventEmitter implements AgentSession {
 
   interrupt(): boolean {
     const turn = this.activeTurn;
-    if (!turn) return false;
+    // Queued messages (steers, or the first message while the thread is still
+    // opening) belong to the work being interrupted: drop them.
+    this.sendEpoch++;
+    if (!turn) {
+      if (this.queuedSends === 0) return false;
+      this.closeOpenPrompts('interrupt');
+      return true;
+    }
     // Nothing waits for a decision on an aborted turn: close open prompts now
     // (their posts resolve as denied via approval_timeout) instead of after
     // the permission timeout.
@@ -373,7 +389,10 @@ export class CodexSession extends EventEmitter implements AgentSession {
         this.totals = total;
         this.status = {
           context_window_size: usage.modelContextWindow ?? 0,
-          total_input_tokens: total.input,
+          // The status-line consumer reads total_input_tokens as "tokens in the
+          // current context", so this is the last request's input incl. cache,
+          // not the thread's cumulative input (that lives in `totals`).
+          total_input_tokens: last.input + last.cachedInput,
           total_output_tokens: total.output,
           current_usage: {
             input_tokens: last.input,
@@ -583,7 +602,7 @@ export class CodexSession extends EventEmitter implements AgentSession {
         if (!s) return 'No usage data yet.';
         const inContext = (s.current_usage?.input_tokens ?? 0) + (s.current_usage?.cache_read_input_tokens ?? 0);
         const pct = s.context_window_size ? Math.round(100 * inContext / s.context_window_size) : 0;
-        return `Context: ${inContext}/${s.context_window_size} tokens (${pct}%) · total in ${s.total_input_tokens}, out ${s.total_output_tokens} · model ${s.model?.id}`;
+        return `Context: ${inContext}/${s.context_window_size} tokens (${pct}%) · total in ${this.totals?.input ?? 0} (+${this.totals?.cachedInput ?? 0} cached), out ${s.total_output_tokens} · model ${s.model?.id}`;
       }
       default:
         return null;

--- a/src/agents/codex/session.ts
+++ b/src/agents/codex/session.ts
@@ -156,15 +156,25 @@ export class CodexSession extends EventEmitter implements AgentSession {
     if (!this.ready) throw new Error('Not started');
     void this.ready.then(async () => {
       if (!this.threadId) return;
-      await this.rpc.request('turn/start', {
-        threadId: this.threadId,
-        input: [
-          { type: 'text', text: content, text_elements: [] },
-          ...extractImagePaths(content).map((path) => ({ type: 'localImage', path })),
-        ],
-        model: this.model,
-        effort: this.effort,
-      });
+      const input = [
+        { type: 'text', text: content, text_elements: [] },
+        ...extractImagePaths(content).map((path) => ({ type: 'localImage', path })),
+      ];
+      // A message while a turn runs steers that turn (what Claude does with a
+      // mid-turn stdin line); turn/start would be rejected as "already
+      // running" and its error result would end the chat's processing state
+      // while the first turn is still going.
+      const turn = this.activeTurn;
+      if (turn) {
+        try {
+          await this.rpc.request('turn/steer', { threadId: this.threadId, input, expectedTurnId: turn.turnId });
+          return;
+        } catch (err) {
+          if (this.activeTurn) throw err;
+          this.log.debug(`turn/steer failed after the turn ended (${err}); starting a new turn`);
+        }
+      }
+      await this.rpc.request('turn/start', { threadId: this.threadId, input, model: this.model, effort: this.effort });
     }).catch((err) => {
       // The chat is in "processing" from the moment the user posted; a
       // rejected turn/start must close that state like a failed turn.
@@ -570,7 +580,8 @@ export class CodexSession extends EventEmitter implements AgentSession {
    */
   private askQuestions(p: Json): Promise<{ answers: Record<string, { answers: string[] }> }> {
     const raw = (p.questions as Array<{ id: string; header: string; question: string; options: Array<{ label: string; description: string }> | null }>) ?? [];
-    if (this.pendingQuestion) this.closeOpenPrompts('question replaced');
+    // Only the superseded question set closes; approvals of this turn stay open.
+    this.closePendingQuestion();
     return new Promise((resolve) => {
       const timeoutMs = (p.autoResolutionMs as number | null) ?? this.options.permissionTimeoutMs ?? 120000;
       const setId = `q-${randomUUID()}`;
@@ -613,12 +624,15 @@ export class CodexSession extends EventEmitter implements AgentSession {
       resolve('decline');
     }
     this.pendingApprovals.clear();
-    const question = this.pendingQuestion;
-    if (question) {
-      this.pendingQuestion = null;
-      this.emitEvent({ type: 'question_timeout', request_id: question.id, session_id: this.threadId });
-      question.resolve({});
-    }
+    this.closePendingQuestion();
     if (open) this.log.debug(`${open} open prompt(s) closed: ${reason}`);
+  }
+
+  private closePendingQuestion(): void {
+    const question = this.pendingQuestion;
+    if (!question) return;
+    this.pendingQuestion = null;
+    this.emitEvent({ type: 'question_timeout', request_id: question.id, session_id: this.threadId });
+    question.resolve({});
   }
 }

--- a/src/agents/codex/version-check.ts
+++ b/src/agents/codex/version-check.ts
@@ -1,5 +1,13 @@
-import { execFileSync } from 'child_process';
+import { crossSpawnSync } from '../../utils/spawn.js';
 import { CODEX_PROTOCOL_VERSION } from './app-server.js';
+
+/** Run the CLI; returns stdout on exit 0, throws otherwise (covers .cmd wrappers on Windows). */
+function run(bin: string, args: string[]): string {
+  const r = crossSpawnSync(bin, args, { encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe'] });
+  if (r.error) throw r.error;
+  if (r.status !== 0) throw new Error(`exit ${r.status}: ${String(r.stderr).trim()}`);
+  return String(r.stdout);
+}
 
 export interface CodexValidationResult {
   installed: boolean;
@@ -17,13 +25,13 @@ export interface CodexValidationResult {
 export function validateCodexCli(bin = process.env.CODEX_BIN ?? 'codex'): CodexValidationResult {
   let version: string;
   try {
-    version = execFileSync(bin, ['--version'], { encoding: 'utf8', timeout: 10000 }).trim().replace(/^codex-cli\s+/, '');
+    version = run(bin, ['--version']).trim().replace(/^codex-cli\s+/, '');
   } catch (err) {
     return { installed: false, version: null, loggedIn: false, message: `Codex CLI not found (${bin}): ${String(err).split('\n')[0]}` };
   }
   let loggedIn = false;
   try {
-    execFileSync(bin, ['login', 'status'], { encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe'] });
+    run(bin, ['login', 'status']);
     loggedIn = true;
   } catch { /* non-zero exit = not logged in */ }
   const drift = version !== CODEX_PROTOCOL_VERSION ? ` (protocol bindings pinned to ${CODEX_PROTOCOL_VERSION})` : '';

--- a/src/agents/codex/version-check.ts
+++ b/src/agents/codex/version-check.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from 'child_process';
+import { CODEX_PROTOCOL_VERSION } from './app-server.js';
+
+export interface CodexValidationResult {
+  installed: boolean;
+  version: string | null;
+  loggedIn: boolean;
+  message: string;
+}
+
+/**
+ * Startup check for the Codex backend: CLI present, version reported, login
+ * state. The app-server protocol is experimental upstream, so a version
+ * other than the pinned one only warns — the bindings were generated from
+ * CODEX_PROTOCOL_VERSION and may drift.
+ */
+export function validateCodexCli(bin = process.env.CODEX_BIN ?? 'codex'): CodexValidationResult {
+  let version: string;
+  try {
+    version = execFileSync(bin, ['--version'], { encoding: 'utf8', timeout: 10000 }).trim().replace(/^codex-cli\s+/, '');
+  } catch (err) {
+    return { installed: false, version: null, loggedIn: false, message: `Codex CLI not found (${bin}): ${String(err).split('\n')[0]}` };
+  }
+  let loggedIn = false;
+  try {
+    execFileSync(bin, ['login', 'status'], { encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'pipe'] });
+    loggedIn = true;
+  } catch { /* non-zero exit = not logged in */ }
+  const drift = version !== CODEX_PROTOCOL_VERSION ? ` (protocol bindings pinned to ${CODEX_PROTOCOL_VERSION})` : '';
+  return {
+    installed: true, version, loggedIn,
+    message: loggedIn ? `Codex CLI ${version}${drift}` : `Codex CLI ${version} is not logged in — run \`codex login\`${drift}`,
+  };
+}

--- a/src/agents/factory.test.ts
+++ b/src/agents/factory.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { createAgentSession } from './factory.js';
+import { ClaudeCli } from '../claude/cli.js';
+
+const opts = { workingDir: '/test', memory: null, agentFeatures: null };
+
+describe('createAgentSession', () => {
+  test('claude returns a ClaudeCli tagged with its backend', () => {
+    const agent = createAgentSession('claude', opts);
+    expect(agent).toBeInstanceOf(ClaudeCli);
+    expect(agent.backend).toBe('claude');
+    expect(agent.isRunning()).toBe(false);
+  });
+
+  test('codex returns a CodexSession that is not running until started', () => {
+    const agent = createAgentSession('codex', opts);
+    expect(agent.backend).toBe('codex');
+    expect(agent.isRunning()).toBe(false);
+    expect(agent.interrupt()).toBe(false);
+  });
+});

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,0 +1,16 @@
+import { ClaudeCli, type ClaudeCliOptions } from '../claude/cli.js';
+import type { AgentBackend, AgentSession } from './types.js';
+import { CodexSession } from './codex/session.js';
+
+/**
+ * Einzige Stelle, die ein Backend instanziiert. Alle Spawn-Pfade
+ * (Start, Resume, !cd/!permissions-Neustart, Worktrees) laufen hierdurch.
+ */
+export function createAgentSession(backend: AgentBackend, options: ClaudeCliOptions): AgentSession {
+  switch (backend) {
+    case 'claude':
+      return new ClaudeCli(options);
+    case 'codex':
+      return new CodexSession(options);
+  }
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,0 +1,2 @@
+export type { AgentBackend, AgentEvent, AgentSession } from './types.js';
+export { createAgentSession } from './factory.js';

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Backend-neutrale Sitzungsschnittstelle. ClaudeCli implementiert sie heute,
+ * der Codex-App-Server-Adapter folgt (Umbaufolge Punkt 4).
+ *
+ * Die Event-Form bleibt vorerst Claudes stream-json (`ClaudeEvent`): der
+ * Transformer und der Events-Handler verstehen sie bereits. Ein Codex-Adapter
+ * uebersetzt seine Notifications in diese Form, statt beide Konsumenten
+ * umzubauen.
+ */
+import type { ClaudeEvent, StatusLineData } from '../claude/cli.js';
+import type { RateLimitHit } from '../claude/rate-limit-detector.js';
+
+export type AgentBackend = 'claude' | 'codex';
+
+/** Normalisiertes Ereignis. Vorerst identisch mit Claudes stream-json. */
+export type AgentEvent = ClaudeEvent;
+
+export interface AgentSession {
+  readonly backend: AgentBackend;
+
+  start(): void;
+  sendMessage(content: string): void;
+  /** Laufenden Turn abbrechen. true, wenn ein Signal gesendet wurde. */
+  interrupt(): boolean;
+  kill(): Promise<void>;
+
+  isRunning(): boolean;
+  isPermanentFailure(): boolean;
+  getPermanentFailureReason(): string | null;
+  getStatusData(): StatusLineData | null;
+  /** Letzte stderr-Ausgabe des Prozesses, fuer Diagnose in Tests und Fehlermeldungen. */
+  getLastStderr(): string;
+
+  /**
+   * Answer an `approval_request` event (Codex-only: approvals are in-process
+   * server requests, not MCP prompts). Claude has no such path.
+   */
+  respondToApproval?(requestId: string, approved: boolean, allowAll?: boolean): void;
+
+  /** Answer the backend's pending question set (Codex `item/tool/requestUserInput`). */
+  respondToQuestion?(answers: Array<{ header: string; answer: string }>, toolUseId?: string): void;
+
+  /**
+   * Run a `!command` natively (compact, model, effort, context, cost …).
+   * Returns the user-visible reply, or null when the backend has no native
+   * implementation — the caller then falls back to the Claude slash passthrough.
+   */
+  runSlashCommand?(command: string, args?: string): Promise<string | null>;
+
+  on(event: 'event', listener: (e: AgentEvent) => void): this;
+  on(event: 'exit', listener: (code: number) => void): this;
+  on(event: 'rate-limit', listener: (hit: RateLimitHit) => void): this;
+  on(event: 'error', listener: (err: Error) => void): this;
+  on(event: 'status', listener: (data: StatusLineData) => void): this;
+}

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -1,3 +1,4 @@
+import type { AgentSession } from '../agents/types.js';
 import { ChildProcess } from 'child_process';
 import { crossSpawn } from '../utils/spawn.js';
 import { EventEmitter } from 'events';
@@ -370,53 +371,26 @@ export function materializeMcpConfig(
  * was written to disk (i.e. not inline-mode) and must be cleaned up by the
  * caller on process exit.
  */
-export function buildPermissionArgs(opts: {
-  permissionMode: PermissionMode;
+export const MCP_SERVER_NAME = 'claude-threads-mcp';
+
+/**
+ * The bot's own MCP server (permission prompts, send_file, read_post,
+ * agent actions …) as a stdio server definition. Shared by the Claude CLI
+ * (`--mcp-config`) and the Codex app-server (`mcp_servers` thread config).
+ */
+export function buildMcpServerDefinition(opts: {
   mcpServerPath: string;
-  platformConfig: PlatformMcpConfig | undefined;
+  platformConfig: PlatformMcpConfig;
   threadId: string | undefined;
-  sessionId: string | undefined;
   permissionTimeoutMs: number;
   debug: boolean;
-  /** Session working directory; passed to MCP child as SESSION_WORKING_DIR. */
   workingDir?: string;
-  /** Per-session upload directory; passed to MCP child as SESSION_UPLOAD_DIR. */
   uploadDir?: string;
-  /** Outbound file (`send_file`) settings. Both fields are optional. */
   outboundFiles?: { enabled?: boolean; maxBytes?: number };
-  /** Username of the session starter; surfaced to the MCP child as
-   *  SESSION_OWNER_USERNAME for `send_dm` attribution. */
   sessionOwnerUsername?: string;
-  /** Decision-bridge socket path; surfaced as DECISION_BRIDGE_PATH. */
   decisionBridgePath?: string;
-  /** Agent-feature tool gates for the MCP child; see ClaudeCliOptions. */
   agentFeatures?: ClaudeCliOptions['agentFeatures'];
-  inline?: boolean; // for tests
-}): { args: string[]; tempFile: string | null } {
-  const args: string[] = [];
-
-  // bypass-mode: tools run without user approval. We still spawn the MCP
-  // server (no --permission-prompt-tool, so the permission_prompt tool
-  // dangles harmlessly) so that send_file remains available — this is the
-  // mode operators most often use for build-anything-on-demand setups,
-  // exactly the workflow where send_file is most useful. Pre-#360 the
-  // server wasn't spawned at all; the change is intentional and additive.
-  //
-  // platformConfig is required even in bypass-mode now, because send_file
-  // talks to the platform REST API. If a deployment really has no platform
-  // (extremely unusual; only the dry-run / shell-driven test fixtures),
-  // pass platformConfig: undefined and accept that send_file won't work.
-  if (opts.permissionMode === 'bypass' && !opts.platformConfig) {
-    args.push('--dangerously-skip-permissions');
-    return { args, tempFile: null };
-  }
-
-  if (!opts.platformConfig) {
-    throw new Error(
-      `platformConfig is required when permissionMode is '${opts.permissionMode}'`,
-    );
-  }
-
+}): { command: string; args: string[]; env: Record<string, string> } {
   const mcpEnv: Record<string, string> = {
     PLATFORM_TYPE: opts.platformConfig.type,
     PLATFORM_URL: opts.platformConfig.url,
@@ -475,17 +449,64 @@ export function buildPermissionArgs(opts: {
     mcpEnv[OUTBOUND_ENV.OUTBOUND_FILES_MAX_BYTES] = String(opts.outboundFiles.maxBytes);
   }
 
-  const mcpConfig: McpConfigBlob = {
-    mcpServers: {
-      'claude-threads-mcp': {
-        type: 'stdio',
-        command: runtimeForScriptPath(opts.mcpServerPath),
-        args: [opts.mcpServerPath],
-        env: mcpEnv,
-      },
-    },
+  return {
+    command: runtimeForScriptPath(opts.mcpServerPath),
+    args: [opts.mcpServerPath],
+    env: mcpEnv,
   };
+}
 
+export function buildPermissionArgs(opts: {
+  permissionMode: PermissionMode;
+  mcpServerPath: string;
+  platformConfig: PlatformMcpConfig | undefined;
+  threadId: string | undefined;
+  sessionId: string | undefined;
+  permissionTimeoutMs: number;
+  debug: boolean;
+  /** Session working directory; passed to MCP child as SESSION_WORKING_DIR. */
+  workingDir?: string;
+  /** Per-session upload directory; passed to MCP child as SESSION_UPLOAD_DIR. */
+  uploadDir?: string;
+  /** Outbound file (`send_file`) settings. Both fields are optional. */
+  outboundFiles?: { enabled?: boolean; maxBytes?: number };
+  /** Username of the session starter; surfaced to the MCP child as
+   *  SESSION_OWNER_USERNAME for `send_dm` attribution. */
+  sessionOwnerUsername?: string;
+  /** Decision-bridge socket path; surfaced as DECISION_BRIDGE_PATH. */
+  decisionBridgePath?: string;
+  /** Agent-feature tool gates for the MCP child; see ClaudeCliOptions. */
+  agentFeatures?: ClaudeCliOptions['agentFeatures'];
+  inline?: boolean; // for tests
+}): { args: string[]; tempFile: string | null } {
+  const args: string[] = [];
+
+  // bypass-mode: tools run without user approval. We still spawn the MCP
+  // server (no --permission-prompt-tool, so the permission_prompt tool
+  // dangles harmlessly) so that send_file remains available — this is the
+  // mode operators most often use for build-anything-on-demand setups,
+  // exactly the workflow where send_file is most useful. Pre-#360 the
+  // server wasn't spawned at all; the change is intentional and additive.
+  //
+  // platformConfig is required even in bypass-mode now, because send_file
+  // talks to the platform REST API. If a deployment really has no platform
+  // (extremely unusual; only the dry-run / shell-driven test fixtures),
+  // pass platformConfig: undefined and accept that send_file won't work.
+  if (opts.permissionMode === 'bypass' && !opts.platformConfig) {
+    args.push('--dangerously-skip-permissions');
+    return { args, tempFile: null };
+  }
+
+  if (!opts.platformConfig) {
+    throw new Error(
+      `platformConfig is required when permissionMode is '${opts.permissionMode}'`,
+    );
+  }
+
+  const definition = buildMcpServerDefinition({ ...opts, platformConfig: opts.platformConfig });
+  const mcpConfig: McpConfigBlob = {
+    mcpServers: { [MCP_SERVER_NAME]: { type: 'stdio', ...definition } },
+  };
   const materialized = materializeMcpConfig(mcpConfig, opts.sessionId, { inline: opts.inline });
   let tempFile: string | null = null;
   if (materialized.mode === 'file') {
@@ -525,7 +546,36 @@ const STDERR_AGGREGATE_SOFT_CAP = 10 * 1024 * 1024; // 10MB
 // Module-private — safe to share: every ClaudeCli runs in the same process.
 let totalStderrBytes = 0;
 
-export class ClaudeCli extends EventEmitter {
+/** Locate the bundled (dist) or source-layout MCP server script. */
+export function resolveMcpServerPath(): string {
+  {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    // When bundled with bun build, __dirname is dist/ (not dist/claude/)
+    // Try the bundled path first, then fall back to source layout
+    const bundledPath = resolve(__dirname, 'mcp', 'mcp-server.js');
+    if (existsSync(bundledPath)) {
+      return bundledPath;
+    }
+    const sourceLayoutPath = resolve(__dirname, '..', 'mcp', 'mcp-server.js');
+    if (existsSync(sourceLayoutPath)) {
+      return sourceLayoutPath;
+    }
+    // Source/dev mode (`bun run dev`, tests): no build output exists — only
+    // the TypeScript source. Point at the .ts; buildPermissionArgs runs it
+    // under the current runtime (bun) instead of node. Without this the MCP
+    // config referenced a nonexistent .js and the permission server could
+    // never spawn in dev mode.
+    const tsPath = resolve(__dirname, '..', 'mcp', 'mcp-server.ts');
+    if (existsSync(tsPath)) {
+      return tsPath;
+    }
+    return sourceLayoutPath;
+  }
+}
+
+export class ClaudeCli extends EventEmitter implements AgentSession {
+  readonly backend = 'claude' as const;
   private process: ChildProcess | null = null;
   private options: ClaudeCliOptions;
   private buffer = '';
@@ -1107,28 +1157,7 @@ export class ClaudeCli extends EventEmitter {
   }
 
   private getMcpServerPath(): string {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-    // When bundled with bun build, __dirname is dist/ (not dist/claude/)
-    // Try the bundled path first, then fall back to source layout
-    const bundledPath = resolve(__dirname, 'mcp', 'mcp-server.js');
-    if (existsSync(bundledPath)) {
-      return bundledPath;
-    }
-    const sourceLayoutPath = resolve(__dirname, '..', 'mcp', 'mcp-server.js');
-    if (existsSync(sourceLayoutPath)) {
-      return sourceLayoutPath;
-    }
-    // Source/dev mode (`bun run dev`, tests): no build output exists — only
-    // the TypeScript source. Point at the .ts; buildPermissionArgs runs it
-    // under the current runtime (bun) instead of node. Without this the MCP
-    // config referenced a nonexistent .js and the permission server could
-    // never spawn in dev mode.
-    const tsPath = resolve(__dirname, '..', 'mcp', 'mcp-server.ts');
-    if (existsSync(tsPath)) {
-      return tsPath;
-    }
-    return sourceLayoutPath;
+    return resolveMcpServerPath();
   }
 
   private getStatusLineWriterPath(): string {

--- a/src/claude/quick-query.ts
+++ b/src/claude/quick-query.ts
@@ -11,6 +11,9 @@
  * Defaults to haiku for speed/cost efficiency.
  */
 
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readFileSync, unlinkSync } from 'fs';
 import { crossSpawn } from '../utils/spawn.js';
 import { getClaudePath } from './version-check.js';
 import { createLogger } from '../utils/logger.js';
@@ -57,7 +60,18 @@ export interface QuickQueryResult {
  *   console.log(result.response);
  * }
  */
+/**
+ * Which CLI answers one-shot helper queries (titles, branch names, routine
+ * parses …). Set once at startup from `config.agentBackend`: a codex-only bot
+ * must never spawn the Claude CLI, not even for a haiku one-shot.
+ */
+let quickQueryBackend: 'claude' | 'codex' = 'claude';
+export function setQuickQueryBackend(backend: 'claude' | 'codex'): void {
+  quickQueryBackend = backend;
+}
+
 export async function quickQuery(options: QuickQueryOptions): Promise<QuickQueryResult> {
+  if (quickQueryBackend === 'codex') return codexQuickQuery(options);
   const {
     prompt,
     model = 'haiku',
@@ -170,5 +184,52 @@ export async function quickQuery(options: QuickQueryOptions): Promise<QuickQuery
       log.debug(`quickQuery: stdin write failed (${(err as NodeJS.ErrnoException).code ?? err.message})`);
     });
     proc.stdin?.end(prompt);
+  });
+}
+
+/**
+ * Codex flavour of quickQuery: `codex exec --ephemeral` with the prompt on
+ * stdin, the final message read from `-o <file>`. Model names are Codex's,
+ * so the Claude `model` option is ignored (the user's default model applies).
+ */
+async function codexQuickQuery(options: QuickQueryOptions): Promise<QuickQueryResult> {
+  const { prompt, workingDir, systemPrompt } = options;
+  // codex exec needs ~6-7 s even for a one-word answer (measured 0.153.4);
+  // callers tuned for haiku (5-15 s) would time out under load.
+  const timeout = Math.max(options.timeout ?? 5000, 20000);
+  const startTime = Date.now();
+  const outFile = join(tmpdir(), `claude-threads-codex-qq-${process.pid}-${Date.now()}.txt`);
+  const args = ['exec', '--ephemeral', '--skip-git-repo-check', '-s', 'read-only', '-o', outFile, '--color', 'never'];
+  const input = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
+  log.debug(`Quick query (codex): timeout=${timeout}ms, prompt="${prompt.substring(0, 50)}..."`);
+  return new Promise<QuickQueryResult>((resolve) => {
+    let stderr = '';
+    let resolved = false;
+    const finish = (r: QuickQueryResult) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timeoutId);
+      try { unlinkSync(outFile); } catch { /* best-effort */ }
+      resolve(r);
+    };
+    const proc = crossSpawn(process.env.CODEX_BIN ?? 'codex', args, {
+      cwd: workingDir || process.cwd(),
+      env: process.env,
+      stdio: ['pipe', 'ignore', 'pipe'],
+    });
+    const timeoutId = setTimeout(() => {
+      proc.kill('SIGTERM');
+      finish({ success: false, error: 'timeout', durationMs: Date.now() - startTime });
+    }, timeout);
+    proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    proc.on('error', (err) => finish({ success: false, error: err.message, durationMs: Date.now() - startTime }));
+    proc.on('exit', (code) => {
+      let response = '';
+      try { response = readFileSync(outFile, 'utf8').trim(); } catch { /* no output file */ }
+      const durationMs = Date.now() - startTime;
+      if (code === 0 && response) finish({ success: true, response, durationMs });
+      else finish({ success: false, error: `exit ${code}: ${stderr.trim().slice(-500)}`, durationMs });
+    });
+    proc.stdin?.end(input);
   });
 }

--- a/src/claude/quick-query.ts
+++ b/src/claude/quick-query.ts
@@ -12,6 +12,7 @@
  */
 
 import { join } from 'path';
+import { randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 import { readFileSync, unlinkSync } from 'fs';
 import { crossSpawn } from '../utils/spawn.js';
@@ -198,7 +199,7 @@ async function codexQuickQuery(options: QuickQueryOptions): Promise<QuickQueryRe
   // callers tuned for haiku (5-15 s) would time out under load.
   const timeout = Math.max(options.timeout ?? 5000, 20000);
   const startTime = Date.now();
-  const outFile = join(tmpdir(), `claude-threads-codex-qq-${process.pid}-${Date.now()}.txt`);
+  const outFile = join(tmpdir(), `claude-threads-codex-qq-${randomUUID()}.txt`); // title+tags run concurrently
   const args = ['exec', '--ephemeral', '--skip-git-repo-check', '-s', 'read-only', '-o', outFile, '--color', 'never'];
   const input = systemPrompt ? `${systemPrompt}\n\n${prompt}` : prompt;
   log.debug(`Quick query (codex): timeout=${timeout}ms, prompt="${prompt.substring(0, 50)}..."`);
@@ -229,6 +230,9 @@ async function codexQuickQuery(options: QuickQueryOptions): Promise<QuickQueryRe
       const durationMs = Date.now() - startTime;
       if (code === 0 && response) finish({ success: true, response, durationMs });
       else finish({ success: false, error: `exit ${code}: ${stderr.trim().slice(-500)}`, durationMs });
+    });
+    proc.stdin?.on('error', (err) => {
+      log.debug(`quickQuery (codex): stdin write failed (${(err as NodeJS.ErrnoException).code ?? err.message})`);
     });
     proc.stdin?.end(input);
   });

--- a/src/commands/executor.ts
+++ b/src/commands/executor.ts
@@ -570,6 +570,10 @@ function createPassthroughHandler(slashCommand: string): CommandHandler {
       return { handled: false }; // Passthrough commands don't work in first message
     }
     if (ctx.isAllowed) {
+      // A non-Claude backend may implement the command natively.
+      if (await ctx.sessionManager.runBackendCommand(ctx.threadId, slashCommand, args)) {
+        return { handled: true };
+      }
       const full = args ? `/${slashCommand} ${args}` : `/${slashCommand}`;
       // Authorization was already verified upstream (ctx.isAllowed). Mark this
       // as a system follow-up so the sink's identity gate (#388) does not

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -2,6 +2,7 @@
  * Configuration type definitions for claude-threads
  */
 
+import type { AgentBackend } from '../agents/types.js';
 import type { AutoUpdateConfig, AutoRestartMode, ScheduledWindow } from '../auto-update/types.js';
 import type { TranscriptionConfig } from '../transcription/types.js';
 import type { DirectChannelModeConfig, ApprovalsMode } from '../platform/utils.js';
@@ -391,6 +392,12 @@ export interface Config {
   stickyMessage?: StickyMessageCustomization; // Optional sticky message customization
   /** Optional Claude account pool. When omitted, bot runs in single-account mode. */
   claudeAccounts?: ClaudeAccount[];
+  /**
+   * Agent backend for every NEW session of this bot. `claude` (default) spawns
+   * the Claude CLI; `codex` the Codex app-server. Existing sessions keep the
+   * backend they were started with (persisted per session).
+   */
+  agentBackend?: AgentBackend;
   /**
    * Optional speech-to-text for inbound audio attachments (voice notes).
    * One provider per daemon, applied to every platform. Omitted = audio is

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,10 @@ import { VERSION } from './version.js';
 import { keepAlive } from './utils/keep-alive.js';
 import { startReactMeasureCleanup } from './utils/perf-cleanup.js';
 import { dim, red, yellow } from './utils/colors.js';
-import { validateClaudeCli } from './claude/version-check.js';
+import { validateClaudeCli, type ClaudeValidationResult } from './claude/version-check.js';
+import { setQuickQueryBackend } from './claude/quick-query.js';
+import { validateCodexCli } from './agents/codex/version-check.js';
+import { CODEX_PROTOCOL_VERSION } from './agents/codex/app-server.js';
 import { startUI, type UIProvider } from './ui/index.js';
 import { setLogHandler } from './utils/logger.js';
 import { handleMessage } from './message-handler.js';
@@ -386,8 +389,11 @@ async function startWithoutDaemon() {
       ?? firstPlatformConfig.skipPermissions,
   });
 
-  // Check Claude CLI version
-  const claudeValidation = validateClaudeCli();
+  // Check Claude CLI version — only when Claude is the backend. A codex-only
+  // bot must never touch the Claude CLI (handoff Punkt 8).
+  const claudeValidation = (config.agentBackend ?? 'claude') === 'claude'
+    ? validateClaudeCli()
+    : { installed: false, version: null, compatible: true, status: 'ok', message: 'Claude CLI not required (codex backend)' } satisfies ClaudeValidationResult;
 
   // Fail on incompatible version unless --skip-version-check is set.
   // Incompatible = below the hard floor or a new major; an untested newer
@@ -399,6 +405,32 @@ async function startWithoutDaemon() {
     console.error(dim(`  Use --skip-version-check to bypass this check (not recommended)`));
     console.error('');
     process.exit(1);
+  }
+  // Backend config is YAML-typed only: fail loudly on anything but the two
+  // known values, and keep a Codex-only bot Codex-only — an account pool
+  // would start Claude usage probes regardless of the session backend.
+  if (config.agentBackend !== undefined && config.agentBackend !== 'claude' && config.agentBackend !== 'codex') {
+    console.error(red(`  ❌ Invalid agentBackend: "${String(config.agentBackend)}". Must be "claude" or "codex".`));
+    console.error('');
+    process.exit(1);
+  }
+  if (config.agentBackend === 'codex' && config.claudeAccounts?.length) {
+    console.error(red('  ❌ claudeAccounts is Claude-only. Remove it for agentBackend: codex (or drop the codex backend).'));
+    console.error('');
+    process.exit(1);
+  }
+  if ((config.agentBackend ?? 'claude') === 'codex') {
+    setQuickQueryBackend('codex');
+    const codex = validateCodexCli();
+    if (!codex.installed || !codex.loggedIn) {
+      console.error(red(`  ❌ ${codex.message}`));
+      console.error('');
+      process.exit(1);
+    }
+    if (codex.version !== CODEX_PROTOCOL_VERSION) {
+      console.error(yellow(`  ⚠️  ${codex.message}`));
+      console.error('');
+    }
   }
   if (claudeValidation.status === 'untested') {
     console.error(yellow(`  ⚠️  ${claudeValidation.message}`));
@@ -633,7 +665,8 @@ async function startWithoutDaemon() {
     config.limits,  // Resource limits (optional, has sensible defaults)
     config.claudeAccounts,  // Claude account pool (undefined = single-account mode)
     config.respondOnlyWhenMentioned,  // Quiet-mode default for new sessions (#402)
-    config.userAttribution  // Per-message [@username]: attribution (default on; only applied once a thread has >1 participant)
+    config.userAttribution,  // Per-message [@username]: attribution (default on; only applied once a thread has >1 participant)
+    config.agentBackend ?? 'claude'  // Backend for new sessions
   );
 
   // Set sticky message customization from config

--- a/src/message-handler.test.ts
+++ b/src/message-handler.test.ts
@@ -85,6 +85,7 @@ function createMockSessionManager() {
     hasPendingWorktreePrompt: mock(() => false),
     handleWorktreeBranchResponse: mock(async () => false),
     sendFollowUp: mock(async () => {}),
+    runBackendCommand: mock(async () => false),
     evaluateWatches: mock(() => {}),
     resumePausedSession: mock(async () => {}),
     cancelPausedSession: mock(() => {}),

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -16,7 +16,7 @@ import {
 } from '../../config/index.js';
 import type { PermissionMode } from '../../config/index.js';
 import { handleRateLimit } from '../../session/lifecycle.js';
-import { ClaudeCli } from '../../claude/cli.js';
+import { createAgentSession } from '../../agents/index.js';
 import { buildRestartCliOptions } from '../../claude/restart-options.js';
 import { randomUUID } from 'crypto';
 import { resolve } from 'path';
@@ -144,7 +144,7 @@ export async function restartClaudeSession(
   }
 
   // Create new Claude CLI
-  const newClaude = new ClaudeCli(cliOptions);
+  const newClaude = createAgentSession(session.agentBackend ?? 'claude', cliOptions);
   session.claude = newClaude;
 
   // Rebind event handlers (use sessionId which is the composite key).

--- a/src/operations/events/handler.ts
+++ b/src/operations/events/handler.ts
@@ -194,7 +194,9 @@ export function handleEventPreProcessing(
       // moment this one expires, and its prompt is skipped while a pending
       // approval is still set. The post itself is closed asynchronously.
       session.messageManager.clearPendingApproval();
-      void updatePost(session, pending.postId, `❌ ${session.platform.getFormatter().formatBold('Action denied')} - the request expired`);
+      // An empty postId is a slot reserved while the post is still being
+      // created; the executor closes that post itself once it exists.
+      if (pending.postId) void updatePost(session, pending.postId, `❌ ${session.platform.getFormatter().formatBold('Action denied')} - the request expired`);
     }
   }
 

--- a/src/operations/events/handler.ts
+++ b/src/operations/events/handler.ts
@@ -16,6 +16,9 @@ import { withErrorHandling } from '../../utils/error-handler/index.js';
 import { resetSessionActivity, post, postError, updatePost } from '../post-helpers/index.js';
 import type { SessionContext } from '../session-context/index.js';
 import { createLogger } from '../../utils/logger.js';
+import { realpathSync } from 'fs';
+import { homedir } from 'os';
+import { join, sep } from 'path';
 import { auditDetailForTool, auditLog, isAuditEnabled } from '../../persistence/audit-log.js';
 import { createSessionLog } from '../../utils/session-log.js';
 import { extractPullRequestUrl } from '../../utils/pr-detector.js';
@@ -168,6 +171,16 @@ function isSidechainEvent(event: ClaudeEvent): boolean {
  * Pre-processing for events when using MessageManager.
  * Handles session-specific side effects that should run BEFORE the main event handling.
  */
+function isInsideDir(path: string, dir: string): boolean {
+  try {
+    const real = realpathSync(path);
+    const base = realpathSync(dir);
+    return real === base || real.startsWith(base.endsWith(sep) ? base : base + sep);
+  } catch {
+    return false;
+  }
+}
+
 export function handleEventPreProcessing(
   session: Session,
   event: ClaudeEvent,
@@ -175,6 +188,50 @@ export function handleEventPreProcessing(
 ): void {
   // Log raw event to thread logger (first thing, before any processing)
   session.threadLogger?.logEvent(event);
+
+  // Codex-only: the agent declined an approval after its timeout. Resolve the
+  // still-open prompt post as denied so a later reaction can't show
+  // "approved" for an action Codex never ran. (The request itself is
+  // rendered by the transformer as an 'action' approval op; the decision
+  // flows back via lifecycle's 'approval:complete' → respondToApproval.)
+  if (event.type === 'approval_timeout' && session.messageManager) {
+    const requestId = (event as ClaudeEvent & { request_id?: string }).request_id;
+    const pending = session.messageManager.getPendingApproval();
+    if (requestId && pending?.toolUseId === requestId) {
+      void session.messageManager.handleApprovalResponse(pending.postId, false);
+    }
+  }
+
+  // Codex-only: the agent gave up waiting for answers. Drop the executor's
+  // pending question set so a late click on the stale post is ignored
+  // instead of being reported as an answer.
+  if (event.type === 'question_timeout' && session.messageManager) {
+    const requestId = (event as ClaudeEvent & { request_id?: string }).request_id;
+    const pending = session.messageManager.getPendingQuestionSet();
+    if (requestId && pending?.toolUseId === requestId) {
+      session.messageManager.clearPendingQuestionSet();
+      sessionLog(session).info(`Question set ${requestId} expired; ignoring late answers`);
+    }
+  }
+
+  // Codex-only: a file the agent produced natively (image generation). Upload
+  // it into the thread. Only files under Codex's own output directory are
+  // accepted — this path never goes through the MCP working-dir validator.
+  if (event.type === 'agent_file') {
+    const e = event as ClaudeEvent & { path?: string; caption?: string };
+    const codexOut = join(process.env.CODEX_HOME || join(homedir(), '.codex'), 'generated_images');
+    const upload = (session.platform as { uploadFile?: (p: string, t: string, o?: { caption?: string }) => Promise<unknown> }).uploadFile;
+    if (e.path && upload && isInsideDir(e.path, codexOut)) {
+      const path = e.path;
+      const caption = e.caption?.slice(0, 300);
+      void withErrorHandling(
+        () => upload.call(session.platform, path, session.threadId, caption ? { caption } : undefined),
+        { action: 'Upload agent-generated file', session },
+      );
+    } else {
+      sessionLog(session).warn(`agent_file ignored: ${e.path ?? '(no path)'} is not under ${codexOut}`);
+    }
+  }
 
   // Audit trail (opt-in per platform): record every tool call, including
   // subagent sidechains — an auditor wants the full execution record even
@@ -230,12 +287,22 @@ export function handleEventPreProcessing(
       compact_metadata?: unknown;
       slash_commands?: string[];
       model?: string;
+      session_id?: string;
     };
 
     // Capture the current model from init events (re-emitted per turn, so a
     // /model switch is reflected on the very next turn — see captures).
     if (e.subtype === 'init' && typeof e.model === 'string') {
       session.currentModel = e.model;
+    }
+
+    // The backend owns the resumable id. Claude echoes the id we passed;
+    // Codex mints its own thread id on thread/start — adopt it here, after
+    // the start succeeded, so a later resume targets the real thread.
+    if (e.subtype === 'init' && typeof e.session_id === 'string' && e.session_id !== session.claudeSessionId) {
+      sessionLog(session).info(`Adopting backend session id ${e.session_id}`);
+      session.claudeSessionId = e.session_id;
+      ctx.ops.persistSession(session);
     }
 
     // Capture available slash commands from init event

--- a/src/operations/events/handler.ts
+++ b/src/operations/events/handler.ts
@@ -16,9 +16,9 @@ import { withErrorHandling } from '../../utils/error-handler/index.js';
 import { resetSessionActivity, post, postError, updatePost } from '../post-helpers/index.js';
 import type { SessionContext } from '../session-context/index.js';
 import { createLogger } from '../../utils/logger.js';
-import { realpathSync } from 'fs';
 import { homedir } from 'os';
-import { join, sep } from 'path';
+import { validateOutboundPath } from '../../mcp/path-validator.js';
+import { join } from 'path';
 import { auditDetailForTool, auditLog, isAuditEnabled } from '../../persistence/audit-log.js';
 import { createSessionLog } from '../../utils/session-log.js';
 import { extractPullRequestUrl } from '../../utils/pr-detector.js';
@@ -28,6 +28,8 @@ import { trackEvent } from '../bug-report/index.js';
 import { parseClaudeCommand, removeCommandFromText, isClaudeAllowedCommand } from '../../commands/index.js';
 
 const log = createLogger('events');
+/** Matches the MCP server's default for send_file. */
+const DEFAULT_OUTBOUND_MAX_BYTES = 100 * 1024 * 1024;
 const sessionLog = createSessionLog(log);
 
 // ---------------------------------------------------------------------------
@@ -171,16 +173,6 @@ function isSidechainEvent(event: ClaudeEvent): boolean {
  * Pre-processing for events when using MessageManager.
  * Handles session-specific side effects that should run BEFORE the main event handling.
  */
-function isInsideDir(path: string, dir: string): boolean {
-  try {
-    const real = realpathSync(path);
-    const base = realpathSync(dir);
-    return real === base || real.startsWith(base.endsWith(sep) ? base : base + sep);
-  } catch {
-    return false;
-  }
-}
-
 export function handleEventPreProcessing(
   session: Session,
   event: ClaudeEvent,
@@ -198,7 +190,11 @@ export function handleEventPreProcessing(
     const requestId = (event as ClaudeEvent & { request_id?: string }).request_id;
     const pending = session.messageManager.getPendingApproval();
     if (requestId && pending?.toolUseId === requestId) {
-      void session.messageManager.handleApprovalResponse(pending.postId, false);
+      // Clear synchronously: the adapter releases the next queued request the
+      // moment this one expires, and its prompt is skipped while a pending
+      // approval is still set. The post itself is closed asynchronously.
+      session.messageManager.clearPendingApproval();
+      void updatePost(session, pending.postId, `❌ ${session.platform.getFormatter().formatBold('Action denied')} - the request expired`);
     }
   }
 
@@ -220,16 +216,28 @@ export function handleEventPreProcessing(
   if (event.type === 'agent_file') {
     const e = event as ClaudeEvent & { path?: string; caption?: string };
     const codexOut = join(process.env.CODEX_HOME || join(homedir(), '.codex'), 'generated_images');
-    const upload = (session.platform as { uploadFile?: (p: string, t: string, o?: { caption?: string }) => Promise<unknown> }).uploadFile;
-    if (e.path && upload && isInsideDir(e.path, codexOut)) {
+    const upload = (session.platform as { uploadFile?: (p: string, t: string, o?: { caption?: string; filename?: string }) => Promise<unknown> }).uploadFile;
+    // Same operator controls as send_file: outboundFiles.enabled / maxBytes,
+    // plus the regular-file/size checks of the outbound validator.
+    const outbound = session.platform.getMcpConfig().outboundFiles;
+    if (outbound?.enabled === false) {
+      sessionLog(session).info(`agent_file ignored: outbound file sending is disabled by the operator`);
+    } else if (e.path && upload) {
       const path = e.path;
       const caption = e.caption?.slice(0, 300);
-      void withErrorHandling(
-        () => upload.call(session.platform, path, session.threadId, caption ? { caption } : undefined),
-        { action: 'Upload agent-generated file', session },
-      );
+      void withErrorHandling(async () => {
+        const validated = await validateOutboundPath(path, {
+          allowedRoots: [codexOut],
+          maxBytes: outbound?.maxBytes && outbound.maxBytes > 0 ? outbound.maxBytes : DEFAULT_OUTBOUND_MAX_BYTES,
+        });
+        if (!validated.ok) {
+          sessionLog(session).warn(`agent_file ignored: ${validated.reason}`);
+          return;
+        }
+        await upload.call(session.platform, validated.resolvedPath, session.threadId, { caption, filename: validated.basename });
+      }, { action: 'Upload agent-generated file', session });
     } else {
-      sessionLog(session).warn(`agent_file ignored: ${e.path ?? '(no path)'} is not under ${codexOut}`);
+      sessionLog(session).warn(`agent_file ignored: ${e.path ?? '(no path)'}`);
     }
   }
 
@@ -693,6 +701,12 @@ function updateUsageStats(
       primaryModel = modelId;
       contextWindowSize = usage.contextWindow;
     }
+  }
+
+  // No cost information (Codex): the single reported model is the primary.
+  if (!primaryModel) {
+    const [only] = Object.keys(result.modelUsage);
+    if (only) { primaryModel = only; contextWindowSize = result.modelUsage[only].contextWindow; }
   }
 
   // The current model (from the per-turn init event) beats the cost

--- a/src/operations/executors/question-approval.test.ts
+++ b/src/operations/executors/question-approval.test.ts
@@ -228,6 +228,42 @@ describe('QuestionApprovalExecutor', () => {
       expect(updates[0][1]).toContain('Action denied');
     });
 
+    it('a reaction whose approval expired mid-update does not release a replacement approval', async () => {
+      const first: ApprovalOp = { type: 'approval', sessionId: 'test:session-1', timestamp: Date.now(), toolUseId: 'req-1', approvalType: 'action', content: 'a' };
+      await executor.execute(first, ctx);
+      const postId = executor.getPendingApproval()!.postId;
+      let release!: () => void;
+      ctx.platform.updatePost = (id: string) => new Promise((r) => { release = () => r({ id } as PlatformPost); });
+      const reaction = executor.handleApprovalResponse(postId, true, ctx);
+      // The agent's timeout fires while the post update is in flight, and the
+      // next queued approval takes the slot.
+      executor.clearPendingApproval();
+      ctx.platform.updatePost = async (id: string) => ({ id } as PlatformPost);
+      const second: ApprovalOp = { ...first, toolUseId: 'req-2', content: 'b' };
+      await executor.execute(second, ctx);
+      expect(executor.getPendingApproval()?.toolUseId).toBe('req-2');
+      release();
+      await reaction;
+      expect(executor.getPendingApproval()?.toolUseId).toBe('req-2'); // survived the stale clear
+    });
+
+    it('a question set replaced while its post is being created does not adopt that post', async () => {
+      const op: QuestionOp = {
+        type: 'question', sessionId: 'test:session-1', timestamp: Date.now(), toolUseId: 'q-1', currentIndex: 0,
+        questions: [{ header: 'H', question: 'one?', options: [{ label: 'a', description: '' }], multiSelect: false }],
+      };
+      const updates: string[] = [];
+      const original = ctx.createInteractivePost;
+      ctx.createInteractivePost = async (...args) => {
+        executor.clearPendingQuestionSet(); // expired while the platform call is in flight
+        return original(...args);
+      };
+      ctx.platform.updatePost = async (id: string, message: string) => { updates.push(message); return { id } as PlatformPost; };
+      await executor.execute(op, ctx);
+      expect(executor.getPendingQuestionSet()).toBeNull();
+      expect(updates.some((m) => m.includes('Question expired'))).toBe(true);
+    });
+
     it('handles rejection response', async () => {
       const op: ApprovalOp = {
         type: 'approval',

--- a/src/operations/executors/question-approval.test.ts
+++ b/src/operations/executors/question-approval.test.ts
@@ -221,7 +221,7 @@ describe('QuestionApprovalExecutor', () => {
         executor.clearPendingApproval();
         return original(...args);
       };
-      ctx.platform.updatePost = async (postId: string, message: string) => { updates.push([postId, message]); };
+      ctx.platform.updatePost = async (postId: string, message: string) => { updates.push([postId, message]); return { id: postId } as PlatformPost; };
       await executor.execute(op, ctx);
       expect(executor.hasPendingApproval()).toBe(false); // the expired request was not installed
       expect(updates).toHaveLength(1);

--- a/src/operations/executors/question-approval.test.ts
+++ b/src/operations/executors/question-approval.test.ts
@@ -264,6 +264,13 @@ describe('QuestionApprovalExecutor', () => {
       expect(updates.some((m) => m.includes('Question expired'))).toBe(true);
     });
 
+    it('releases the reserved slot when the approval post cannot be created', async () => {
+      const op: ApprovalOp = { type: 'approval', sessionId: 'test:session-1', timestamp: Date.now(), toolUseId: 'req-1', approvalType: 'plan' };
+      ctx.createInteractivePost = async () => { throw new Error('platform 500'); };
+      await expect(executor.execute(op, ctx)).rejects.toThrow('platform 500');
+      expect(executor.hasPendingApproval()).toBe(false);
+    });
+
     it('handles rejection response', async () => {
       const op: ApprovalOp = {
         type: 'approval',

--- a/src/operations/executors/question-approval.test.ts
+++ b/src/operations/executors/question-approval.test.ts
@@ -211,6 +211,23 @@ describe('QuestionApprovalExecutor', () => {
       expect(approvalCompleted!.toolUseId).toBe('tool-123');
     });
 
+    it('closes the post when the approval was cleared while the post was being created', async () => {
+      const op: ApprovalOp = { type: 'approval', sessionId: 'test:session-1', timestamp: Date.now(), toolUseId: 'req-1', approvalType: 'action', content: 'Bash: ls' };
+      const updates: Array<[string, string]> = [];
+      const original = ctx.createInteractivePost;
+      ctx.createInteractivePost = async (...args) => {
+        // The agent's timeout fires while the platform call is in flight.
+        expect(executor.getPendingApproval()?.toolUseId).toBe('req-1');
+        executor.clearPendingApproval();
+        return original(...args);
+      };
+      ctx.platform.updatePost = async (postId: string, message: string) => { updates.push([postId, message]); };
+      await executor.execute(op, ctx);
+      expect(executor.hasPendingApproval()).toBe(false); // the expired request was not installed
+      expect(updates).toHaveLength(1);
+      expect(updates[0][1]).toContain('Action denied');
+    });
+
     it('handles rejection response', async () => {
       const op: ApprovalOp = {
         type: 'approval',

--- a/src/operations/executors/question-approval.ts
+++ b/src/operations/executors/question-approval.ts
@@ -194,18 +194,26 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
     this.state.pendingApproval = reserved;
 
     // Create interactive post with approval reactions
-    const post = await ctx.createInteractivePost(
-      message,
-      // ✅ only for actions — plans have no session-wide variant
-      op.approvalType === 'plan'
-        ? [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0]]
-        : [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0], ALLOW_ALL_EMOJIS[0]],
-      {
-        type: 'plan_approval',
-        interactionType: 'plan_approval',
-        toolUseId: op.toolUseId,
-      }
-    );
+    let post;
+    try {
+      post = await ctx.createInteractivePost(
+        message,
+        // ✅ only for actions — plans have no session-wide variant
+        op.approvalType === 'plan'
+          ? [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0]]
+          : [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0], ALLOW_ALL_EMOJIS[0]],
+        {
+          type: 'plan_approval',
+          interactionType: 'plan_approval',
+          toolUseId: op.toolUseId,
+        }
+      );
+    } catch (err) {
+      // A reservation without a post can never be answered: release it, unless
+      // a replacement already owns the slot.
+      if (this.state.pendingApproval === reserved) this.state.pendingApproval = null;
+      throw err;
+    }
 
     if (this.state.pendingApproval !== reserved) {
       ctx.logger.info(`${op.approvalType} approval ${formatShortId(op.toolUseId)} expired while its post was being created`);

--- a/src/operations/executors/question-approval.ts
+++ b/src/operations/executors/question-approval.ts
@@ -8,7 +8,7 @@
  * - Processing user responses via reactions
  */
 
-import { NUMBER_EMOJIS, APPROVAL_EMOJIS, DENIAL_EMOJIS, isApprovalEmoji, isDenialEmoji, getNumberEmojiIndex } from '../../utils/emoji.js';
+import { NUMBER_EMOJIS, APPROVAL_EMOJIS, DENIAL_EMOJIS, isApprovalEmoji, isDenialEmoji, getNumberEmojiIndex, isAllowAllEmoji, ALLOW_ALL_EMOJIS } from '../../utils/emoji.js';
 import { auditLog } from '../../persistence/audit-log.js';
 import { formatShortId } from '../../utils/format.js';
 import { completePendingPrompt } from './pending-prompt.js';
@@ -181,14 +181,18 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
       }
       message +=
         `👍 Approve\n` +
-        `👎 Deny\n\n` +
+        `👎 Deny\n` +
+        `✅ Approve for the rest of this session\n\n` +
         ctx.formatter.formatItalic('React to respond');
     }
 
     // Create interactive post with approval reactions
     const post = await ctx.createInteractivePost(
       message,
-      [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0]],
+      // ✅ only for actions — plans have no session-wide variant
+      op.approvalType === 'plan'
+        ? [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0]]
+        : [APPROVAL_EMOJIS[0], DENIAL_EMOJIS[0], ALLOW_ALL_EMOJIS[0]],
       {
         type: 'plan_approval',
         interactionType: 'plan_approval',
@@ -317,7 +321,8 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
   handleApprovalResponse(
     postId: string,
     approved: boolean,
-    ctx: ExecutorContext
+    ctx: ExecutorContext,
+    allowAll = false
   ): Promise<boolean> {
     return completePendingPrompt({
       pending: this.state.pendingApproval,
@@ -326,12 +331,13 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
       label: 'approval',
       statusMessage: ({ type }) => {
         ctx.logger.info(`${type} ${approved ? 'approved' : 'rejected'}`);
+        if (allowAll) return `✅ ${ctx.formatter.formatBold('Action approved for the rest of this session')} - proceeding...`;
         return approved
           ? `✅ ${ctx.formatter.formatBold(type === 'plan' ? 'Plan approved' : 'Action approved')} - proceeding...`
           : `❌ ${ctx.formatter.formatBold(type === 'plan' ? 'Changes requested' : 'Action denied')}`;
       },
       clear: () => { this.state.pendingApproval = null; },
-      emit: ({ toolUseId }) => this.events?.emit('approval:complete', { toolUseId, approved }),
+      emit: ({ toolUseId }) => this.events?.emit('approval:complete', { toolUseId, approved, allowAll }),
     });
   }
 
@@ -420,6 +426,12 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
         const handled = await this.handleApprovalResponse(postId, true, ctx);
         ctx.logger.debug(`QuestionApprovalExecutor: approval outcome=approved, handled=${handled}`);
         return handled;
+      }
+      // ✅ = allow-all: approve and stop prompting for the rest of the session.
+      // Action prompts only (Codex backend); plan approvals keep ignoring it.
+      if (approvalType === 'action' && isAllowAllEmoji(emoji)) {
+        ctx.logger.debug(`Allow-all reaction from @${user}: approved for session`);
+        return this.handleApprovalResponse(postId, true, ctx, true);
       }
       if (isDenialEmoji(emoji)) {
         ctx.logger.debug(`Approval reaction from @${user}: denied`);

--- a/src/operations/executors/question-approval.ts
+++ b/src/operations/executors/question-approval.ts
@@ -186,6 +186,13 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
         ctx.formatter.formatItalic('React to respond');
     }
 
+    // Reserve the slot before the post exists: an approval that expires or is
+    // interrupted while the post is still being created clears this entry,
+    // and the check after the await then closes the fresh post instead of
+    // installing a request nobody can answer any more.
+    const reserved = { postId: '', type: op.approvalType, toolUseId: op.toolUseId };
+    this.state.pendingApproval = reserved;
+
     // Create interactive post with approval reactions
     const post = await ctx.createInteractivePost(
       message,
@@ -200,12 +207,12 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
       }
     );
 
-    // Track pending approval state
-    this.state.pendingApproval = {
-      postId: post.id,
-      type: op.approvalType,
-      toolUseId: op.toolUseId,
-    };
+    if (this.state.pendingApproval !== reserved) {
+      ctx.logger.info(`${op.approvalType} approval ${formatShortId(op.toolUseId)} expired while its post was being created`);
+      await ctx.platform.updatePost(post.id, `❌ ${ctx.formatter.formatBold('Action denied')} - the request expired`);
+      return;
+    }
+    reserved.postId = post.id;
 
     ctx.logger.debug(`Created ${op.approvalType} approval post ${formatShortId(post.id)}`);
   }

--- a/src/operations/executors/question-approval.ts
+++ b/src/operations/executors/question-approval.ts
@@ -221,9 +221,10 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
    * Post the current question in the question set.
    */
   async postCurrentQuestion(ctx: ExecutorContext): Promise<void> {
-    if (!this.state.pendingQuestionSet) return;
+    const set = this.state.pendingQuestionSet;
+    if (!set) return;
 
-    const { currentIndex, questions } = this.state.pendingQuestionSet;
+    const { currentIndex, questions } = set;
     if (currentIndex >= questions.length) return;
 
     const q = questions[currentIndex];
@@ -254,11 +255,22 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
       {
         type: 'question',
         interactionType: 'question',
-        toolUseId: this.state.pendingQuestionSet.toolUseId,
+        toolUseId: set.toolUseId,
       }
     );
 
-    this.state.pendingQuestionSet.currentPostId = post.id;
+    if (this.state.pendingQuestionSet !== set) {
+      // Expired or superseded while the post was being created: never let
+      // this post become the replacement set's current question.
+      ctx.logger.info(`Question set ${formatShortId(set.toolUseId)} expired while its post was being created`);
+      try {
+        await ctx.platform.updatePost(post.id, `❌ ${ctx.formatter.formatBold('Question expired')}`);
+      } catch (err) {
+        ctx.logger.debug(`Failed to close expired question post: ${err}`);
+      }
+      return;
+    }
+    set.currentPostId = post.id;
   }
 
   /**
@@ -270,10 +282,11 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
     optionIndex: number,
     ctx: ExecutorContext
   ): Promise<boolean> {
-    if (!this.state.pendingQuestionSet) return false;
-    if (this.state.pendingQuestionSet.currentPostId !== postId) return false;
+    const set = this.state.pendingQuestionSet;
+    if (!set) return false;
+    if (set.currentPostId !== postId) return false;
 
-    const { currentIndex, questions, toolUseId } = this.state.pendingQuestionSet;
+    const { currentIndex, questions, toolUseId } = set;
     const question = questions[currentIndex];
     if (!question) return false;
 
@@ -294,10 +307,13 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
       ctx.logger.debug(`Failed to update question post: ${err}`);
     }
 
-    // Move to next question or finish
-    this.state.pendingQuestionSet.currentIndex++;
+    // The set may have expired or been replaced during the post update.
+    if (this.state.pendingQuestionSet !== set) return true;
 
-    if (this.state.pendingQuestionSet.currentIndex < questions.length) {
+    // Move to next question or finish
+    set.currentIndex++;
+
+    if (set.currentIndex < questions.length) {
       // Post next question
       await this.postCurrentQuestion(ctx);
     } else {
@@ -331,8 +347,9 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
     ctx: ExecutorContext,
     allowAll = false
   ): Promise<boolean> {
+    const pending = this.state.pendingApproval;
     return completePendingPrompt({
-      pending: this.state.pendingApproval,
+      pending,
       postId,
       ctx,
       label: 'approval',
@@ -343,7 +360,9 @@ export class QuestionApprovalExecutor extends BaseExecutor<QuestionApprovalState
           ? `✅ ${ctx.formatter.formatBold(type === 'plan' ? 'Plan approved' : 'Action approved')} - proceeding...`
           : `❌ ${ctx.formatter.formatBold(type === 'plan' ? 'Changes requested' : 'Action denied')}`;
       },
-      clear: () => { this.state.pendingApproval = null; },
+      // Only release the slot we answered: the request may have expired during
+      // the post update and a replacement may already own the slot.
+      clear: () => { if (this.state.pendingApproval === pending) this.state.pendingApproval = null; },
       emit: ({ toolUseId }) => this.events?.emit('approval:complete', { toolUseId, approved, allowAll }),
     });
   }

--- a/src/operations/message-manager-events.ts
+++ b/src/operations/message-manager-events.ts
@@ -48,6 +48,8 @@ export interface MessageManagerEventMap {
   'approval:complete': {
     toolUseId: string;
     approved: boolean;
+    /** ✅ on an action prompt: approve and auto-approve the rest of the session. */
+    allowAll?: boolean;
   };
 
   /**

--- a/src/operations/session-context/types.ts
+++ b/src/operations/session-context/types.ts
@@ -12,7 +12,8 @@
  */
 
 import type { Session } from '../../session/types.js';
-import type { ClaudeCli, ClaudeEvent } from '../../claude/cli.js';
+import type { ClaudeEvent } from '../../claude/cli.js';
+import type { AgentBackend, AgentSession } from '../../agents/index.js';
 import type { PlatformClient, PlatformFile } from '../../platform/index.js';
 import type { SessionStore } from '../../persistence/session-store.js';
 import type { GitHubEmailsStore } from '../../persistence/github-emails-store.js';
@@ -38,6 +39,8 @@ export interface SessionConfig {
   permissionMode: PermissionMode;
   /** Whether Chrome browser automation is enabled */
   chromeEnabled: boolean;
+  /** Backend for new sessions; undefined = 'claude'. */
+  agentBackend?: AgentBackend;
   /**
    * Config default for the per-session "respond only when @mentioned" toggle
    * (#402). Seeds `Session.respondOnlyWhenMentioned` on new sessions. Default
@@ -195,7 +198,7 @@ export interface SessionOperations {
    * process dying — without it, a stale exit tears down the restarted
    * session.
    */
-  handleExit(sessionId: string, code: number, source?: ClaudeCli): Promise<void>;
+  handleExit(sessionId: string, code: number, source?: AgentSession): Promise<void>;
 
   // ---------------------------------------------------------------------------
   // Session Lifecycle

--- a/src/operations/transformer.ts
+++ b/src/operations/transformer.ts
@@ -100,6 +100,15 @@ export function transformEvent(
     case 'result':
       return transformResult(event, ctx);
 
+    // Codex-only: an in-process approval request (command / file change).
+    // Rendered as an 'action' approval; the decision travels back through the
+    // events handler (src/operations/events/handler.ts) to the agent.
+    case 'approval_request': {
+      const e = event as ClaudeEvent & { request_id?: string; tool_name?: string; content?: string };
+      if (!e.request_id) return [];
+      return [createApprovalOp(ctx.sessionId, e.request_id, 'action', `${e.tool_name ?? 'Tool'}: ${e.content ?? ''}`)];
+    }
+
     default:
       // Unknown event type - no operations
       return [];

--- a/src/operations/worktree/handler.ts
+++ b/src/operations/worktree/handler.ts
@@ -29,7 +29,7 @@ import {
   detectWorktreeInfo,
 } from '../../git/worktree.js';
 import type { ClaudeCliOptions, ClaudeEvent } from '../../claude/cli.js';
-import { ClaudeCli } from '../../claude/cli.js';
+import { createAgentSession, type AgentSession } from '../../agents/index.js';
 import { buildRestartCliOptions } from '../../claude/restart-options.js';
 import { buildAppendSystemPrompt } from '../../commands/system-prompt-generator.js';
 import { postSkippedFilesFeedback, type BuiltMessageContent } from '../streaming/handler.js';
@@ -432,7 +432,7 @@ export async function createAndSwitchToWorktree(
     worktreeMode: WorktreeMode;
     permissionTimeoutMs?: number;
     handleEvent: (sessionId: string, event: ClaudeEvent) => void;
-    handleExit: (sessionId: string, code: number, source?: ClaudeCli) => Promise<void>;
+    handleExit: (sessionId: string, code: number, source?: AgentSession) => Promise<void>;
     updateSessionHeader: (session: Session) => Promise<void>;
     flush: (session: Session) => Promise<void>;
     persistSession: (session: Session) => void;
@@ -583,7 +583,7 @@ export async function createAndSwitchToWorktree(
         // Fresh CLI session (resume: false) — clear accumulated task/tool
         // state so the new session's task ids can't collide with stale ones.
         session.messageManager?.clearClaudeSessionState();
-        const newClaude = new ClaudeCli(cliOptions);
+        const newClaude = createAgentSession(session.agentBackend ?? 'claude', cliOptions);
         session.claude = newClaude;
 
         // Rebind event handlers
@@ -764,7 +764,7 @@ export async function createAndSwitchToWorktree(
       // Fresh CLI session (resume: false) — clear accumulated task/tool
       // state so the new session's task ids can't collide with stale ones.
       session.messageManager?.clearClaudeSessionState();
-      const newClaude = new ClaudeCli(cliOptions);
+      const newClaude = createAgentSession(session.agentBackend ?? 'claude', cliOptions);
       session.claude = newClaude;
 
       // Rebind event handlers (use sessionId which is the composite key)

--- a/src/persistence/session-store.ts
+++ b/src/persistence/session-store.ts
@@ -1,3 +1,4 @@
+import type { AgentBackend } from '../agents/types.js';
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { writeFileAtomic } from './atomic-file.js';
 import { homedir } from 'os';
@@ -88,6 +89,7 @@ export interface PersistedSession {
   platformId: string;            // Which platform instance (e.g., 'default', 'mattermost-main')
   threadId: string;              // Thread ID within that platform
   claudeSessionId: string;       // UUID for --session-id / --resume
+  agentBackend?: AgentBackend;   // 'claude' | 'codex'; absent on pre-backend data → claude
   startedBy: string;             // Username who started the session
   startedByDisplayName?: string; // Display name for UI
   startedAt: string;             // ISO date

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -21,7 +21,7 @@ import { isAuthorizedForSession, sessionAllowedUserSet } from './authorization.j
 import type { PlatformClient, PlatformFile } from '../platform/index.js';
 import type { ClaudeCliOptions, ClaudeEvent, RateLimitHit } from '../claude/cli.js';
 import { DecisionBridgeServer, BridgeUnavailableError } from '../mcp/decision-bridge.js';
-import { ClaudeCli } from '../claude/cli.js';
+import { createAgentSession, type AgentSession } from '../agents/index.js';
 import { cooldownDeadline } from '../claude/rate-limit-detector.js';
 import { isRevivable } from '../persistence/session-store.js';
 import type { PersistedSession } from '../persistence/session-store.js';
@@ -527,7 +527,13 @@ function createMessageManager(
   // Subscribe to events from MessageManager
   // These replace the callback-based approach for cleaner separation of concerns
 
-  messageManager.events.on('question:complete', ({ toolUseId: _toolUseId, answers }) => {
+  messageManager.events.on('question:complete', ({ toolUseId, answers }) => {
+    if (session.claude.backend === 'codex' && session.claude.respondToQuestion) {
+      session.claude.respondToQuestion(answers, toolUseId);
+      sessionLog(session).info('Question answered → codex');
+      ctx.ops.startTyping(session);
+      return;
+    }
     // On modern CLIs AskUserQuestion blocks on the MCP permission prompt; the
     // decision bridge delivers the answers through the permission response's
     // updatedInput, and a stdin send would arrive as a stray extra user
@@ -541,7 +547,16 @@ function createMessageManager(
     session.claude.sendMessage(answerJson);
   });
 
-  messageManager.events.on('approval:complete', ({ toolUseId: _toolUseId, approved }) => {
+  messageManager.events.on('approval:complete', ({ toolUseId, approved, allowAll }) => {
+    // Codex: approvals are in-process server requests keyed by request id
+    // (== the approval op's toolUseId). A late reaction after the agent's
+    // timeout is a no-op there — never echo 'approved' as a user message.
+    if (session.claude.backend === 'codex' && session.claude.respondToApproval) {
+      session.claude.respondToApproval(toolUseId, approved, allowAll);
+      sessionLog(session).info(`Action ${approved ? 'approved' : 'denied'} → codex ${toolUseId}`);
+      ctx.ops.startTyping(session);
+      return;
+    }
     // Same split as questions: on modern CLIs the plan approval resolves the
     // blocked ExitPlanMode permission request via the bridge — the CLI then
     // tells Claude "User has approved your plan" itself.
@@ -1093,9 +1108,9 @@ async function startSessionImpl(
       ctx.ops,
     ),
   };
-  let claude: ClaudeCli;
+  let claude: AgentSession;
   try {
-    claude = new ClaudeCli(cliOptions);
+    claude = createAgentSession(ctx.config.agentBackend ?? 'claude', cliOptions);
   } catch (err) {
     // The bridge has no owner yet — close it here or it leaks its socket dir
     void decisionBridge?.close();
@@ -1110,6 +1125,7 @@ async function startSessionImpl(
     platform,
     claudeSessionId,
     claudeAccountId: claudeAccount?.id,
+    agentBackend: ctx.config.agentBackend ?? 'claude',
     unattended: options.unattended || undefined,
     startedBy: username,
     startedByDisplayName: displayName,
@@ -1496,9 +1512,9 @@ async function resumeSessionImpl(
       ctx.ops,
     ),
   };
-  let claude: ClaudeCli;
+  let claude: AgentSession;
   try {
-    claude = new ClaudeCli(cliOptions);
+    claude = createAgentSession(state.agentBackend ?? 'claude', cliOptions);
   } catch (err) {
     // The bridge has no owner yet — close it here or it leaks its socket dir
     void resumeBridge?.close();
@@ -1513,6 +1529,7 @@ async function resumeSessionImpl(
     platform,
     claudeSessionId: state.claudeSessionId,
     claudeAccountId: claudeAccount?.id,
+    agentBackend: state.agentBackend ?? 'claude',
     unattended: _resumedUnattended(state) || undefined,
     startedBy: state.startedBy,
     startedByDisplayName: state.startedByDisplayName,
@@ -1915,7 +1932,7 @@ export async function handleExit(
   sessionId: string,
   code: number,
   ctx: SessionContext,
-  source?: ClaudeCli
+  source?: AgentSession
 ): Promise<void> {
   const session = mutableSessions(ctx).get(sessionId);
   const shortId = sessionId.substring(0, 8);

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -790,7 +790,7 @@ describe('SessionManager', () => {
         'queuedPrompt', 'queuedByUsername', 'queuedFiles', 'firstPrompt', 'pendingContextPrompt',
         'needsContextPromptOnNextMessage', 'lifecyclePostId', 'isPaused', 'sessionTitle',
         'sessionDescription', 'sessionTags', 'pullRequestUrl', 'messageCount',
-        'resumeFailCount', 'claudeAccountId', 'sessionHeaderMode', 'taskTrackerState',
+        'resumeFailCount', 'claudeAccountId', 'agentBackend', 'sessionHeaderMode', 'taskTrackerState',
         'unattended',
       ]);
       expect(new Set(Object.keys(written))).toEqual(expectedKeys);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -14,7 +14,7 @@
 
 import { EventEmitter } from 'events';
 import { ClaudeEvent } from '../claude/cli.js';
-import type { ClaudeCli } from '../claude/cli.js';
+import type { AgentBackend, AgentSession } from '../agents/index.js';
 import type { PlatformClient, PlatformUser, PlatformPost, PlatformFile } from '../platform/index.js';
 import { SessionStore, PersistedSession, PersistedContextPrompt } from '../persistence/session-store.js';
 import type { PersistedTrackedTask } from '../operations/task-tracker.js';
@@ -103,6 +103,7 @@ export class SessionManager extends EventEmitter {
   private respondOnlyWhenMentioned: boolean;
   /** Config default for per-message `[@username]:` attribution on new sessions. */
   private userAttribution: boolean;
+  private readonly agentBackend: AgentBackend;
   private threadLogsEnabled: boolean;
   private threadLogsRetentionDays: number;
   // Resolved limits configuration
@@ -183,7 +184,8 @@ export class SessionManager extends EventEmitter {
     limits?: LimitsConfig,
     claudeAccounts?: ClaudeAccount[],
     respondOnlyWhenMentioned = false,
-    userAttribution = true
+    userAttribution = true,
+    agentBackend: AgentBackend = 'claude'
   ) {
     super();
     this.workingDir = workingDir;
@@ -195,6 +197,7 @@ export class SessionManager extends EventEmitter {
     this.worktreeMode = worktreeMode;
     this.respondOnlyWhenMentioned = respondOnlyWhenMentioned;
     this.userAttribution = userAttribution;
+    this.agentBackend = agentBackend;
     this.threadLogsEnabled = threadLogsEnabled;
     this.threadLogsRetentionDays = threadLogsRetentionDays;
     this.limits = resolveLimits(limits);
@@ -398,6 +401,7 @@ export class SessionManager extends EventEmitter {
       workingDir: this.workingDir,
       permissionMode: this.permissionMode,
       chromeEnabled: this.chromeEnabled,
+      agentBackend: this.agentBackend,
       respondOnlyWhenMentioned: this.respondOnlyWhenMentioned,
       userAttribution: this.userAttribution,
       debug: this.debug,
@@ -675,7 +679,7 @@ export class SessionManager extends EventEmitter {
   // Exit Handling (delegates to lifecycle module)
   // ---------------------------------------------------------------------------
 
-  private async handleExit(sessionId: string, code: number, source?: ClaudeCli): Promise<void> {
+  private async handleExit(sessionId: string, code: number, source?: AgentSession): Promise<void> {
     await lifecycle.handleExit(sessionId, code, this.getContext(), source);
   }
 
@@ -823,6 +827,7 @@ export class SessionManager extends EventEmitter {
       messageCount: session.messageCount,
       resumeFailCount: session.lifecycle.resumeFailCount,
       claudeAccountId: session.claudeAccountId,
+      agentBackend: session.agentBackend,
       sessionHeaderMode: session.sessionHeaderMode,
       unattended: session.unattended,
     };
@@ -1304,6 +1309,20 @@ export class SessionManager extends EventEmitter {
   // Commands
   async cancelSession(threadId: string, username: string): Promise<void> {
     return this.withSession(threadId, (session) => commands.cancelSession(session, username, this.getContext()));
+  }
+
+  /**
+   * Let the session's backend run a `!command` natively. True when handled
+   * (reply posted); false when the backend has no implementation and the
+   * caller should fall back to the Claude slash passthrough.
+   */
+  async runBackendCommand(threadId: string, command: string, args?: string): Promise<boolean> {
+    const session = this.findSessionByThreadId(threadId);
+    if (!session?.claude.runSlashCommand) return false;
+    const reply = await session.claude.runSlashCommand(command, args);
+    if (reply === null) return false;
+    await post(session, 'info', reply);
+    return true;
   }
 
   async interruptSession(threadId: string, username: string): Promise<void> {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -2,7 +2,7 @@
  * Session management types and interfaces
  */
 
-import type { ClaudeCli } from '../claude/cli.js';
+import type { AgentBackend, AgentSession } from '../agents/index.js';
 import type { PlatformClient, PlatformFile } from '../platform/index.js';
 import type { OverheadVisibility, PermissionMode } from '../config/index.js';
 import type { WorktreeInfo } from '../persistence/session-store.js';
@@ -267,11 +267,14 @@ export interface Session {
   workingDir: string;
 
   // Claude process
-  claude: ClaudeCli;
+  claude: AgentSession;
 
   // Claude account id the session is running under (when the bot is configured
   // with a `claudeAccounts` pool). Undefined in single-account mode.
   claudeAccountId?: string;
+
+  /** Backend this session was started with. Undefined on pre-backend data = 'claude'. */
+  agentBackend?: AgentBackend;
 
   /**
    * True for unattended runs (routine fires, watch fires). Gates the


### PR DESCRIPTION
## What

A second agent backend: OpenAI Codex via `codex app-server`, selectable per bot.

```yaml
agentBackend: codex   # default: claude
```

Sessions are driven through an `AgentSession` interface with two implementations: the existing `ClaudeCli` (unchanged behaviour, still the default) and `CodexSession`, which runs `codex app-server` over stdio (JSON-RPC, one process per session). Each session persists the backend it was started with, so old persisted sessions resume as Claude.

## How it works

`CodexSession` translates Codex notifications into the Claude stream-json event shape the rest of the bot already consumes — `system/init` (Codex thread id as `session_id`), assistant text / thinking / `tool_use`, user `tool_result`, `result` with `modelUsage`, `system/error` — so transformer, events handler, message manager, thread logs, audit and memory need no backend branches. Codex-native things are mapped onto the existing UI:

- **Approvals** (command execution, file changes, permission requests, MCP tool calls of foreign servers) go through the reaction prompts; the bot's own MCP server is accepted without a prompt, like on Claude. ✅ on an action prompt approves the rest of the session (`acceptForSession`). Timeouts, late reactions and interrupts close the prompts.
- **Questions**: `item/tool/requestUserInput` renders as `AskUserQuestion`.
- **Mid-turn messages** steer the running turn (`turn/steer`), like a stdin line does on Claude.
- **Commands**: `!compact` → `thread/compact/start`, `!model` / `!effort` → next `turn/start`, `!context` / `!cost` → token usage. `!stop`, `!cd`, `!permissions` and worktrees work unchanged.
- **Files**: image attachments are sent as `localImage` input; generated images are uploaded into the thread under the outbound-file policy (`outboundFiles.enabled` / `maxBytes`, validator). `send_file`, `read_post`, agent actions etc. come from the bot's MCP server, which Codex loads as `claude-threads-mcp`.
- **Limits and auth**: usage limits raise the existing rate-limit event with the reset time; auth errors are shown in the thread and treated as permanent.
- **No hidden Claude usage**: title/branch suggestions run through `codex exec --ephemeral`; startup validates the Codex CLI (installed, logged in, protocol version pinned to 0.153.4) and refuses `claudeAccounts` together with `agentBackend: codex`.

Permission mapping: `default` → `approvalPolicy: untrusted`, `sandbox: workspace-write`; `auto` → `on-request`; `bypass` → `never`, `danger-full-access`.

## Scope note

The `AgentSession` abstraction (interface, factory, five spawn sites) and the Codex adapter are bundled because the abstraction has no second user without the adapter. If you would rather take the abstraction alone first — or not take a second backend at all — say so and I will split or close.

The app-server protocol is marked experimental upstream; the bindings are pinned to one CLI version and drift only warns at startup.

## Verification

- Unit tests for the JSON-RPC client and the session translation: approval serialization, timeouts and late answers, allow-all, interrupt epochs, question sets and stale answers, permission requests, MCP elicitations, item translation, image generation, exit codes, steering, spawn failures, rate limits.
- The existing suite is unchanged (`bun run test` clean, `tsc --noEmit`, eslint).
- Hardened through adversarial review rounds with a second model; every finding is covered by a regression test.
- Running in production as a personal Mattermost bot (Codex, ChatGPT plan) next to a Claude-backed bot under the same user: approvals, questions, image generation, resume across restarts, usage-limit and re-login paths all exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnEaPZso3WCMFyQTee9ZsG
