### PR TITLE
1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.35.0] - 2026-09-06
+
 ### Changed
 - **Sessions no longer inherit the account's MCP servers and claude.ai connectors** (#560). **Breaking.** The Claude CLI is now started with `--strict-mcp-config`, so a session only sees the bot's own permission server plus the servers declared under the new `mcpServers` key (top-level or per platform; stdio or http/sse). Before, a bot run under a personal account handed every session in the channel that account's user-level MCP servers, its claude.ai connectors (Gmail, Drive, Calendar) and the repo's `.mcp.json`, and anyone on `allowedUsers` could use them. If your sessions relied on inherited servers, declare them in `mcpServers`, or set `strictMcpConfig: false` on the platform to get the old behavior back. Each session now logs the MCP servers the CLI reported at start and warns when one did not connect.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.34.2",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.34.2",
+      "version": "1.35.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.34.2",
+  "version": "1.35.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Minor release. Merging this publishes to npm via release.yml.

- `package.json` 1.34.2 to 1.35.0 (`package-lock.json` follows).
- CHANGELOG `[Unreleased]` promoted to `[1.35.0] - 2026-09-06` with #563: sessions only see the bot's MCP servers (`--strict-mcp-config` by default), new `mcpServers` and `strictMcpConfig` config keys, MCP server logging at session start.

The changelog entry is marked breaking because sessions that relied on inherited MCP servers lose them without an error; it ships as a minor on purpose, with the two ways back (`mcpServers`, `strictMcpConfig: false`) spelled out in the entry.
