### PR TITLE
CI: pin Bun 1.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 env:
   # Pin Bun to a known version so a Bun release can't silently break CI.
   # Bump in lockstep with what's developed against locally.
-  BUN_VERSION: 1.3.3
+  BUN_VERSION: 1.4.2
 
 jobs:
   security:

--- a/.github/workflows/dependabot-sync-lockfile.yml
+++ b/.github/workflows/dependabot-sync-lockfile.yml
@@ -27,7 +27,7 @@ permissions:
 
 env:
   # Keep in lockstep with .github/workflows/ci.yml.
-  BUN_VERSION: 1.3.3
+  BUN_VERSION: 1.4.2
 
 jobs:
   sync:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ on:
 env:
   # Pin Bun to a known version so a Bun release can't silently break CI.
   # Bump in lockstep with .github/workflows/ci.yml.
-  BUN_VERSION: 1.3.3
+  BUN_VERSION: 1.4.2
 
 jobs:
   integration:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 env:
   # Pin Bun to a known version so a Bun release can't silently break a publish.
   # Bump in lockstep with .github/workflows/ci.yml.
-  BUN_VERSION: 1.3.3
+  BUN_VERSION: 1.4.2
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ concurrency:
 
 env:
   # Keep in lockstep with .github/workflows/ci.yml and publish.yml.
-  BUN_VERSION: 1.3.3
+  BUN_VERSION: 1.4.2
 
 jobs:
   release:


### PR DESCRIPTION
Bumps `BUN_VERSION` from 1.3.3 to 1.4.2 in all five workflows.

## Why

#569 fixed a real leak in the published build: `TypedEventEmitter.removeAllListeners()` forwarded its optional argument as an explicit `undefined`, which Node reads as "the event named undefined", so `dispose()` removed nothing. Two existing tests already described the correct behavior. They passed on Bun 1.3.3, where `removeAllListeners(undefined)` clears everything, and fail on Bun 1.4.2, which behaves like Node. CI was testing against semantics the published build never runs under.

## Verified on 1.4.2 at current main

- `bun run test`: 3447 pass, 0 fail
- `bun run typecheck`, `bun run lint`, `bun run knip`: clean
- `bun run build`: three bundles
- `bun audit`: no vulnerabilities
- `bun install --frozen-lockfile --dry-run`: accepted, no lockfile rewrite

`package.json#engines.bun` stays at `>=1.2.21`; this changes what CI runs, not what users need.
