### PR TITLE
Make the gh command injectable so the gate test stops filing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Verifying the `bugReports` gate no longer files a public issue** (#586). `createGitHubIssue` called `execSync` directly, so the one test that proves the gate is load-bearing reached the real `gh` CLI the moment the gate was removed. Anyone following the repo's own red-green rule therefore filed a public issue titled "T" from their test suite, three times in one afternoon (#581, #582, #583). The command is now injectable, the same way `checkGitHubCli` already was, and the test passes a stub and asserts directly that no subprocess runs. A second case covers the other direction, so a stub that was never wired up cannot make the first one pass for the wrong reason.
+
 ## [1.36.1] - 2026-09-10
 
 ### Fixed

--- a/src/operations/bug-report/handler.ts
+++ b/src/operations/bug-report/handler.ts
@@ -707,14 +707,25 @@ export function checkGitHubCli(
  *
  * Note: Images should be uploaded to Catbox.moe first and their URLs
  * embedded in the body markdown before calling this function.
+ *
+ * `exec` is injectable for the same reason it is on `checkGitHubCli`, and for
+ * a sharper one: without it this function cannot be exercised at all without
+ * filing a real issue on the real repository. The `bugReports: false` gate
+ * above it can only be proven load-bearing by removing it and watching a test
+ * go red — and with a hardcoded `execSync` that mutation posts publicly.
+ * It did, three times in one afternoon (#581, #582, #583), which is what
+ * #586 is about. Tests must pass a stub.
  */
 export async function createGitHubIssue(
   title: string,
   body: string,
-  workingDir: string
+  workingDir: string,
+  exec: (command: string, options: { cwd: string; encoding: 'utf-8'; timeout: number; stdio: ['pipe', 'pipe', 'pipe'] }) => string = execSync as never
 ): Promise<string> {
-  // Check gh CLI first
-  const ghStatus = checkGitHubCli();
+  // Check gh CLI first, through the same injected command: a caller that
+  // stubs the subprocess is stubbing the whole `gh` dependency, so the test
+  // does not also depend on a real authenticated CLI on the runner.
+  const ghStatus = checkGitHubCli(exec as never);
   if (!ghStatus.installed || !ghStatus.authenticated) {
     throw new Error(ghStatus.error);
   }
@@ -728,7 +739,7 @@ export async function createGitHubIssue(
     // Create the issue
     const cmd = `gh issue create --repo "${GITHUB_REPO}" --title "${escapeShell(title)}" --body-file "${bodyFile}"`;
 
-    const result = execSync(cmd, {
+    const result = exec(cmd, {
       cwd: workingDir,
       encoding: 'utf-8',
       timeout: 30000,

--- a/src/operations/commands/bug-report-gate.test.ts
+++ b/src/operations/commands/bug-report-gate.test.ts
@@ -103,15 +103,49 @@ describe('bugReports: false', () => {
     (session.messageManager as unknown as Record<string, unknown>).clearPendingBugReport = clearPendingBugReport;
     (session.platform as unknown as Record<string, unknown>).updatePost = updatePost;
 
-    await commands.handleBugReportApproval(session, true, 'alice', ctxWithBugReports(false));
+    // Stub the subprocess. Without this the mutation that proves this gate is
+    // load-bearing — removing the check and watching this test go red — runs
+    // `gh issue create` against the real repository and files a public issue
+    // titled "T". It did exactly that three times (#581, #582, #583) before
+    // #586 made the command injectable.
+    const exec = mock(() => 'https://github.com/anneschuth/claude-threads/issues/999\n');
 
-    // Nothing filed: the only route to createGitHubIssue reports success by
-    // editing the card with an issue URL, so an edit carrying one would mean
-    // the report went out.
+    await commands.handleBugReportApproval(session, true, 'alice', ctxWithBugReports(false), exec);
+
+    // The direct assertion: the gate is upstream of the subprocess, so the
+    // command is never even built, let alone run.
+    expect(exec).not.toHaveBeenCalled();
+
+    // And nothing reached the card either: the only route to createGitHubIssue
+    // reports success by editing it with an issue URL.
     const edits = updatePost.mock.calls.map((c) => String((c as unknown[])[1])).join('\n');
     expect(edits).not.toContain('github.com');
     expect(edits.toLowerCase()).not.toContain('submitted');
     expect(clearPendingBugReport).toHaveBeenCalled();
+  });
+
+  it('files through the injected command when bug reports are enabled', async () => {
+    // The counterpart, and the reason `exec` not being called above means
+    // something: with the gate open this same path DOES reach the subprocess.
+    // Without this case, a stub that is never wired up would pass the test
+    // above for the wrong reason.
+    const { session } = sessionWith();
+    const clearPendingBugReport = mock(() => {});
+    const updatePost = mock(async () => {});
+    (session.messageManager as unknown as Record<string, unknown>).getPendingBugReport = () => ({
+      postId: 'card-1', title: 'T', body: 'B', description: 'd', imageUrls: [],
+    });
+    (session.messageManager as unknown as Record<string, unknown>).clearPendingBugReport = clearPendingBugReport;
+    (session.platform as unknown as Record<string, unknown>).updatePost = updatePost;
+
+    // Answers the `gh --version` / `gh auth status` probes too, so the test
+    // does not need a real authenticated CLI on the runner.
+    const exec = mock(() => 'https://github.com/anneschuth/claude-threads/issues/999\n');
+
+    await commands.handleBugReportApproval(session, true, 'alice', ctxWithBugReports(true), exec);
+
+    const ranCommands = exec.mock.calls.map((c) => String((c as unknown[])[0]));
+    expect(ranCommands.some((c) => c.startsWith('gh issue create'))).toBe(true);
   });
 
   it('does not offer the 🐛 quick-report reaction on error posts', async () => {

--- a/src/operations/commands/handler.ts
+++ b/src/operations/commands/handler.ts
@@ -1437,7 +1437,10 @@ export async function handleBugReportApproval(
   session: Session,
   isApproved: boolean,
   username: string,
-  ctx: SessionContext
+  ctx: SessionContext,
+  // Injectable so a test can prove the gate below is load-bearing without
+  // filing a real issue. See the note on `createGitHubIssue` (#586).
+  exec?: Parameters<typeof createGitHubIssue>[3]
 ): Promise<void> {
   // Read from MessageManager (sole source of truth)
   const pending = session.messageManager?.getPendingBugReport();
@@ -1459,7 +1462,8 @@ export async function handleBugReportApproval(
       const issueUrl = await createGitHubIssue(
         pending.title,
         pending.body,
-        session.workingDir
+        session.workingDir,
+        exec
       );
 
       // Update the approval post to show success


### PR DESCRIPTION
Fixes #586.

`createGitHubIssue` called `execSync` directly, so the one test that proves the `bugReports: false` gate is load-bearing reached the real `gh` CLI the moment the gate was removed. Anyone following this repo's own red-green rule therefore filed a public issue titled "T" from their test suite. It happened three times in one afternoon: #581, #582, #583.

The irony is precise. The test only reaches the dangerous path in exactly two situations: someone deliberately verifying the gate works, or a future refactor having broken it for real. Both are the moments you least want a side effect.

## What changed

`createGitHubIssue` takes an injectable `exec`, the same way `checkGitHubCli` already did and for a documented reason. The injected command also covers the `gh --version` / `gh auth status` probes, so a stubbing test no longer depends on a real authenticated CLI being present on the runner. `handleBugReportApproval` passes it through.

The test now hands in a stub and asserts directly that **no subprocess runs**, which is a stronger claim than the old proxy of "no issue URL appeared in the card text".

A second case covers the other direction: with the gate open, the same path does reach `gh issue create`. Without it, a stub that was never wired up would make the first test pass for the wrong reason.

## Verification

I ran the exact mutation that caused the incident, removing the `bugReportsEnabled` check from `handleBugReportApproval`:

- test goes **red** (1 fail, 6 pass), which is the point of it existing
- and **no issue was filed** — the issue list is unchanged before and after

Full suite 3536 pass / 0 fail, lint, typecheck and knip clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bNsyE8EoWg6c2hStCGyJx