### PR TITLE
1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.35.0] - 2026-09-06
+
 ### Changed
 - **Sessions no longer get the account's claude.ai connectors** (#560, #563). A bot run under a personal account handed every session in the channel that account's Gmail, Google Drive and Calendar tools, and anyone on `allowedUsers` could use them. The CLI is now started with `disableClaudeAiConnectors` in its inline settings and `ENABLE_CLAUDEAI_MCP_SERVERS=false` in its environment, which removes exactly those (verified on CLI 2.1.112, 2.1.251 and 2.1.263: the connectors vanish, a plugin's MCP server stays). The bot's own haiku one-shots (watch confirms, distillation, parsers, title suggestions, the usage probe) run without them too. Everything else the machine provides still loads: user-level servers, servers bundled with plugins, the repo's `.mcp.json`. Set `claudeAiConnectors: true` on a platform to let them through. Also new: `mcpServers` (top-level or per platform, stdio or http/sse) to declare servers in `config.yaml`, `strictMcpConfig: true` as opt-in hardening that passes `--strict-mcp-config` so a session gets only the bot's own set, a per-session log line of the MCP servers the CLI reported (with a warning when one did not connect, and an in-thread warning when connectors are active on a CLI that ignores the switch), a session-header row when a platform deviates from the default posture, and a note on `!plugin install` when strict mode will keep the plugin's MCP servers from loading.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.34.2",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.34.2",
+      "version": "1.35.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.34.2",
+  "version": "1.35.0",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Minor release. Merging this publishes to npm via release.yml.

- `package.json` 1.34.2 to 1.35.0 (`package-lock.json` follows).
- CHANGELOG `[Unreleased]` promoted to `[1.35.0] - 2026-09-06` with #563 and #565: sessions and the bot's own haiku one-shots no longer get the account's claude.ai connectors; new `claudeAiConnectors`, `mcpServers` and `strictMcpConfig` config keys; MCP servers logged per session, with in-thread warnings when a connector slips through on an old CLI or when strict mode is refused by an enterprise-managed MCP config.

Both PRs went through two independent review rounds before this; everything found was fixed in #565.
