### PR TITLE
Sessions see only the bot's MCP servers: strict MCP config by default, mcpServers in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Sessions no longer inherit the account's MCP servers and claude.ai connectors** (#560). **Breaking.** The Claude CLI is now started with `--strict-mcp-config`, so a session only sees the bot's own permission server plus the servers declared under the new `mcpServers` key (top-level or per platform; stdio or http/sse). Before, a bot run under a personal account handed every session in the channel that account's user-level MCP servers, its claude.ai connectors (Gmail, Drive, Calendar) and the repo's `.mcp.json`, and anyone on `allowedUsers` could use them. If your sessions relied on inherited servers, declare them in `mcpServers`, or set `strictMcpConfig: false` on the platform to get the old behavior back. Each session now logs the MCP servers the CLI reported at start and warns when one did not connect.
+
 ## [1.34.2] - 2026-09-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ worktreeMode: prompt
 respondOnlyWhenMentioned: false   # New threads only reply when @mentioned (per-thread !mentions overrides)
 userAttribution: true             # Prefix user turns with [@username]: so Claude can tell speakers apart (default on; only applied once a thread has >1 participant)
 
+# Optional: MCP servers every platform's sessions get, on top of the bot's own.
+# Sessions see ONLY these (the CLI runs with --strict-mcp-config, default), never
+# the account's user-level servers / claude.ai connectors or the repo's .mcp.json.
+mcpServers:
+  docs: { type: http, url: https://mcp.example.com/ }
+
 # Optional: Customize the sticky channel message
 stickyMessage:
   description: "Porygon — Mixpanel analytics bot"    # Shown below the title
@@ -132,6 +138,9 @@ platforms:
     botName: claude-code
     allowedUsers: [alice, bob]
     skipPermissions: false
+    strictMcpConfig: true            # default; false re-inherits the account's servers and connectors (#560)
+    mcpServers:                      # per-platform servers, merged over the top-level map
+      github: { command: npx, args: [-y, "@modelcontextprotocol/server-github"], env: { GITHUB_TOKEN: ghp-x } }
 
   # Slack configuration
   - id: slack-workspace

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -255,6 +255,10 @@ claude-threads --setup
 
 This will reload your existing config and let you update settings.
 
+### A note on the account the bot runs under
+
+The bot starts the Claude CLI with `--strict-mcp-config`, so sessions only get the MCP servers the bot itself configures (its permission server plus any `mcpServers` in `config.yaml`). The claude.ai connectors and user-level MCP servers of the account you run the bot under are not visible to sessions, even when you run it from your own laptop with your own login. If you do want a platform's sessions to use them, set `strictMcpConfig: false` on that platform, and keep in mind that everyone on its `allowedUsers` then gets them. See [MCP servers](docs/CONFIGURATION.md#mcp-servers-mcpservers-strictmcpconfig).
+
 ### Manual Configuration (Advanced)
 
 > **⚠️ Not recommended for first-time setup!**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,6 +24,12 @@ platforms:
     allowedUsers: [alice, bob]
     permissionMode: default
     memory: true                  # persistent memory (default on; see Memory below)
+    strictMcpConfig: true         # sessions only see the bot's MCP servers (default; see MCP servers below)
+    mcpServers:                   # extra MCP servers for this platform's sessions
+      github:
+        command: npx
+        args: [-y, "@modelcontextprotocol/server-github"]
+        env: { GITHUB_TOKEN: ghp-your-token }
 
   # Slack
   - id: slack-eng
@@ -52,6 +58,7 @@ platforms:
 | `threadLogs` | Thread logging (see below) | enabled |
 | `stickyMessage` | Sticky message text customization (see below) | none |
 | `claudeAccounts` | Multi-account pool (see below) | single-account mode |
+| `mcpServers` | MCP servers every platform's sessions get, on top of the bot's own (see [MCP servers](#mcp-servers-mcpservers-strictmcpconfig)) | none |
 
 ### Resource Limits (`limits`)
 
@@ -297,6 +304,37 @@ The `permissionMode` field controls how the bot handles a session's tool-use req
 | `bypass` | No prompts and no classifier. Every tool-use is allowed. Equivalent to `--dangerously-skip-permissions`. This is what the legacy `skipPermissions: true` maps to. |
 
 A running session can switch mode at any time with `!permissions <mode>`; that override is not persisted across a bot restart.
+
+### MCP servers (`mcpServers`, `strictMcpConfig`)
+
+A session only sees the MCP servers the bot hands the Claude CLI: its own permission server plus whatever you declare under `mcpServers`. The CLI is started with `--strict-mcp-config`, so the servers it would otherwise pick up on its own stay out: the user-level servers of the account the bot runs under, that account's claude.ai connectors (Gmail, Google Drive, Calendar, ...), and any `.mcp.json` in the working directory.
+
+That default exists because a bot run under a personal account used to hand every session in the channel the operator's mailbox. Anyone on `allowedUsers` could ask for it, and a message approved through the message-approval flow or a watch firing on channel content could reach it without anyone meaning to.
+
+Declare the servers you want, either for all platforms at the top level or per platform (the platform entry wins on a name clash):
+
+```yaml
+mcpServers:                       # top level: every platform
+  docs:
+    type: http                    # or sse
+    url: https://mcp.example.com/
+    headers: { Authorization: "Bearer ..." }
+
+platforms:
+  - id: mattermost-main
+    # ... credentials ...
+    mcpServers:                   # this platform only
+      github:
+        command: npx              # stdio server: command, optional args and env
+        args: [-y, "@modelcontextprotocol/server-github"]
+        env: { GITHUB_TOKEN: ghp-your-token }
+```
+
+A stdio server needs `command` (with optional `args` and `env`); a remote one needs `type: http` or `type: sse` and a `url` (with optional `headers`). The name `claude-threads-mcp` is reserved for the bot's own server. A malformed entry stops the bot at startup with the field path in the message, rather than dropping the server silently. Secrets in `env` and `headers` travel in the same owner-only tempfile as the bot's platform token, not on the command line.
+
+Each session logs the servers the CLI reported at start (`MCP servers: claude-threads-mcp (connected), github (failed)`), and warns when one did not connect. That line is the place to look when a declared server's tools do not show up.
+
+To go back to inheriting everything the account and the repo provide, set `strictMcpConfig: false` on that platform. Do that only for a platform whose users you would trust with the account's connectors, because there is no finer switch: it is all or nothing per platform. Claude.ai connectors cannot be declared in `mcpServers`; they are bound to the account, so `strictMcpConfig: false` is the only way to give a bot access to them.
 
 ### Quieting the bot's overhead messages
 

--- a/src/claude/cli.test.ts
+++ b/src/claude/cli.test.ts
@@ -393,6 +393,7 @@ describe('materializeMcpConfig', () => {
     if (result.mode !== 'file') throw new Error('expected file mode');
     const parsed = JSON.parse(readFileSync(result.path, 'utf8')) as McpConfigBlob;
     const server = parsed.mcpServers['claude-threads-mcp'];
+    if (server.type !== 'stdio') throw new Error('expected the bot server to be stdio');
     expect(server.env.PLATFORM_TOKEN).toBe('SECRET-TOKEN');
     rmSync(result.path);
   });
@@ -479,6 +480,75 @@ describe('buildPermissionArgs', () => {
     expect(args).toContain('mcp__claude-threads-mcp__permission_prompt');
     expect(args).not.toContain('--permission-mode');
     expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  // -------------------------------------------------------------------------
+  // MCP server scope (#560): strict by default, operator servers in the blob
+  // -------------------------------------------------------------------------
+  const blobOf = (args: string[]): McpConfigBlob =>
+    JSON.parse(args[args.indexOf('--mcp-config') + 1]) as McpConfigBlob;
+
+  it('passes --strict-mcp-config by default so inherited servers and connectors stay out', () => {
+    const { args } = buildPermissionArgs({ ...baseOpts, permissionMode: 'default' });
+    expect(args).toContain('--strict-mcp-config');
+  });
+
+  it('bypass with a platform is strict too (the blob is still built there)', () => {
+    const { args } = buildPermissionArgs({ ...baseOpts, permissionMode: 'bypass' });
+    expect(args).toContain('--strict-mcp-config');
+  });
+
+  it('strictMcpConfig: false omits the flag (explicit opt-in to inheritance)', () => {
+    const { args } = buildPermissionArgs({
+      ...baseOpts,
+      permissionMode: 'default',
+      platformConfig: { ...baseOpts.platformConfig, strictMcpConfig: false },
+    });
+    expect(args).not.toContain('--strict-mcp-config');
+  });
+
+  it('declared stdio servers ride in the blob, normalized, with their env off argv', () => {
+    const { args } = buildPermissionArgs({
+      ...baseOpts,
+      permissionMode: 'default',
+      platformConfig: {
+        ...baseOpts.platformConfig,
+        mcpServers: { github: { command: 'npx', args: ['-y', 'gh-mcp'], env: { GITHUB_TOKEN: 'SECRET-GH' } }, bare: { command: 'my-mcp' } },
+      },
+    });
+    const blob = blobOf(args);
+    expect(blob.mcpServers.github).toEqual({ type: 'stdio', command: 'npx', args: ['-y', 'gh-mcp'], env: { GITHUB_TOKEN: 'SECRET-GH' } });
+    expect(blob.mcpServers.bare).toEqual({ type: 'stdio', command: 'my-mcp', args: [], env: {} });
+    expect(blob.mcpServers['claude-threads-mcp']).toBeDefined();
+    const argvWithoutBlob = args.filter((_, i) => args[i - 1] !== '--mcp-config');
+    expect(argvWithoutBlob.join(' ')).not.toContain('SECRET-GH');
+  });
+
+  it('declared remote servers pass through with their headers', () => {
+    const { args } = buildPermissionArgs({
+      ...baseOpts,
+      permissionMode: 'default',
+      platformConfig: {
+        ...baseOpts.platformConfig,
+        mcpServers: { docs: { type: 'http', url: 'https://mcp.example.test/', headers: { Authorization: 'Bearer x' } } },
+      },
+    });
+    expect(blobOf(args).mcpServers.docs).toEqual({ type: 'http', url: 'https://mcp.example.test/', headers: { Authorization: 'Bearer x' } });
+  });
+
+  it("a declared server cannot replace the bot's own permission server", () => {
+    const { args } = buildPermissionArgs({
+      ...baseOpts,
+      permissionMode: 'default',
+      platformConfig: {
+        ...baseOpts.platformConfig,
+        mcpServers: { 'claude-threads-mcp': { command: '/evil/server' } },
+      },
+    });
+    const bot = blobOf(args).mcpServers['claude-threads-mcp'];
+    if (bot.type !== 'stdio') throw new Error('expected stdio');
+    expect(bot.command).not.toBe('/evil/server');
+    expect(bot.args).toEqual(['/path/to/mcp-server.js']);
   });
 
   it('runs a built .js MCP server under node', () => {

--- a/src/claude/cli.ts
+++ b/src/claude/cli.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from 'child_process';
+import type { McpServerConfig } from '../config/types.js';
 import { crossSpawn } from '../utils/spawn.js';
 import { EventEmitter } from 'events';
 import { resolve, dirname } from 'path';
@@ -95,6 +96,17 @@ export interface PlatformMcpConfig {
    * config. When omitted the bot defaults to enabled with 100MB cap.
    */
   outboundFiles?: { enabled?: boolean; maxBytes?: number };
+  /**
+   * Operator-declared MCP servers (config.yaml `mcpServers`, already
+   * validated) that ride in the same `--mcp-config` blob as the bot's own.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
+  /**
+   * Pass `--strict-mcp-config` so the CLI ignores every MCP source but that
+   * blob. Default (undefined) is strict; only an explicit `false` inherits
+   * the account's servers and connectors and the repo's `.mcp.json` (#560).
+   */
+  strictMcpConfig?: boolean;
 }
 
 export interface ClaudeCliOptions {
@@ -330,13 +342,12 @@ function isErrorResultEvent(event: ClaudeEvent): boolean {
 /**
  * Shape of an MCP `--mcp-config` blob for the Claude CLI. Exported for tests.
  */
+export type McpBlobServer =
+  | { type: 'stdio'; command: string; args: string[]; env: Record<string, string> }
+  | { type: 'http' | 'sse'; url: string; headers?: Record<string, string> };
+
 export interface McpConfigBlob {
-  mcpServers: Record<string, {
-    type: 'stdio';
-    command: string;
-    args: string[];
-    env: Record<string, string>;
-  }>;
+  mcpServers: Record<string, McpBlobServer>;
 }
 
 /**
@@ -486,6 +497,17 @@ export function buildPermissionArgs(opts: {
     },
   };
 
+  // Operator-declared servers ride in the same blob (so their env/headers
+  // stay off argv too). The bot's own name is reserved: the config loader
+  // refuses it, and this guard keeps any caller that bypasses the loader
+  // from swapping out the permission server.
+  for (const [name, server] of Object.entries(opts.platformConfig.mcpServers ?? {})) {
+    if (name === 'claude-threads-mcp') continue;
+    mcpConfig.mcpServers[name] = 'url' in server
+      ? { type: server.type, url: server.url, ...(server.headers ? { headers: server.headers } : {}) }
+      : { type: 'stdio', command: server.command, args: server.args ?? [], env: server.env ?? {} };
+  }
+
   const materialized = materializeMcpConfig(mcpConfig, opts.sessionId, { inline: opts.inline });
   let tempFile: string | null = null;
   if (materialized.mode === 'file') {
@@ -493,6 +515,15 @@ export function buildPermissionArgs(opts: {
     args.push('--mcp-config', materialized.path);
   } else {
     args.push('--mcp-config', materialized.value);
+  }
+
+  // Only the servers in that blob. Without the flag the CLI also loads the
+  // account's user-level servers and claude.ai connectors and the repo's
+  // .mcp.json, so a bot run under a personal account handed every session
+  // the operator's Gmail and Drive (#560). Verified on 2.0.74 (the floor)
+  // and 2.1.263: plugins and skills still load, only MCP sources are cut.
+  if (opts.platformConfig.strictMcpConfig !== false) {
+    args.push('--strict-mcp-config');
   }
 
   // Mode-specific flags:

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,11 +23,18 @@ export type {
   PlatformOverhead,
   MemoryOption,
   ResolvedMemoryConfig,
+  McpServerConfig,
+  McpStdioServerConfig,
+  McpRemoteServerConfig,
 } from './types.js';
 export {
   DEFAULT_MEMORY_CONFIG,
   MEMORY_DISABLED,
   resolveMemoryConfig,
+  resolveMcpServers,
+  resolveStrictMcpConfig,
+  validateMcpServers,
+  BOT_MCP_SERVER_NAME,
   resolveRoutinesEnabled,
   resolveTranscriptionEnabled,
   resolveWatchesEnabled,

--- a/src/config/mcp-servers.test.ts
+++ b/src/config/mcp-servers.test.ts
@@ -1,0 +1,110 @@
+/**
+ * MCP server scope (#560): `mcpServers` validation/merge and the
+ * `strictMcpConfig` default. Pure functions; no CLI spawned.
+ */
+import { describe, expect, it, spyOn } from 'bun:test';
+import {
+  BOT_MCP_SERVER_NAME,
+  resolveMcpServers,
+  resolveStrictMcpConfig,
+  validateMcpServers,
+} from './types.js';
+
+describe('validateMcpServers', () => {
+  it('treats an absent map as no servers', () => {
+    expect(validateMcpServers(undefined, 'mcpServers')).toEqual({});
+    expect(validateMcpServers(null, 'mcpServers')).toEqual({});
+  });
+
+  it('normalizes a minimal stdio server', () => {
+    expect(validateMcpServers({ fs: { command: 'mcp-fs' } }, 'mcpServers')).toEqual({
+      fs: { type: 'stdio', command: 'mcp-fs', args: [], env: {} },
+    });
+  });
+
+  it('keeps args and env on a stdio server', () => {
+    expect(
+      validateMcpServers({ gh: { command: 'npx', args: ['-y', 'gh-mcp'], env: { TOKEN: 't' } } }, 'mcpServers').gh,
+    ).toEqual({ type: 'stdio', command: 'npx', args: ['-y', 'gh-mcp'], env: { TOKEN: 't' } });
+  });
+
+  it('infers http for a url without a type, and passes sse headers through', () => {
+    const out = validateMcpServers(
+      {
+        docs: { url: 'https://mcp.example.test/' },
+        feed: { type: 'sse', url: 'https://sse.example.test/', headers: { Authorization: 'Bearer x' } },
+      },
+      'mcpServers',
+    );
+    expect(out.docs).toEqual({ type: 'http', url: 'https://mcp.example.test/' });
+    expect(out.feed).toEqual({ type: 'sse', url: 'https://sse.example.test/', headers: { Authorization: 'Bearer x' } });
+  });
+
+  it("refuses the bot's own server name", () => {
+    expect(() => validateMcpServers({ [BOT_MCP_SERVER_NAME]: { command: 'x' } }, 'mcpServers')).toThrow(
+      /claude-threads-mcp.*cannot be redefined/,
+    );
+  });
+
+  it('refuses names the CLI cannot turn into tool names', () => {
+    expect(() => validateMcpServers({ 'bad name': { command: 'x' } }, 'mcpServers')).toThrow(/server names/);
+  });
+
+  it('refuses a list, a non-object entry, a stdio server without a command, a remote one without a url', () => {
+    expect(() => validateMcpServers([{ command: 'x' }], 'mcpServers')).toThrow(/expected a map/);
+    expect(() => validateMcpServers({ a: 'mcp-fs' }, 'mcpServers')).toThrow(/mcpServers\.a: expected an object/);
+    expect(() => validateMcpServers({ a: { args: ['x'] } }, 'mcpServers')).toThrow(/needs a command/);
+    expect(() => validateMcpServers({ a: { type: 'http' } }, 'mcpServers')).toThrow(/needs a url/);
+  });
+
+  it('refuses non-string args, env and headers, and unknown types', () => {
+    expect(() => validateMcpServers({ a: { command: 'x', args: [1] } }, 'mcpServers')).toThrow(/\.args/);
+    expect(() => validateMcpServers({ a: { command: 'x', env: { N: 1 } } }, 'mcpServers')).toThrow(/\.env/);
+    expect(() => validateMcpServers({ a: { type: 'http', url: 'u', headers: { H: 1 } } }, 'mcpServers')).toThrow(/\.headers/);
+    expect(() => validateMcpServers({ a: { type: 'grpc', url: 'u' } }, 'mcpServers')).toThrow(/\.type/);
+  });
+
+  it('names the offending field path', () => {
+    expect(() => validateMcpServers({ a: {} }, 'platforms[mm].mcpServers')).toThrow(/platforms\[mm\]\.mcpServers\.a/);
+  });
+});
+
+describe('resolveMcpServers', () => {
+  it('merges top-level and platform maps, the platform winning on a clash', () => {
+    const out = resolveMcpServers(
+      { shared: { command: 'shared-mcp' }, gh: { command: 'gh-global' } },
+      { gh: { command: 'gh-platform' }, local: { command: 'local-mcp' } },
+      'platforms[mm].mcpServers',
+    );
+    expect(Object.keys(out).sort()).toEqual(['gh', 'local', 'shared']);
+    expect(out.gh).toEqual({ type: 'stdio', command: 'gh-platform', args: [], env: {} });
+  });
+
+  it('validates both maps', () => {
+    expect(() => resolveMcpServers({ a: {} }, undefined, 'p')).toThrow(/mcpServers\.a/);
+    expect(() => resolveMcpServers(undefined, { a: {} }, 'platforms[mm].mcpServers')).toThrow(/platforms\[mm\]\.mcpServers\.a/);
+  });
+});
+
+describe('resolveStrictMcpConfig', () => {
+  it('defaults to strict', () => {
+    expect(resolveStrictMcpConfig(undefined)).toBe(true);
+    expect(resolveStrictMcpConfig(null)).toBe(true);
+  });
+
+  it('honors an explicit boolean', () => {
+    expect(resolveStrictMcpConfig(false)).toBe(false);
+    expect(resolveStrictMcpConfig(true)).toBe(true);
+  });
+
+  it('warns and stays strict on garbage', () => {
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolveStrictMcpConfig('nope', 'platforms[mm].strictMcpConfig')).toBe(true);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0][0])).toContain('platforms[mm].strictMcpConfig');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -216,6 +216,116 @@ export function resolveAuditLogEnabled(value: unknown, fieldPath?: string): bool
 /**
  * Thread logging configuration
  */
+// =============================================================================
+// MCP servers (#560)
+// =============================================================================
+
+/** Name of the bot's own MCP server in every `--mcp-config` blob. Reserved. */
+export const BOT_MCP_SERVER_NAME = 'claude-threads-mcp';
+
+/** A local MCP server: a process the Claude CLI spawns over stdio. */
+export interface McpStdioServerConfig {
+  type?: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** A remote MCP server reached over streamable HTTP or SSE. */
+export interface McpRemoteServerConfig {
+  type: 'http' | 'sse';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type McpServerConfig = McpStdioServerConfig | McpRemoteServerConfig;
+
+/**
+ * Normalize the per-platform `strictMcpConfig` field. Undefined/`true` →
+ * the CLI only sees the servers in the bot's own `--mcp-config` blob (its
+ * permission server plus `mcpServers` declared in config.yaml). `false`
+ * restores the pre-#560 inheritance: the account's user-level servers and
+ * claude.ai connectors, and the repo's `.mcp.json`, all load too.
+ */
+export function resolveStrictMcpConfig(value: unknown, fieldPath?: string): boolean {
+  return resolveBooleanFeature(value, fieldPath ?? 'strictMcpConfig', {
+    default: true,
+    verb: 'inherited MCP servers stay excluded',
+  });
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return (
+    typeof value === 'object' && value !== null && !Array.isArray(value) &&
+    Object.values(value as Record<string, unknown>).every((v) => typeof v === 'string')
+  );
+}
+
+/**
+ * Validate one `mcpServers` map. Throws on the first malformed entry: a
+ * server the operator declared and the bot silently dropped would be worse
+ * than a startup error, because the session would just lack the tools.
+ */
+export function validateMcpServers(value: unknown, fieldPath: string): Record<string, McpServerConfig> {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(
+      `Invalid ${fieldPath}: expected a map of server name → {command, args?, env?} or {type: http|sse, url, headers?}`,
+    );
+  }
+  const out: Record<string, McpServerConfig> = {};
+  for (const [name, raw] of Object.entries(value as Record<string, unknown>)) {
+    const path = `${fieldPath}.${name}`;
+    if (name === BOT_MCP_SERVER_NAME) {
+      throw new Error(`Invalid ${path}: "${BOT_MCP_SERVER_NAME}" is the bot's own server and cannot be redefined`);
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(name)) {
+      throw new Error(`Invalid ${path}: server names may contain letters, digits, "_", "." and "-" only`);
+    }
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      throw new Error(`Invalid ${path}: expected an object`);
+    }
+    const s = raw as Record<string, unknown>;
+    const type = s.type ?? (typeof s.url === 'string' && s.command === undefined ? 'http' : 'stdio');
+    if (type === 'http' || type === 'sse') {
+      if (typeof s.url !== 'string' || s.url.length === 0) {
+        throw new Error(`Invalid ${path}: a ${type} server needs a url`);
+      }
+      if (s.headers !== undefined && !isStringRecord(s.headers)) {
+        throw new Error(`Invalid ${path}.headers: expected a map of strings`);
+      }
+      out[name] = { type, url: s.url, ...(s.headers ? { headers: s.headers } : {}) };
+    } else if (type === 'stdio') {
+      if (typeof s.command !== 'string' || s.command.length === 0) {
+        throw new Error(`Invalid ${path}: a stdio server needs a command (or set type: http|sse with a url)`);
+      }
+      if (s.args !== undefined && !(Array.isArray(s.args) && s.args.every((a) => typeof a === 'string'))) {
+        throw new Error(`Invalid ${path}.args: expected a list of strings`);
+      }
+      if (s.env !== undefined && !isStringRecord(s.env)) {
+        throw new Error(`Invalid ${path}.env: expected a map of strings`);
+      }
+      out[name] = { type: 'stdio', command: s.command, args: (s.args as string[] | undefined) ?? [], env: (s.env as Record<string, string> | undefined) ?? {} };
+    } else {
+      throw new Error(`Invalid ${path}.type: expected stdio, http or sse, got ${JSON.stringify(s.type)}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * The servers one platform instance passes to the CLI: the top-level
+ * `mcpServers` merged with the platform's own, the platform winning on a
+ * name clash. Both maps are validated; an empty result is fine.
+ */
+export function resolveMcpServers(
+  global: unknown,
+  platform: unknown,
+  fieldPath: string,
+): Record<string, McpServerConfig> {
+  return { ...validateMcpServers(global, 'mcpServers'), ...validateMcpServers(platform, fieldPath) };
+}
+
 export interface ThreadLogsConfig {
   enabled?: boolean;        // Default: true
   retentionDays?: number;   // Default: 30 - days to keep logs after session ends
@@ -397,6 +507,13 @@ export interface Config {
    * saved and listed like any other file. See docs/audio-transcription-spec.md.
    */
   transcription?: TranscriptionConfig;
+  /**
+   * MCP servers every platform instance passes to the Claude CLI, on top of
+   * the bot's own permission server. A platform's `mcpServers` entry with
+   * the same name wins. See `strictMcpConfig` on the platform for why these
+   * are the only servers a session sees.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
   platforms: PlatformInstanceConfig[];
 }
 
@@ -484,6 +601,22 @@ export interface PlatformInstanceConfig {
    * `false` disables message evaluation and the !watch/!watches commands.
    */
   watches?: boolean;
+  /**
+   * Only let the CLI use the MCP servers the bot hands it: its own
+   * permission server plus `mcpServers` (default `true`). Without it the CLI
+   * also loads the account's user-level servers and claude.ai connectors
+   * (Gmail, Drive, ...) and the repo's `.mcp.json`, so every session in the
+   * channel got whatever the operator's account had attached (#560). Set
+   * `false` to restore that inheritance for a platform you trust with it.
+   */
+  strictMcpConfig?: boolean;
+  /**
+   * Extra MCP servers for this platform's sessions, merged over the top-level
+   * `mcpServers`. Keyed by server name; each entry is either a stdio server
+   * (`command`, optional `args`/`env`) or a remote one (`type: http|sse`,
+   * `url`, optional `headers`). The name `claude-threads-mcp` is reserved.
+   */
+  mcpServers?: Record<string, McpServerConfig>;
   /**
    * Transcribe inbound audio attachments in this platform's channels
    * (default: enabled wherever the top-level `transcription:` block is

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   type SlackPlatformConfig,
   type PlatformInstanceConfig,
   type PermissionMode,
-  type OverheadVisibility,
+  type OverheadVisibility, resolveMcpServers, resolveStrictMcpConfig
 } from './config/index.js';
 import type { CliArgs } from './config/index.js';
 import { runOnboarding } from './onboarding.js';
@@ -685,6 +685,22 @@ async function startWithoutDaemon() {
       platformType: typedConfig.type as 'mattermost' | 'slack',
       enabled: isEnabled,
     });
+
+    // MCP servers this platform's sessions may use: the bot's own plus what
+    // the operator declared (top-level merged with per-platform). Resolved
+    // once here, before the client is built, so derived DM instances that
+    // spread this config inherit the validated values. A malformed entry
+    // throws: a declared server that silently vanished would be worse than
+    // a startup error.
+    platformConfig.mcpServers = resolveMcpServers(
+      config.mcpServers,
+      platformConfig.mcpServers,
+      `platforms[${platformConfig.id}].mcpServers`,
+    );
+    platformConfig.strictMcpConfig = resolveStrictMcpConfig(
+      platformConfig.strictMcpConfig,
+      `platforms[${platformConfig.id}].strictMcpConfig`,
+    );
 
     // Create platform client using factory
     const client = createPlatformClient(platformConfig);

--- a/src/operations/events/handler.test.ts
+++ b/src/operations/events/handler.test.ts
@@ -333,6 +333,25 @@ describe('handleEventPreProcessing', () => {
     expect(session.availableSlashCommands?.has('review')).toBe(true);
   });
 
+  test('records the MCP server set from init and only re-records on change', () => {
+    expect(session.mcpServersSummary).toBeUndefined();
+    const init = {
+      type: 'system',
+      subtype: 'init',
+      mcp_servers: [{ name: 'claude-threads-mcp', status: 'connected' }, { name: 'github', status: 'failed' }],
+    };
+    handleEventPreProcessing(session, init, ctx);
+    expect(session.mcpServersSummary).toBe('claude-threads-mcp (connected), github (failed)');
+
+    // Same set again (init is re-emitted per turn): nothing changes.
+    handleEventPreProcessing(session, init, ctx);
+    expect(session.mcpServersSummary).toBe('claude-threads-mcp (connected), github (failed)');
+
+    // Strict mode with nothing but the bot's own server, or none at all.
+    handleEventPreProcessing(session, { type: 'system', subtype: 'init', mcp_servers: [] }, ctx);
+    expect(session.mcpServersSummary).toBe('none');
+  });
+
   test('handles slash_commands with leading slashes', () => {
     const initEvent = {
       type: 'system',

--- a/src/operations/events/handler.ts
+++ b/src/operations/events/handler.ts
@@ -230,7 +230,26 @@ export function handleEventPreProcessing(
       compact_metadata?: unknown;
       slash_commands?: string[];
       model?: string;
+      mcp_servers?: Array<{ name?: string; status?: string }>;
     };
+
+    // Log which MCP servers the CLI actually connected. init is re-emitted
+    // per turn, so only speak when the set changes. This is the operator's
+    // one visible check that strictMcpConfig / mcpServers did what they
+    // meant (#560) and that a declared server came up at all.
+    if (e.subtype === 'init' && Array.isArray(e.mcp_servers)) {
+      const summary = e.mcp_servers.map((s) => `${s.name ?? '?'} (${s.status ?? 'unknown'})`).join(', ') || 'none';
+      if (session.mcpServersSummary !== summary) {
+        session.mcpServersSummary = summary;
+        sessionLog(session).info(`MCP servers: ${summary}`);
+        const down = e.mcp_servers.filter((s) => s.status !== 'connected' && s.status !== 'pending');
+        if (down.length > 0) {
+          sessionLog(session).warn(
+            `MCP servers not connected: ${down.map((s) => `${s.name ?? '?'} (${s.status ?? 'unknown'})`).join(', ')}`,
+          );
+        }
+      }
+    }
 
     // Capture the current model from init events (re-emitted per turn, so a
     // /model switch is reflected on the very next turn — see captures).

--- a/src/platform/base-client.ts
+++ b/src/platform/base-client.ts
@@ -29,6 +29,7 @@ import type {
   ThreadMessage,
 } from './types.js';
 import type { PlatformFormatter } from './formatter.js';
+import type { McpServerConfig } from '../config/types.js';
 
 const log = createLogger('base-client');
 
@@ -42,6 +43,10 @@ export interface BaseMcpConfig {
   token: string;
   channelId: string;
   allowedUsers: string[];
+  /** Operator-declared MCP servers for the `--mcp-config` blob (resolved at startup). */
+  mcpServers?: Record<string, McpServerConfig>;
+  /** Pass `--strict-mcp-config` (default true; see PlatformInstanceConfig). */
+  strictMcpConfig?: boolean;
 }
 
 /**

--- a/src/platform/client.ts
+++ b/src/platform/client.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import type { McpServerConfig } from '../config/types.js';
 import type { ResolvedDirectChannelMode, ApprovalsMode } from './utils.js';
 import type {
   PlatformUser,
@@ -148,6 +149,8 @@ export interface PlatformClient extends EventEmitter {
     allowedUsers: string[];
     appToken?: string;
     outboundFiles?: { enabled?: boolean; maxBytes?: number };
+    mcpServers?: Record<string, McpServerConfig>;
+    strictMcpConfig?: boolean;
   };
 
   /**

--- a/src/platform/mattermost/client.test.ts
+++ b/src/platform/mattermost/client.test.ts
@@ -111,6 +111,8 @@ describe('MattermostClient pure helpers', () => {
       channelId: 'cc',
       allowedUsers: ['u'],
       outboundFiles: undefined,
+      mcpServers: undefined,
+      strictMcpConfig: undefined,
     });
   });
 

--- a/src/platform/mattermost/client.ts
+++ b/src/platform/mattermost/client.ts
@@ -1,4 +1,5 @@
 import { WebSocket } from '../../utils/websocket.js';
+import type { McpServerConfig } from '../../config/types.js';
 import type { MattermostPlatformConfig } from '../../config/index.js';
 import { wsLogger, createLogger } from '../../utils/logger.js';
 import { formatShortId } from '../../utils/format.js';
@@ -44,6 +45,8 @@ export class MattermostClient extends BasePlatformClient {
   private channelId: string;
   private directMessages: boolean;
   private outboundFiles?: { enabled?: boolean; maxBytes?: number };
+  private mcpServers?: Record<string, McpServerConfig>;
+  private strictMcpConfig?: boolean;
   private userCache: Map<string, MattermostUser> = new Map();
   private botUserId: string | null = null;
   private readonly formatter = new MattermostFormatter();
@@ -62,6 +65,8 @@ export class MattermostClient extends BasePlatformClient {
     this.botName = platformConfig.botName;
     this.allowedUsers = platformConfig.allowedUsers;
     this.outboundFiles = platformConfig.outboundFiles;
+    this.mcpServers = platformConfig.mcpServers;
+    this.strictMcpConfig = platformConfig.strictMcpConfig;
     this.directChannelMode = resolveDirectChannelMode(platformConfig.directChannelMode);
     this.approvals = platformConfig.approvals;
     this.ackReaction = normalizeAckReaction(platformConfig.ackReaction, `platforms[${platformConfig.id}].ackReaction`);
@@ -755,6 +760,8 @@ export class MattermostClient extends BasePlatformClient {
       channelId: this.channelId,
       allowedUsers: this.allowedUsers,
       outboundFiles: this.outboundFiles,
+      mcpServers: this.mcpServers,
+      strictMcpConfig: this.strictMcpConfig,
     };
   }
 

--- a/src/platform/slack/client.ts
+++ b/src/platform/slack/client.ts
@@ -1,4 +1,5 @@
 import { WebSocket, countPingsAsActivity } from '../../utils/websocket.js';
+import type { McpServerConfig } from '../../config/types.js';
 import type { SlackPlatformConfig } from '../../config/index.js';
 import { wsLogger, createLogger } from '../../utils/logger.js';
 import { truncateMessageSafely, escapeRegExp, getEmojiName, formatWebSocketError, resolvePostThreadId, isDcmThreadId, normalizeAckReaction, resolveDirectChannelMode, type ResolvedDirectChannelMode, type ApprovalsMode } from '../utils.js';
@@ -92,6 +93,8 @@ export class SlackClient extends BasePlatformClient {
   private rateLimitRetryAfter = 0;
 
   private outboundFiles?: { enabled?: boolean; maxBytes?: number };
+  private mcpServers?: Record<string, McpServerConfig>;
+  private strictMcpConfig?: boolean;
 
   /** When a working-status was last asserted, per anchoring message ts. */
   private readonly statusSentAt = new Map<string, number>();
@@ -119,6 +122,8 @@ export class SlackClient extends BasePlatformClient {
     this.allowedUsers = platformConfig.allowedUsers;
     this.apiUrl = platformConfig.apiUrl || 'https://slack.com/api';
     this.outboundFiles = platformConfig.outboundFiles;
+    this.mcpServers = platformConfig.mcpServers;
+    this.strictMcpConfig = platformConfig.strictMcpConfig;
     this.directChannelMode = resolveDirectChannelMode(platformConfig.directChannelMode);
     this.approvals = platformConfig.approvals;
     this.ackReaction = normalizeAckReaction(platformConfig.ackReaction, `platforms[${platformConfig.id}].ackReaction`);
@@ -947,6 +952,8 @@ export class SlackClient extends BasePlatformClient {
       allowedUsers: this.allowedUsers,
       appToken: this.appToken, // Required for Socket Mode in permission server
       outboundFiles: this.outboundFiles,
+      mcpServers: this.mcpServers,
+      strictMcpConfig: this.strictMcpConfig,
     };
   }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -421,6 +421,11 @@ export interface Session {
    * field always names what the next turn actually uses. In-memory only.
    */
   currentModel?: string;
+  /**
+   * "name (status), ..." of the MCP servers the CLI reported in its last
+   * system/init event; used to log the set once per change. In-memory only.
+   */
+  mcpServersSummary?: string;
 
   // Last message posted to the thread (for jump-to-bottom links)
   lastMessageId?: string;


### PR DESCRIPTION
Fixes #560.

## What changes

- The Claude CLI is started with `--strict-mcp-config`, so a session only sees the servers in the bot's own `--mcp-config` blob: the permission server plus whatever the operator declares. The account's user-level MCP servers, its claude.ai connectors and the repo's `.mcp.json` no longer load.
- New config: `mcpServers` (top-level and per platform, platform wins on a name clash), each entry a stdio server (`command`, optional `args`/`env`) or a remote one (`type: http|sse`, `url`, optional `headers`). Validated at startup with the field path in the error; `claude-threads-mcp` is reserved. Declared servers travel in the same owner-only tempfile as the platform token, so their secrets stay off argv.
- New per-platform `strictMcpConfig`, default `true`; `false` restores the old inheritance for that platform.
- Each session logs the MCP servers the CLI reported in its init event (once per change) and warns when one is not connected. That is the operator's check that a declared server came up.

## Why the default flips

A bot run under a personal account gave every session in the channel that account's Gmail, Drive and Calendar tools (107 tools instead of 30 on the test account). Everyone on `allowedUsers` could use them, and so could a message let through by the approval flow or a watch firing on channel content. Interactive permissions gate each call, but `skipPermissions` platforms and autonomous watches do not. The account pool made it inconsistent on top: which tools a session had depended on which pooled account it landed on.

## Verification

- `--strict-mcp-config` exists on 2.0.74 (the supported floor) and on 2.1.263. On 2.1.263 it drops all seven connectors of the test account; plugins (7) and skills (69) still load.
- New tests: the flag is present by default and absent with `strictMcpConfig: false` (red without the code: the default test fails when the `args.push` is removed), declared stdio and remote servers land in the blob normalized and off argv, the reserved name cannot replace the permission server, the config validator's accept and reject cases, merge precedence, and the init logging.
- `tsc --noEmit`, eslint, knip clean; 3417 unit tests pass. The integration mock ignores unknown flags, so the mock-CLI suites are unaffected.

## Breaking

Operators whose sessions relied on inherited servers get a Claude without those tools after upgrading, with no error. The CHANGELOG entry says how to get them back (`mcpServers`, or `strictMcpConfig: false`). Per the release policy in CLAUDE.md this is a major bump; that decision is for the release PR, not this one.
