### PR TITLE
Fix the flaky decision-bridge question test

### DIFF
--- a/tests/integration/suites/session-questions.test.ts
+++ b/tests/integration/suites/session-questions.test.ts
@@ -16,6 +16,7 @@ import {
   waitForPostMatching,
   getThreadPosts,
   addReaction,
+  waitForReaction,
   getPlatformBotOptions,
   type TestSessionContext,
 } from '../helpers/session-helpers.js';
@@ -122,6 +123,13 @@ describe.skipIf(SKIP)('Session Questions', () => {
         const questionPost = await waitForPostMatching(
           ctx, rootPost.id, /Which approach would you prefer/i, { timeout: 20000 }
         );
+
+        // The question text is posted before the bot adds its own option
+        // reactions, so reacting as soon as the text appears can land in the
+        // gap where nothing is listening yet: the answer is dropped and the
+        // wait below burns its full timeout. Wait for the bot's own '1️⃣' to
+        // show that the post is ready to be answered.
+        await waitForReaction(ctx, questionPost.id, 'one', { timeout: 20000 });
 
         // Answer with option 1: resolves the pending MCP permission call via
         // the bridge; the mock only continues once updatedInput.answers


### PR DESCRIPTION
`Session Questions > should deliver the answer through the decision bridge on option reaction` has failed on four runs in a row today, always at ~21.7s, on unrelated PRs (#579, #580, #544) and on main itself. That is a race, not bad luck, and it was costing a rerun on every PR.

**The race.** The bot posts the question text first and adds its own 1️⃣–4️⃣ option reactions afterwards. The test reacted as soon as the text matched, so on a slow runner it could react before anything was listening. The answer is dropped, and the second `waitForPostMatching` then burns its full 20s timeout, which is exactly the ~21.7s signature.

**The fix.** Wait for the bot's own `one` reaction before adding ours. `waitForReaction` already polls for precisely this, so it is one line plus the import. No production code changes.

I cannot reproduce this locally (no Docker here), so the real verification is this PR's own integration run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bNsyE8EoWg6c2hStCGyJx