### PR TITLE
1.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.35.1] - 2026-09-08
+
+### Fixed
+- **A finished session no longer leaks its event listeners** (#569, thanks @R09722akaBennett). `TypedEventEmitter.removeAllListeners()` forwarded its optional argument as an explicit `undefined`, which Node's `EventEmitter` reads as "the event named undefined", so `MessageManager.dispose()` removed nothing and every session's closures stayed alive. Invisible in CI because Bun 1.3.3 behaves differently from Node there; Bun 1.4.2 agrees with Node and fails the existing tests on the old code.
+- **The resume notice no longer promises that interrupted work continued** (#571, thanks @kaza; item 1 of #533). After a daemon restart or a platform re-enable, a thread whose turn was in flight was told "You can continue where you left off" while nothing continued: `isProcessing` starts false and nothing is sent to the CLI. The notice now says why the resume happened and, for the two daemon-initiated cases, that anything still running did not survive; only a resume a person asked for keeps the invitation. Attribution to the session owner is gone from the boot path, where nobody was there.
+
 ## [1.35.0] - 2026-09-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-threads",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-threads",
-      "version": "1.35.0",
+      "version": "1.35.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-threads",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "description": "Run Claude Code from Slack or Mattermost. Sessions stream live into threads where your whole team can watch and steer.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Patch release. Merging this publishes to npm via release.yml.

- `package.json` 1.35.0 to 1.35.1 (`package-lock.json` follows).
- CHANGELOG `[Unreleased]` promoted to `[1.35.1] - 2026-09-08` with #569 (every finished session leaked its event listeners in the published build; invisible in CI under Bun 1.3.3) and #571 (the resume notice stops promising that interrupted work continued).
- CI runs under Bun 1.4.2 since #572, which agrees with Node where 1.3.3 did not; release.yml verifies this bump under it.
