### PR TITLE
Verify Claude CLI 2.1.263 and fix the subagent capture prompt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -610,7 +610,7 @@ The version is checked at startup against a three-tier policy
 | CLI version | Behavior |
 |-------------|----------|
 | Below `2.0.74` (hard floor) | Error message and **exit** — the bot can't work at all |
-| `>=2.0.74 <2.2.0` (verified range; latest verified: 2.1.251) | Runs normally |
+| `>=2.0.74 <2.2.0` (verified range; latest verified: 2.1.263) | Runs normally |
 | Newer 2.x above the verified range | **Warn-and-run**: startup warning + "⚠️ untested" marker in the sticky message and session headers. A new CLI minor must not take every bot down until a claude-threads release ships |
 | A new major (3.x+) | Error message and **exit** — different contract, warn-and-run would be reckless |
 
@@ -621,7 +621,7 @@ next to the CLI version in the sticky message and session headers.
 
 To install the latest verified version:
 ```bash
-npm install -g @anthropic-ai/claude-code@2.1.251
+npm install -g @anthropic-ai/claude-code@2.1.263
 ```
 
 The Claude CLI version is displayed:

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -361,14 +361,14 @@ platforms:
 ### General Issues
 
 #### "Claude CLI not found"
-- **Install** Claude Code CLI: `npm install -g @anthropic-ai/claude-code@2.1.251`
+- **Install** Claude Code CLI: `npm install -g @anthropic-ai/claude-code@2.1.263`
 - **Verify** it's in PATH: `which claude`
 - **Set** custom path if needed: `CLAUDE_PATH=/path/to/claude claude-threads`
 
 #### "Incompatible Claude CLI version" / "⚠️ untested"
 - **Check** your version: `claude --version`
 - The bot only refuses to start when the CLI is **too old** (below 2.0.74) or a **new major** (3.x+). A newer 2.x than the verified range runs normally with an "⚠️ untested" warning at startup and next to the version in the channel — install the latest verified version to clear it.
-- **Install** the latest verified version: `npm install -g @anthropic-ai/claude-code@2.1.251`
+- **Install** the latest verified version: `npm install -g @anthropic-ai/claude-code@2.1.263`
 - **Skip check** (not recommended): `claude-threads --skip-version-check`
 
 #### Can't find config file

--- a/src/claude/version-check.ts
+++ b/src/claude/version-check.ts
@@ -47,7 +47,7 @@ export const CLAUDE_CLI_MIN_VERSION = '2.0.74';
 export const CLAUDE_CLI_VERIFIED_RANGE = '>=2.0.74 <2.2.0';
 export const CLAUDE_CLI_SUPPORTED_MAJOR = 2;
 /** Newest CLI version actually verified against; used in messages. */
-export const CLAUDE_CLI_LATEST_VERIFIED = '2.1.251';
+export const CLAUDE_CLI_LATEST_VERIFIED = '2.1.263';
 
 /**
  * Result of checking Claude CLI version.

--- a/tests/e2e-real-cli/capture-events.ts
+++ b/tests/e2e-real-cli/capture-events.ts
@@ -313,7 +313,7 @@ const FLOWS: Flow[] = [
     description: 'Task tool subagent: parent_tool_use_id sidechain events',
     args: ['--dangerously-skip-permissions'],
     steps: [
-      { text: 'Use the Task tool to launch a subagent with this exact prompt: "Reply with the word SUBAGENT-HELLO and nothing else." Wait for it, then reply exactly: SUBAGENT-DONE' },
+      { text: 'Use the Agent tool (load it with ToolSearch first if it is deferred; do not use TaskCreate) to launch a subagent with this exact prompt: "Reply with the word SUBAGENT-HELLO and nothing else." Wait for it, then reply exactly: SUBAGENT-DONE' },
     ],
     timeoutMs: 240_000,
   },

--- a/tests/integration/fixtures/mock-claude/runner.ts
+++ b/tests/integration/fixtures/mock-claude/runner.ts
@@ -48,7 +48,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCENARIOS_DIR = join(__dirname, 'scenarios');
 
 /** Version reported for --version; inside the verified range. */
-const MOCK_CLI_VERSION = '2.1.251';
+const MOCK_CLI_VERSION = '2.1.263';
 
 // ============================================================================
 // Argv — the bot passes these; parse what shapes the event stream

--- a/tests/integration/fixtures/real-cli-captures/README.md
+++ b/tests/integration/fixtures/real-cli-captures/README.md
@@ -29,6 +29,40 @@ These captures are the **ground truth** for the integration mock CLI
 against them. When the mock and a capture disagree, the capture wins — fix
 the mock.
 
+## Re-verified against 2.1.263 (2026-09-06)
+
+All flows were re-captured with 2.1.263 on a developer machine and compared
+structurally against the files here: event type and subtype sequence,
+content-block types, tool names, top-level keys. Every shape the bot consumes
+held: the bridge round trips ("User has approved your plan", "Your questions
+have been answered"), the deny shapes, `compact_boundary` with
+`compact_metadata` after a successful compact and its absence after a failed
+one, `error_max_turns`, `aborted_streaming` on SIGINT, TaskCreate ids
+resolving through the result text, and `parent_tool_use_id` on subagent
+sidechain events. The manual decision-bridge e2e passed on the same version.
+
+The files were deliberately not replaced. The differences that did show up
+are environmental, not dialect. The same three flows captured with 2.1.251
+and 2.1.263 on that machine were identical to each other, and both differed
+from the committed files in ways that follow from the recording environment:
+`thinking` blocks and `system/thinking_tokens` come and go with the account's
+thinking setting; `active_goal`, `post_turn_summary`, `commands_changed`,
+`task_summary` and `autocompact_state` are noise the bot ignores; `system/init`
+lists every claude.ai connector the recording account has attached, which does
+not belong in a public fixture. `startup_timing` left `system/init` and
+`memory_paths` arrived; `result` traded `time_origin_ms`,
+`time_to_request_from_spawn_ms` and `warm_spare_claimed` for
+`first_content_frame_ms`. The bot reads none of those keys.
+
+Two things to know before the next re-capture:
+
+- Tool schemas are deferred. `ToolSearch` is in the tool list and `Agent`,
+  `ExitPlanMode` and `AskUserQuestion` are not, so a prompt has to name the
+  tool precisely. The subagent flow now says "Agent tool"; the old "Task tool"
+  wording sent haiku to `TaskCreate` and produced a capture without a subagent.
+- Record on an account without claude.ai connectors, or expect their tool
+  names in `system/init`.
+
 ## Flows
 
 | Capture | What it proves |


### PR DESCRIPTION
## What

- `CLAUDE_CLI_LATEST_VERIFIED` 2.1.251 to 2.1.263 (the verified range `>=2.0.74 <2.2.0` is unchanged), plus the install lines in CLAUDE.md and SETUP_GUIDE.md and the mock CLI's reported version.
- The capture harness's subagent flow now names the `Agent` tool. Under deferred tool schemas the old "Task tool" wording sent haiku to `TaskCreate` and produced a capture with no subagent in it.
- A "Re-verified against 2.1.263" section in the captures README with what was compared and why the files were not replaced.

## Verification

- `tests/e2e-real-cli/capture-events.ts` for every flow on 2.1.263, then a structural comparison (event type and subtype sequence, content-block types, tool names, top-level keys) against the committed 2.1.251 files. Every shape the bot consumes held: both bridge round trips, the deny shapes, `compact_boundary` after success and its absence after failure, `error_max_turns`, `aborted_streaming` on SIGINT, TaskCreate id resolution, `parent_tool_use_id` on sidechain events.
- `tests/e2e-real-cli/decision-bridge-e2e.ts` on 2.1.263: plan approval and question answers both round-trip.
- The remaining differences are environmental. The same three flows captured with 2.1.251 and 2.1.263 on the same machine are identical to each other; both differ from the committed files only in thinking blocks (account setting), ignored `system` subtypes, timing keys, and the tool list, which on a developer account includes every claude.ai connector (see #560). That is also why the fixture files stay at 2.1.251: a public fixture should not list someone's connectors.
- `bun test src/claude/version-check.test.ts` passes, `tsc --noEmit` clean.
