### PR TITLE
fix: clear all listeners when removeAllListeners() is called with no argument

### DIFF
--- a/src/operations/message-manager-events.ts
+++ b/src/operations/message-manager-events.ts
@@ -252,7 +252,13 @@ export class TypedEventEmitter extends EventEmitter {
    * @returns this (for chaining)
    */
   removeAllListeners(event?: MessageManagerEvent): this {
-    return super.removeAllListeners(event);
+    // Forward a no-arg call as a no-arg call. EventEmitter branches on
+    // arguments.length, so an explicit `undefined` reads as "remove listeners
+    // for the event named undefined" and clears nothing -- which silently left
+    // dispose() leaking every session's listeners.
+    return event === undefined
+      ? super.removeAllListeners()
+      : super.removeAllListeners(event);
   }
 
   /**


### PR DESCRIPTION
## Summary

`TypedEventEmitter.removeAllListeners()` removes nothing when called without an
argument, so `MessageManager.dispose()` never drops the session's listeners and
every finished session leaks the closures it registered.

## Changes

- `src/operations/message-manager-events.ts`: forward a no-arg
  `removeAllListeners()` call to `EventEmitter` as a no-arg call, instead of
  passing an explicit `undefined`.

## Root cause

The override forwards the optional parameter unconditionally:

```ts
removeAllListeners(event?: MessageManagerEvent): this {
  return super.removeAllListeners(event);
}
```

`EventEmitter.prototype.removeAllListeners` branches on `arguments.length`. A
no-arg call on the subclass still reaches the base method with
`arguments.length === 1` and `type === undefined`, which is read as "remove
listeners for the event named `undefined`" -- so nothing is removed.

`MessageManager.dispose()` relies on this call, and its own comment describes
the leak it is meant to prevent:

```ts
// Without this the closures held by listeners keep session state alive
// after the session ends, leaking across many sessions.
this.events.removeAllListeners();
```

## Testing

Two existing tests already cover this behaviour and are currently failing on
`main`:

- `TypedEventEmitter > removeAllListeners > removes all listeners when no event specified`
- `MessageManager > Lifecycle > removes all event listeners on dispose`

Both pass with this change. Full unit suite goes from 3394 pass / 2 fail to
**3396 pass / 0 fail**. `bun run lint`, `tsc --noEmit` and `bun run build` all
succeed.

Reproduced identically on bun 1.4.2 and node 26, so this is not a
runtime-version quirk.

## Checklist

- [x] Tests pass (`bun run test`)
- [x] Linting passes (`bun run lint`)
- [ ] Documentation updated (if needed) -- not applicable
