### PR TITLE
resume: stop promising that interrupted work continued (#533 item 1)

### DIFF
--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1337,6 +1337,91 @@ describe('authorization gate at sinks (#388)', () => {
     });
   });
 
+  describe('the resume notice tells the truth about what continued', () => {
+    // A resume with no `resumedBy` was nobody's request: the daemon restarted
+    // and restored the session. `isProcessing` starts false and nothing is
+    // sent to the CLI, so a turn that was in flight when the bot stopped is
+    // simply gone — and the notice used to say "you can continue where you
+    // left off" regardless (#533).
+    let prevClaudePath: string | undefined;
+    beforeEach(() => {
+      prevClaudePath = process.env.CLAUDE_PATH;
+      process.env.CLAUDE_PATH = '/bin/echo';
+    });
+    afterEach(() => {
+      if (prevClaudePath === undefined) delete process.env.CLAUDE_PATH;
+      else process.env.CLAUDE_PATH = prevClaudePath;
+    });
+
+    function bootState(overrides?: Record<string, unknown>) {
+      return {
+        threadId: 'thread-boot',
+        platformId: 'test-platform',
+        claudeSessionId: 'claude-session-1',
+        workingDir: process.cwd(),
+        startedBy: 'alice',
+        sessionAllowedUsers: ['alice'],
+        ...overrides,
+      };
+    }
+
+    function bootContext() {
+      const platform = createMockPlatform({
+        isUserAllowed: mock(() => true) as any,
+        getPost: mock(() => Promise.resolve({ id: 'thread-boot' })) as any,
+        // Resume builds real CLI options from this; without allowedUsers it
+        // throws long before the notice.
+        getMcpConfig: mock(() => ({
+          type: 'mattermost', url: 'https://chat.example.com',
+          token: 't', channelId: 'c', allowedUsers: ['alice'],
+        })) as any,
+      });
+      const ctx = createMockSessionContext(new Map());
+      (ctx.state.platforms as Map<string, PlatformClient>).set('test-platform', platform);
+      return { ctx, platform };
+    }
+
+    const notices = (platform: PlatformClient) => [
+      ...(platform.createPost as any).mock.calls.map((c: unknown[]) => String(c[0])),
+      ...(platform.updatePost as any).mock.calls.map((c: unknown[]) => String(c[1])),
+    ].filter((t) => t.includes('Session resumed'));
+
+    it('a restart-triggered resume does not promise the interrupted work continued', async () => {
+      const { ctx, platform } = bootContext();
+
+      await lifecycle.resumeSession(bootState() as never, ctx);  // no resumedBy: the daemon did this
+
+      const notice = notices(platform).at(-1) as string;
+      expect(notice).toBeDefined();
+      expect(notice).not.toContain('continue where you left off');
+      expect(notice.toLowerCase()).toContain('did not survive');
+    });
+
+    it('a person-triggered resume still says the work continues, because their message follows', async () => {
+      const { ctx, platform } = bootContext();
+
+      await lifecycle.resumeSession(bootState({ threadId: 'thread-asked' }) as never, ctx, 'alice');
+
+      const notice = notices(platform).at(-1) as string;
+      expect(notice).toContain('continue where you left off');
+    });
+
+    it('says the same thing whether or not there is a pause post to edit', async () => {
+      // The truth of "did anything continue" turns on WHY the resume happened,
+      // not on whether a shutdown left a post behind. Both branches used the
+      // same wording before, and both were wrong for a restart.
+      const { ctx, platform } = bootContext();
+
+      await lifecycle.resumeSession(
+        bootState({ threadId: 'thread-paused-post', lifecyclePostId: 'post-9' }) as never,
+        ctx,
+      );
+
+      const notice = notices(platform).at(-1) as string;
+      expect(notice).not.toContain('continue where you left off');
+    });
+  });
+
   describe('resumePausedSession', () => {
     function persistedState(overrides?: Record<string, unknown>) {
       return {

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1406,6 +1406,21 @@ describe('authorization gate at sinks (#388)', () => {
       expect(notice).toContain('continue where you left off');
     });
 
+    it('a platform re-enable does not blame a restart that never happened', async () => {
+      // `resumedBy` only says whether a chat identity was supplied. The daemon
+      // reaches resumeSession without one for TWO different reasons, and an
+      // operator toggling a platform back on in the UI is the second — the
+      // bot never stopped (Codex review).
+      const { ctx, platform } = bootContext();
+
+      await lifecycle.resumeSession(bootState({ threadId: 'thread-toggle' }) as never, ctx, undefined, 'platform-enabled');
+
+      const notice = notices(platform).at(-1) as string;
+      expect(notice).not.toContain('restart');
+      expect(notice).toContain('platform');
+      expect(notice).not.toContain('continue where you left off');
+    });
+
     it('says the same thing whether or not there is a pause post to edit', async () => {
       // The truth of "did anything continue" turns on WHY the resume happened,
       // not on whether a shutdown left a post behind. Both branches used the

--- a/src/session/lifecycle.test.ts
+++ b/src/session/lifecycle.test.ts
@@ -1419,6 +1419,8 @@ describe('authorization gate at sinks (#388)', () => {
 
       const notice = notices(platform).at(-1) as string;
       expect(notice).not.toContain('continue where you left off');
+      // ...and it no longer credits a person who did not ask for it.
+      expect(notice).not.toContain('by @');
     });
   });
 

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -1682,7 +1682,13 @@ async function resumeSessionImpl(
 
     if (session.lifecyclePostId) {
       const postId = session.lifecyclePostId;
-      const resumeMsg = `🔄 ${sessionFormatter.formatBold('Session resumed')} by ${sessionFormatter.formatUserMention(session.startedBy)}\n${sessionFormatter.formatItalic(outcome)}`;
+      // Attributed only when someone actually asked. On a boot resume the
+      // daemon did it, and crediting the session owner reads as though they
+      // were here (Gemini review).
+      const by = askedForByAPerson
+        ? ` by ${sessionFormatter.formatUserMention(session.startedBy)}`
+        : ` after bot restart (v${VERSION})`;
+      const resumeMsg = `🔄 ${sessionFormatter.formatBold('Session resumed')}${by}\n${sessionFormatter.formatItalic(outcome)}`;
       await withErrorHandling(
         () => session.platform.updatePost(postId, resumeMsg),
         { action: 'Update timeout/shutdown post for resume', session }

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -1303,10 +1303,19 @@ async function startSessionImpl(
 /**
  * Resume a session from persisted state.
  */
+/**
+ * Why a resume happened, for the notice. `resumedBy` cannot answer this: it
+ * only says whether a chat identity was supplied, and the daemon reaches
+ * `resumeSession` for two different reasons without one — boot restore, and
+ * an operator re-enabling a platform from the UI (Codex review).
+ */
+export type ResumeTrigger = 'boot' | 'platform-enabled';
+
 export async function resumeSession(
   state: PersistedSession,
   ctx: SessionContext,
-  resumedBy?: string
+  resumedBy?: string,
+  trigger: ResumeTrigger = 'boot'
 ): Promise<void> {
   // Idempotency guard: a resume can be triggered from two sides at once
   // (startup resume-all and an incoming message via resumePausedSession).
@@ -1327,7 +1336,7 @@ export async function resumeSession(
       await inFlight.catch(() => {});
       return;
     }
-    const attempt = resumeSessionImpl(state, ctx, resumedBy);
+    const attempt = resumeSessionImpl(state, ctx, resumedBy, trigger);
     _inFlightSessionStarts.set(sessionKey, attempt);
     try {
       await attempt;
@@ -1336,13 +1345,14 @@ export async function resumeSession(
     }
     return;
   }
-  await resumeSessionImpl(state, ctx, resumedBy);
+  await resumeSessionImpl(state, ctx, resumedBy, trigger);
 }
 
 async function resumeSessionImpl(
   state: PersistedSession,
   ctx: SessionContext,
-  resumedBy?: string
+  resumedBy?: string,
+  trigger: ResumeTrigger = 'boot'
 ): Promise<void> {
   // Validate required fields - skip gracefully if critical data is missing
   if (!state.threadId || !state.platformId || !state.claudeSessionId || !state.workingDir) {
@@ -1670,15 +1680,22 @@ async function resumeSessionImpl(
     const sessionFormatter = session.platform.getFormatter();
     // What actually continues depends on WHY this resume happened, not on
     // whether a shutdown left a post to edit. A resume with a `resumedBy` was
-    // asked for by a person, and their message or reaction follows it — that
-    // work does continue. A resume without one is the daemon restoring
+    // asked for by a person: the message path delivers their message straight
+    // after, and the reaction path at least means someone is present and
+    // about to type. Inviting them to carry on is honest. A resume without one is the daemon restoring
     // sessions at boot: `isProcessing` starts false and nothing is sent to the
     // CLI, so a turn that was in flight when the bot stopped is simply gone.
     // Both branches used to promise continuation regardless (#533).
+    // A person who asked for this resume is about to act on it, so an
+    // invitation to carry on is the right thing to say. Nobody asked for the
+    // other two, and in both of them a turn that was in flight is simply
+    // gone: `isProcessing` starts false and nothing is sent to the CLI.
     const askedForByAPerson = resumedBy !== undefined;
     const outcome = askedForByAPerson
       ? 'Reconnected to Claude session. You can continue where you left off.'
-      : 'Conversation history is intact, but anything that was still running when the bot stopped did not survive the restart — send a message to pick it up.';
+      : trigger === 'platform-enabled'
+        ? 'Conversation history is intact, but anything that was still running when the platform was disabled has stopped — send a message to pick it up.'
+        : 'Conversation history is intact, but anything that was still running when the bot stopped did not survive the restart — send a message to pick it up.';
 
     if (session.lifecyclePostId) {
       const postId = session.lifecyclePostId;
@@ -1687,7 +1704,9 @@ async function resumeSessionImpl(
       // were here (Gemini review).
       const by = askedForByAPerson
         ? ` by ${sessionFormatter.formatUserMention(session.startedBy)}`
-        : ` after bot restart (v${VERSION})`;
+        : trigger === 'platform-enabled'
+          ? ' (platform re-enabled)'
+          : ` after bot restart (v${VERSION})`;
       const resumeMsg = `🔄 ${sessionFormatter.formatBold('Session resumed')}${by}\n${sessionFormatter.formatItalic(outcome)}`;
       await withErrorHandling(
         () => session.platform.updatePost(postId, resumeMsg),
@@ -1698,7 +1717,8 @@ async function resumeSessionImpl(
       transitionTo(session, 'active');
     } else {
       // Fallback: create new post if no lifecyclePostId (e.g., old persisted sessions)
-      const restartMsg = `${sessionFormatter.formatBold('Session resumed')} after bot restart (v${VERSION})\n${sessionFormatter.formatItalic(outcome)}`;
+      const suffix = trigger === 'platform-enabled' ? ' (platform re-enabled)' : ` after bot restart (v${VERSION})`;
+      const restartMsg = `${sessionFormatter.formatBold('Session resumed')}${suffix}\n${sessionFormatter.formatItalic(outcome)}`;
       await post(session, 'resume', restartMsg);
     }
 

--- a/src/session/lifecycle.ts
+++ b/src/session/lifecycle.ts
@@ -1668,9 +1668,21 @@ async function resumeSessionImpl(
     // If we have a lifecyclePostId, this was a timeout/shutdown - update that post
     // Otherwise create a new post (normal for old persisted sessions without lifecyclePostId)
     const sessionFormatter = session.platform.getFormatter();
+    // What actually continues depends on WHY this resume happened, not on
+    // whether a shutdown left a post to edit. A resume with a `resumedBy` was
+    // asked for by a person, and their message or reaction follows it — that
+    // work does continue. A resume without one is the daemon restoring
+    // sessions at boot: `isProcessing` starts false and nothing is sent to the
+    // CLI, so a turn that was in flight when the bot stopped is simply gone.
+    // Both branches used to promise continuation regardless (#533).
+    const askedForByAPerson = resumedBy !== undefined;
+    const outcome = askedForByAPerson
+      ? 'Reconnected to Claude session. You can continue where you left off.'
+      : 'Conversation history is intact, but anything that was still running when the bot stopped did not survive the restart — send a message to pick it up.';
+
     if (session.lifecyclePostId) {
       const postId = session.lifecyclePostId;
-      const resumeMsg = `🔄 ${sessionFormatter.formatBold('Session resumed')} by ${sessionFormatter.formatUserMention(session.startedBy)}\n${sessionFormatter.formatItalic('Reconnected to Claude session. You can continue where you left off.')}`;
+      const resumeMsg = `🔄 ${sessionFormatter.formatBold('Session resumed')} by ${sessionFormatter.formatUserMention(session.startedBy)}\n${sessionFormatter.formatItalic(outcome)}`;
       await withErrorHandling(
         () => session.platform.updatePost(postId, resumeMsg),
         { action: 'Update timeout/shutdown post for resume', session }
@@ -1680,7 +1692,7 @@ async function resumeSessionImpl(
       transitionTo(session, 'active');
     } else {
       // Fallback: create new post if no lifecyclePostId (e.g., old persisted sessions)
-      const restartMsg = `${sessionFormatter.formatBold('Session resumed')} after bot restart (v${VERSION})\n${sessionFormatter.formatItalic('Reconnected to Claude session. You can continue where you left off.')}`;
+      const restartMsg = `${sessionFormatter.formatBold('Session resumed')} after bot restart (v${VERSION})\n${sessionFormatter.formatItalic(outcome)}`;
       await post(session, 'resume', restartMsg);
     }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1089,7 +1089,7 @@ export class SessionManager extends EventEmitter {
 
     for (const state of sessionsToResume) {
       try {
-        await lifecycle.resumeSession(state, this.getContext());
+        await lifecycle.resumeSession(state, this.getContext(), undefined, 'platform-enabled');
         log.info(`▶️ Resumed session ${state.threadId.substring(0, 8)}`);
       } catch (err) {
         log.warn(`Failed to resume session ${state.threadId}: ${err}`);
@@ -1244,7 +1244,7 @@ export class SessionManager extends EventEmitter {
       if (activeToResume.length > 0) {
         log.info(`🔄 Attempting to resume ${activeToResume.length} active session(s)...`);
         for (const state of activeToResume) {
-          await lifecycle.resumeSession(state, this.getContext());
+          await lifecycle.resumeSession(state, this.getContext(), undefined, 'boot');
         }
       }
     }


### PR DESCRIPTION
Item (1) from #533 — the one you said you'd take today, and #549 only covered the reaper message so it was still open.

## The lie

The resume notice said **"You can continue where you left off"** on every path, including the one where nothing continues. After a deploy, a thread whose turn was in flight is told it can carry on; `isProcessing` starts `false`, nothing is sent to the CLI, and the work is simply gone. The thread looks resumed and is idle.

Both branches shared the sentence, so both were wrong after a restart — and the *edit-an-existing-post* branch is the one a deploy actually takes, since `postShutdownMessages` sets `lifecyclePostId` on the way down.

## The fix

The wording now turns on **why** the resume happened.

| Trigger | Notice says |
|---|---|
| A person (message or reaction) | "Reconnected… You can continue where you left off." |
| Daemon boot | "Session resumed after bot restart (v1.35.0) — conversation history is intact, but anything that was still running when the bot stopped did not survive the restart. Send a message to pick it up." |
| Platform re-enabled | Same, worded for the platform being disabled rather than a restart |

**Three review rounds, and two of them found this PR making smaller versions of the same mistake:**

- Gemini: the edit branch still opened with *"Session resumed by @owner"* — on a boot resume that credits someone who wasn't there. Attributed only when a person asked, now.
- Codex: my first cut inferred "the daemon did this" from `resumedBy === undefined`. That's wrong. `manager.ts:1092` is `resumePausedSessionsForPlatform`, which fires when an **operator re-enables a platform from the UI toggle** — no username, no restart. Those threads would have been told their work didn't survive a restart that never happened. The reason is now passed explicitly (`ResumeTrigger`), not deduced. Fixing a message that guessed by guessing would have been a poor look.
- Codex also checked a comment I wrote claiming a person's resume is always followed by their message: `tryResumeFromReaction` returns without sending anything to Claude. The invitation is still right for that path — someone is present and about to type — but not for the reason I'd written down. Comment corrected.

## Scope

This does **not** detect that a turn was interrupted — that needs `openTurnAt`, item (2). It stops claiming otherwise. Nothing else changes: no new posts, no suppression, no lifecycle behaviour.

Four tests, three verified red by reverting their branch individually. 3533 tests pass; typecheck, eslint and `git diff --check` clean. Reviewed by Codex, Gemini and CodeRabbit (0 findings on the final diff).

---

Separately, I've opened #570 with the design sketch you asked for on item (4) — the three questions answered, plus how it subsumes the DCM half from #550.
