### PR TITLE
CI: drive the built bot under Node through a real session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,35 @@ jobs:
           node dist/index.js --help
           node dist/index.js --version
           node dist/mcp/mcp-server.js --help || true
+
+  # The built bot, run by Node, driven through a real session: Socket Mode
+  # against the Slack mock, the mock Claude CLI, the MCP server as
+  # `node dist/mcp/mcp-server.js`, a graceful SIGTERM. Every other job runs the
+  # bot's code inside bun; #569 (a leak that only exists under Node's
+  # EventEmitter) passed all of them. This is the one that runs what we ship.
+  node-e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["20", "22", "24"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: bun install
+      - run: bun run build
+
+      - name: End-to-end session under Node ${{ matrix.node-version }}
+        run: |
+          node --version
+          bun test tests/node-e2e --timeout 180000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,11 @@ jobs:
           node dist/mcp/mcp-server.js --help || true
 
   # The built bot, run by Node, driven through a real session: Socket Mode
-  # against the Slack mock, the mock Claude CLI, the MCP server as
-  # `node dist/mcp/mcp-server.js`, a graceful SIGTERM. Every other job runs the
-  # bot's code inside bun; #569 (a leak that only exists under Node's
-  # EventEmitter) passed all of them. This is the one that runs what we ship.
+  # against the Slack mock, the mock Claude CLI, interactive permissions so the
+  # MCP server runs as `node dist/mcp/mcp-server.js`, a !stop, a second
+  # session, a SIGTERM against it. Every other job runs the bot's code inside
+  # bun; #569 (a leak that only exists under Node's EventEmitter) passed all of
+  # them. This is the one that runs what we ship.
   node-e2e:
     runs-on: ubuntu-latest
     needs: build
@@ -220,4 +221,4 @@ jobs:
       - name: End-to-end session under Node ${{ matrix.node-version }}
         run: |
           node --version
-          bun test tests/node-e2e --timeout 180000
+          bun test tests/node-e2e --timeout 240000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -616,6 +616,13 @@ the floor strands users on otherwise-supported LTS lines. Forced to 20 by
   only exists on newer Node breaks the build before reaching users.
 - `ci.yml` has a `node-smoke` matrix (`[20, 22, 24]`) that runs the built
   binary under each currently-relevant Node line.
+- `ci.yml` also has a `node-e2e` matrix (same Node lines) that runs
+  `tests/node-e2e/`: the built bot as `node dist/index.js --headless` against
+  the in-process Slack mock with the mock Claude CLI, through one real session
+  (mention over Socket Mode, reply, graceful SIGTERM, exit 0). Every other
+  test runs the bot's code inside bun; this is the only one that runs what
+  users run. #569 (a listener leak that only exists under Node's
+  `EventEmitter`) is the reason it exists. Locally: `bun run test:node-e2e`.
 
 **When to bump the floor**: only when a real dep forces it. Update
 `package.json#engines.node`, `publish.yml` Node version, the `node-smoke`
@@ -669,6 +676,7 @@ bun run build        # Compile TypeScript to dist/
 bun run dev          # Run from source with watch mode
 bun start            # Run compiled version
 bun run test         # Run unit tests (~3000 tests)
+bun run test:node-e2e  # Build, then drive the built bot under Node through one session (Slack mock)
 bun run lint         # Run ESLint
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit",
     "knip": "knip --no-config-hints",
     "prepare": "husky",
-    "test:node-e2e": "bun run build && bun test tests/node-e2e --timeout 180000"
+    "test:node-e2e": "bun run build && bun test tests/node-e2e --timeout 240000"
   },
   "keywords": [
     "claude",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint:fix": "eslint src/ --fix",
     "typecheck": "tsc --noEmit",
     "knip": "knip --no-config-hints",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test:node-e2e": "bun run build && bun test tests/node-e2e --timeout 180000"
   },
   "keywords": [
     "claude",

--- a/tests/integration/fixtures/slack/mock-server.ts
+++ b/tests/integration/fixtures/slack/mock-server.ts
@@ -257,7 +257,14 @@ export class SlackMockServer extends EventEmitter {
       },
     });
 
+    // Port 0 asks the OS for a free one; read back what we got.
+    this.port = this.server.port ?? this.port;
     this.log(`Slack mock server started on port ${this.port}`);
+  }
+
+  /** Socket Mode clients currently connected (a bot that finished its handshake). */
+  getSocketModeConnectionCount(): number {
+    return this.wsConnections.size;
   }
 
   async stop(): Promise<void> {

--- a/tests/node-e2e/slack-node.test.ts
+++ b/tests/node-e2e/slack-node.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Black-box end-to-end run of the BUILT bot under Node.
+ *
+ * Every other test in this repo runs the bot's code inside `bun test`, so a
+ * behavior that differs between Bun and Node (#569: `removeAllListeners`
+ * semantics) passes CI and fails in production, where `claude-threads` is
+ * `node dist/index.js`. This test starts exactly that process, headless,
+ * against the in-process Slack mock, with the mock Claude CLI, and drives one
+ * session through Socket Mode: mention, reply, graceful SIGTERM. The MCP
+ * permission server is spawned by the bot as `node dist/mcp/mcp-server.js`,
+ * so that path runs under Node too.
+ *
+ * Needs `bun run build` first (the CI job does it; `bun run test:node-e2e`
+ * does it locally). Not part of `bun run test`.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { spawn, type ChildProcess } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { SlackMockServer } from '../integration/fixtures/slack/mock-server.js';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(HERE, '..', '..');
+const DIST_INDEX = join(ROOT, 'dist', 'index.js');
+const MOCK_CLAUDE = join(ROOT, 'tests', 'integration', 'fixtures', 'mock-claude', 'mock-claude');
+const PORT = Number(process.env.NODE_E2E_SLACK_PORT ?? 3461);
+const BOT_USER = 'U_BOT_USER';
+const TEST_USER = 'U_TEST_USER1';
+const REPLY_TIMEOUT_MS = Number(process.env.NODE_E2E_REPLY_TIMEOUT_MS ?? 60_000);
+const SCENARIO = process.env.NODE_E2E_SCENARIO ?? 'simple-response';
+
+async function waitFor<T>(probe: () => T | null | undefined | false, timeoutMs: number, what: string): Promise<T> {
+  const start = Date.now();
+  for (;;) {
+    const v = probe();
+    if (v) return v as T;
+    if (Date.now() - start > timeoutMs) throw new Error(`Timed out after ${timeoutMs}ms waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 250));
+  }
+}
+
+describe('built bot under Node (Slack mock, mock Claude)', () => {
+  let server: SlackMockServer;
+  let home: string;
+  let bot: ChildProcess | null = null;
+  let stdout = '';
+  let stderr = '';
+  let failed = true; // flipped at the end of the test body
+
+  beforeAll(async () => {
+    if (!existsSync(DIST_INDEX)) throw new Error(`${DIST_INDEX} missing: run \`bun run build\` first`);
+    server = new SlackMockServer({ port: PORT, debug: process.env.DEBUG === '1' });
+    await server.start();
+
+    // A private HOME: config.yaml, sessions, logs and memory all land here.
+    home = mkdtempSync(join(tmpdir(), 'ct-node-e2e-'));
+    const work = join(home, 'work');
+    mkdirSync(work, { recursive: true });
+    mkdirSync(join(home, '.config', 'claude-threads'), { recursive: true });
+    writeFileSync(join(home, '.config', 'claude-threads', 'config.yaml'), [
+      'version: 1',
+      `workingDir: ${work}`,
+      'chrome: false',
+      'worktreeMode: off',
+      'keepAlive: false',
+      'autoUpdate:',
+      '  enabled: false',
+      'platforms:',
+      '  - id: node-e2e-slack',
+      '    type: slack',
+      '    displayName: Node e2e',
+      `    botToken: ${server.getBotToken()}`,
+      `    appToken: ${server.getAppToken()}`,
+      `    channelId: ${server.getChannelId()}`,
+      '    botName: claude-code',
+      '    allowedUsers: [testuser1]',
+      '    permissionMode: bypass',
+      `    apiUrl: http://localhost:${PORT}/api`,
+      '    memory: false',
+      '    routines: false',
+      '    watches: false',
+      '',
+    ].join('\n'), { mode: 0o600 });
+  });
+
+  afterAll(async () => {
+    if (failed) {
+      console.log('--- bot stdout (tail) ---\n' + stdout.split('\n').slice(-80).join('\n'));
+      console.log('--- bot stderr (tail) ---\n' + stderr.split('\n').slice(-40).join('\n'));
+    }
+    if (bot && bot.exitCode === null) {
+      try { bot.kill('SIGKILL'); } catch { /* gone */ }
+    }
+    await server.stop();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test('starts, answers a mention over Socket Mode, and shuts down cleanly on SIGTERM', async () => {
+    bot = spawn('node', [DIST_INDEX, '--headless', '--no-auto-restart', '--no-keep-alive'], {
+      cwd: home,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        CLAUDE_PATH: MOCK_CLAUDE,
+        CLAUDE_SCENARIO: SCENARIO,
+        CLAUDE_THREADS_SESSIONS_PATH: join(home, 'sessions.json'),
+        CLAUDE_THREADS_MEMORY_DIR: join(home, 'memory'),
+        CLAUDE_THREADS_ROUTINES_PATH: join(home, 'routines.yaml'),
+        CLAUDE_THREADS_WATCHES_PATH: join(home, 'watches.yaml'),
+        NO_COLOR: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    bot.stdout!.on('data', (c: Buffer) => { stdout += c.toString(); });
+    bot.stderr!.on('data', (c: Buffer) => { stderr += c.toString(); });
+    const exited = new Promise<number | null>((r) => bot!.on('exit', (code) => r(code)));
+
+    await waitFor(() => stdout.includes('Bot ready and listening for messages') || null, 45_000, 'the bot to report ready');
+    // The mention travels over the Socket Mode websocket; wait until the bot
+    // has actually completed the handshake before injecting it.
+    await waitFor(() => /hello|: connected/i.test(stdout) || null, 30_000, 'the Socket Mode connection');
+    await new Promise((r) => setTimeout(r, 500));
+
+    const channel = server.getChannelId();
+    const mention = server.simulateMessageEvent(channel, TEST_USER, `<@${BOT_USER}> hello from node e2e`);
+
+    const reply = await waitFor(
+      () => [...server.getState().messages.values()].find(
+        (m) => m.user === BOT_USER && m.thread_ts === mention.ts && m.text.includes('mock response'),
+      ),
+      REPLY_TIMEOUT_MS,
+      "Claude's reply in the thread",
+    );
+    expect(reply.text).toContain('I received your message');
+
+    // The session header is a bot post in the same thread; the sticky is a
+    // top-level bot post in the channel. Both went through Node.
+    const botPosts = [...server.getState().messages.values()].filter((m) => m.user === BOT_USER);
+    expect(botPosts.some((m) => m.thread_ts === mention.ts && m.ts !== reply.ts)).toBe(true);
+    expect(botPosts.some((m) => !m.thread_ts)).toBe(true);
+
+    bot.kill('SIGTERM');
+    const code = await Promise.race([
+      exited,
+      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 20_000)),
+    ]);
+    expect(code).toBe(0);
+
+    // Runtime-semantics bugs surface here as uncaught errors, not as failed assertions.
+    expect(stderr).not.toMatch(/TypeError|ReferenceError|Unhandled|ERR_/);
+    failed = false;
+  }, 150_000);
+});

--- a/tests/node-e2e/slack-node.test.ts
+++ b/tests/node-e2e/slack-node.test.ts
@@ -6,16 +6,22 @@
  * semantics) passes CI and fails in production, where `claude-threads` is
  * `node dist/index.js`. This test starts exactly that process, headless,
  * against the in-process Slack mock, with the mock Claude CLI, and drives one
- * session through Socket Mode: mention, reply, graceful SIGTERM. The MCP
- * permission server is spawned by the bot as `node dist/mcp/mcp-server.js`,
- * so that path runs under Node too.
+ * two sessions through Socket Mode: mention, reply, `!stop` (the dispose
+ * path #569 leaked on), a second session, then SIGTERM while it is live
+ * (the shutdown path #556 fixed) and the persisted state it leaves behind.
+ * Permissions are interactive, so the bot spawns its MCP permission server
+ * as `node dist/mcp/mcp-server.js` and the mock CLI connects to it; that
+ * path runs under Node as well. What this cannot see: a silent leak that
+ * changes nothing observable. It sees crashes, hangs, uncaught errors,
+ * Node's own MaxListenersExceededWarning, and any behavior change in the
+ * session round trip.
  *
  * Needs `bun run build` first (the CI job does it; `bun run test:node-e2e`
  * does it locally). Not part of `bun run test`.
  */
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
-import { spawn, type ChildProcess } from 'child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { spawn, execSync, type ChildProcess } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -25,11 +31,14 @@ const HERE = fileURLToPath(new URL('.', import.meta.url));
 const ROOT = resolve(HERE, '..', '..');
 const DIST_INDEX = join(ROOT, 'dist', 'index.js');
 const MOCK_CLAUDE = join(ROOT, 'tests', 'integration', 'fixtures', 'mock-claude', 'mock-claude');
-const PORT = Number(process.env.NODE_E2E_SLACK_PORT ?? 3461);
+const PORT = Number(process.env.NODE_E2E_SLACK_PORT ?? 0); // 0: a free port
 const BOT_USER = 'U_BOT_USER';
 const TEST_USER = 'U_TEST_USER1';
 const REPLY_TIMEOUT_MS = Number(process.env.NODE_E2E_REPLY_TIMEOUT_MS ?? 60_000);
-const SCENARIO = process.env.NODE_E2E_SCENARIO ?? 'simple-response';
+// persistent-session keeps the mock CLI alive between turns, like the real
+// CLI, so !stop and SIGTERM both meet a live session.
+const SCENARIO = process.env.NODE_E2E_SCENARIO ?? 'persistent-session';
+const REPLY_TEXT = "I'm ready to help";
 
 async function waitFor<T>(probe: () => T | null | undefined | false, timeoutMs: number, what: string): Promise<T> {
   const start = Date.now();
@@ -50,7 +59,9 @@ describe('built bot under Node (Slack mock, mock Claude)', () => {
   let failed = true; // flipped at the end of the test body
 
   beforeAll(async () => {
-    if (!existsSync(DIST_INDEX)) throw new Error(`${DIST_INDEX} missing: run \`bun run build\` first`);
+    for (const f of [DIST_INDEX, join(ROOT, 'dist', 'mcp', 'mcp-server.js')]) {
+      if (!existsSync(f)) throw new Error(`${f} missing: run \`bun run build\` first`);
+    }
     server = new SlackMockServer({ port: PORT, debug: process.env.DEBUG === '1' });
     await server.start();
 
@@ -76,8 +87,8 @@ describe('built bot under Node (Slack mock, mock Claude)', () => {
       `    channelId: ${server.getChannelId()}`,
       '    botName: claude-code',
       '    allowedUsers: [testuser1]',
-      '    permissionMode: bypass',
-      `    apiUrl: http://localhost:${PORT}/api`,
+      '    permissionMode: default',
+      `    apiUrl: ${server.getUrl()}/api`,
       '    memory: false',
       '    routines: false',
       '    watches: false',
@@ -119,28 +130,43 @@ describe('built bot under Node (Slack mock, mock Claude)', () => {
     const exited = new Promise<number | null>((r) => bot!.on('exit', (code) => r(code)));
 
     await waitFor(() => stdout.includes('Bot ready and listening for messages') || null, 45_000, 'the bot to report ready');
-    // The mention travels over the Socket Mode websocket; wait until the bot
-    // has actually completed the handshake before injecting it.
-    await waitFor(() => /hello|: connected/i.test(stdout) || null, 30_000, 'the Socket Mode connection');
-    await new Promise((r) => setTimeout(r, 500));
+    // The mention travels over the Socket Mode websocket; the mock drops
+    // events while nobody is connected, so ask the mock, not the log.
+    await waitFor(() => server.getSocketModeConnectionCount() > 0 || null, 30_000, 'the Socket Mode connection');
 
     const channel = server.getChannelId();
-    const mention = server.simulateMessageEvent(channel, TEST_USER, `<@${BOT_USER}> hello from node e2e`);
+    const botPosts = () => [...server.getState().messages.values()].filter((m) => m.user === BOT_USER);
+    const replyIn = (threadTs: string) => botPosts().find((m) => m.thread_ts === threadTs && m.text.includes(REPLY_TEXT));
 
-    const reply = await waitFor(
-      () => [...server.getState().messages.values()].find(
-        (m) => m.user === BOT_USER && m.thread_ts === mention.ts && m.text.includes('mock response'),
-      ),
-      REPLY_TIMEOUT_MS,
-      "Claude's reply in the thread",
+    // Session 1: mention, reply, then !stop, which runs the dispose path.
+    const first = server.simulateMessageEvent(channel, TEST_USER, `<@${BOT_USER}> hello from node e2e`);
+    const reply1 = await waitFor(() => replyIn(first.ts), REPLY_TIMEOUT_MS, "Claude's reply in thread 1");
+    expect(reply1.text).toContain(REPLY_TEXT);
+    // Session header in the thread, sticky at the top level: both went through Node.
+    expect(botPosts().some((m) => m.thread_ts === first.ts && m.ts !== reply1.ts)).toBe(true);
+    expect(botPosts().some((m) => !m.thread_ts)).toBe(true);
+
+    server.simulateMessageEvent(channel, TEST_USER, '!stop', first.ts);
+    await waitFor(
+      () => botPosts().find((m) => m.thread_ts === first.ts && /Session cancelled/.test(m.text)),
+      30_000, 'the "Session cancelled" post',
     );
-    expect(reply.text).toContain('I received your message');
 
-    // The session header is a bot post in the same thread; the sticky is a
-    // top-level bot post in the channel. Both went through Node.
-    const botPosts = [...server.getState().messages.values()].filter((m) => m.user === BOT_USER);
-    expect(botPosts.some((m) => m.thread_ts === mention.ts && m.ts !== reply.ts)).toBe(true);
-    expect(botPosts.some((m) => !m.thread_ts)).toBe(true);
+    // Session 2 in a fresh thread; SIGTERM lands while it is live. Starting
+    // it at all proves the first one left the registry (dispose ran).
+    const second = server.simulateMessageEvent(channel, TEST_USER, `<@${BOT_USER}> second session`);
+    await waitFor(() => replyIn(second.ts), REPLY_TIMEOUT_MS, "Claude's reply in thread 2");
+    // And a fresh session in the STOPPED thread must start too: a stale
+    // registry entry would swallow this message instead.
+    const again = server.simulateMessageEvent(channel, TEST_USER, `<@${BOT_USER}> again after stop`, undefined);
+    await waitFor(() => replyIn(again.ts), REPLY_TIMEOUT_MS, "Claude's reply in the third thread");
+
+    // The claim that the MCP permission server runs under Node is checked,
+    // not assumed: while session 2 is live, its child must be visible as
+    // `node .../dist/mcp/mcp-server.js` (the mock CLI spawns the real server
+    // from --mcp-config because permissions are interactive).
+    const procs = execSync('ps -eo args', { encoding: 'utf8' });
+    expect(procs).toMatch(/^node .*dist\/mcp\/mcp-server\.js/m);
 
     bot.kill('SIGTERM');
     const code = await Promise.race([
@@ -149,8 +175,15 @@ describe('built bot under Node (Slack mock, mock Claude)', () => {
     ]);
     expect(code).toBe(0);
 
-    // Runtime-semantics bugs surface here as uncaught errors, not as failed assertions.
-    expect(stderr).not.toMatch(/TypeError|ReferenceError|Unhandled|ERR_/);
+    // Shutdown persists the live session for resume; the file is under the private HOME.
+    const sessionsFile = join(home, 'sessions.json');
+    expect(existsSync(sessionsFile)).toBe(true);
+    expect(readFileSync(sessionsFile, 'utf8')).toContain(second.ts);
+
+    // Runtime-semantics bugs surface as uncaught errors or Node's own leak
+    // warning, not as failed assertions. stderr is empty on a healthy run.
+    expect(stderr).not.toMatch(/TypeError|ReferenceError|Unhandled|ERR_|MaxListenersExceededWarning/);
+    expect(stdout).not.toMatch(/\[ERROR\]/);
     failed = false;
-  }, 150_000);
+  }, 200_000);
 });


### PR DESCRIPTION
## Why

Every CI job ran the bot's code inside bun: unit tests are `bun test`, and the integration suites build the `SessionManager` in-process. #569 was a leak that exists only under Node's `EventEmitter` semantics, and it passed all of them while two existing tests described the bug. The published package is `node dist/index.js`. Nothing in CI ran that.

## What

- `tests/node-e2e/slack-node.test.ts`: starts the built bot as `node dist/index.js --headless --no-auto-restart` with a private `HOME` and config, against the in-process Slack mock (ephemeral port) and the mock Claude CLI in its persistent-session scenario, with interactive permissions. Drives: a mention over Socket Mode and Claude's reply in the thread; the session header and the sticky; `!stop` and its "Session cancelled" post; a second session in a fresh thread and a third in the stopped thread (a stale registry entry would swallow that one); a `ps` check that the MCP permission server is running as `node .../dist/mcp/mcp-server.js`; SIGTERM against the live session, exit code 0; `sessions.json` under the private HOME naming the live session; no `[ERROR]` log lines; no `TypeError`/`ReferenceError`/`Unhandled`/`ERR_`/`MaxListenersExceededWarning` on stderr. On failure it dumps the bot's stdout and stderr tails.
- The Slack mock gains `getSocketModeConnectionCount()` (readiness comes from the mock, not from grepping the log) and accepts port 0.
- `ci.yml` job `node-e2e`, matrix Node 20/22/24, after `build`.
- `bun run test:node-e2e` locally (builds first). Not part of `bun run test`.
- CLAUDE.md: CI strategy and dev commands.

## What it cannot see

A silent leak that changes nothing observable, which is what #569 was. It sees crashes, hangs, uncaught errors, Node's own leak warning, and any change in the session round trip; the readiness check alone already caught a wrong API URL during development (the bot logs "ready" with zero platforms connected).

## Verified

- Green three times in a row locally under Node 25 (about 3 s each), no stray processes.
- Red with `NODE_E2E_SCENARIO=error-response NODE_E2E_REPLY_TIMEOUT_MS=8000`: fails on the reply wait and prints the bot log.
- Typecheck, lint, knip clean; the workflow YAML parses.

Independent review round applied: the first version ran under `permissionMode: bypass`, where the bot never spawns the MCP server, so it claimed a path it did not run; the scenario exited on its own before SIGTERM; the second readiness wait matched lines already in the log buffer. All three fixed as above.
